### PR TITLE
Optimize row expanding

### DIFF
--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -126,7 +126,7 @@ const Table = React.createClass({
       const childrenColumn = record[childrenColumnName];
       const isRowExpanded = this.isRowExpanded(record);
       let expandedRowContent;
-      if (expandedRowRender) {
+      if (expandedRowRender && isRowExpanded) {
         expandedRowContent = expandedRowRender(record, i);
       }
       const className = rowClassName(record, i);

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -172,6 +172,13 @@ const Table = React.createClass({
     return <colgroup>{cols}</colgroup>;
   },
 
+  isRowExpanded(record) {
+    const info = this.state.expandedRows.filter((i) => {
+      return i.record === record;
+    });
+    return info[0] && info[0].expanded;
+  },
+
   render() {
     const props = this.props;
     const prefixCls = props.prefixCls;
@@ -210,13 +217,6 @@ const Table = React.createClass({
         </div>
       </div>
     );
-  },
-
-  isRowExpanded(record) {
-    const info = this.state.expandedRows.filter((i) => {
-      return i.record === record;
-    });
-    return info[0] && info[0].expanded;
   },
 });
 

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -124,6 +124,7 @@ const Table = React.createClass({
       const record = data[i];
       const key = keyFn ? keyFn(record, i) : undefined;
       const childrenColumn = record[childrenColumnName];
+      const isRowExpanded = this.isRowExpanded(record);
       let expandedRowContent;
       if (expandedRowRender) {
         expandedRowContent = expandedRowRender(record, i);
@@ -138,13 +139,13 @@ const Table = React.createClass({
         visible={visible}
         onExpand={this.onExpanded}
         expandable={childrenColumn || expandedRowContent}
-        expanded={this.isRowExpanded(record)}
+        expanded={isRowExpanded}
         prefixCls={`${props.prefixCls}-row`}
         childrenColumnName={childrenColumnName}
         columns={columns}
         key={key}/>);
 
-      const subVisible = visible && this.isRowExpanded(record);
+      const subVisible = visible && isRowExpanded;
 
       if (expandedRowContent) {
         rst.push(this.getExpandedRow(key, expandedRowContent, subVisible, expandedRowClassName(record, i)));


### PR DESCRIPTION
This PR optimizes the row expanding procedure and deal better with rendering `React` components in the `expandedRowRender` function by:

* reducing the number of calls to determine if the same row is expanded inside the same `render`,
* only calling the `expandedRowRender` function when the row is expanded.
  * this way, a react component mounted here will have the `componentDidMount` and `componentWillUnmount` methods correctly called.

It also, fixes an *linting* error present in the `master` branch