### PR TITLE
read text.children when there is children in text

### DIFF
--- a/src/TableRow.jsx
+++ b/src/TableRow.jsx
@@ -50,7 +50,7 @@ const TableRow = React.createClass({
         text = render(text, record, index) || {};
         tdProps = text.props || {};
 
-        if (!React.isValidElement(text)) {
+        if (!React.isValidElement(text) && 'children' in text) {
           text = text.children;
         }
         rowSpan = tdProps.rowSpan;


### PR DESCRIPTION
Fix problem below, which is work in old version.

```js
var columns = [{
  title: 'xx',
  render() {
    return 'raw text without wrapping';  // It is broken in 3.6
  }
}]
```