### PR TITLE
Manage expanded row keys externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,18 @@ var table = React.render(
           <td>get row's className</td>
       </tr>
       <tr>
+          <td>expandedRowKeys</td>
+          <td>Array<string></td>
+          <th></th>
+          <td>expanded rows keys</td>
+      </tr>
+      <tr>
+          <td>onExpandedRowsChange</td>
+          <td>Function(expandedRows)</td>
+          <th>save the expanded rows in the internal state</th>
+          <td>function to call when the expanded rows change</td>
+      </tr>
+      <tr>
           <td>expandedRowClassName</td>
           <td>Function(recode,index):string</td>
           <th></th>

--- a/examples/expandedRowRender.js
+++ b/examples/expandedRowRender.js
@@ -19,7 +19,8 @@ var CheckBox = React.createClass({
 var MyTable = React.createClass({
   getInitialState: function () {
     return {
-      data: this.props.data
+      data: this.props.data,
+      expandedRowKeys: []
     };
   },
 
@@ -46,6 +47,22 @@ var MyTable = React.createClass({
     return record.a;
   },
 
+  onExpandedRowsChange(rows) {
+    this.setState({
+      expandedRowKeys: rows
+    })
+  },
+
+  toggleButton() {
+    if (this.state.expandedRowKeys.length) {
+      const closeAll = () => this.setState({expandedRowKeys: []});
+      return <button onClick={closeAll}>关闭所有</button>
+    } else {
+      const openAll = () => this.setState({expandedRowKeys: ['123', 'cdd', '1333']});
+      return <button onClick={openAll}>展开全部</button>
+    }
+  },
+
   render: function () {
     var state = this.state;
     var columns = [
@@ -55,10 +72,19 @@ var MyTable = React.createClass({
       {title: '操作', dataIndex: '', key: 'x', render: this.renderAction}
     ];
     return (
-      <Table columns={columns}
-             expandIconAsCell={true}
-        expandedRowRender={expandedRowRender}
-        data={state.data} className="table" rowKey={this.getRowKey}/>
+      <div>
+        {this.toggleButton()}
+        <Table
+          columns={columns}
+          expandIconAsCell={true}
+          expandedRowRender={expandedRowRender}
+          expandedRowKeys={this.state.expandedRowKeys}
+          onExpandedRowsChange={this.onExpandedRowsChange}
+          data={state.data}
+          className="table"
+          rowKey={this.getRowKey}
+        />
+      </div>
     );
   },
 
@@ -76,9 +102,10 @@ function expandedRowRender(record){
 ReactDOM.render(
   <div>
     <h2>expandedRowRender</h2>
-    <MyTable data={data}
-
-      className="table"/>
+    <MyTable
+      data={data}
+      className="table"
+    />
   </div>,
   document.getElementById('__react-content')
 );


### PR DESCRIPTION
This PR adds the ability to manage the expanded row keys externally, by passing the keys of the rows that should be expanded as `expandedRowKeys` prop, and being notified on changes with the prop function `onExpandedRowsChange`.

It also, does not break the interface as it is backwards compatible. If none of these props are passed into the component, it will continue with the previous behaviour of storing the expanded rows in the internal state.

Further:
* New features were shown off in the `examples/expandedRowRender.js`
* New features were documented in the README.md 