### PR TITLE
TableRow: fix behavior for custom render

### DIFF
--- a/src/TableRow.jsx
+++ b/src/TableRow.jsx
@@ -55,8 +55,16 @@ const TableRow = React.createClass({
       }
 
       if (render) {
-        text = render(text, record, index) || {};
+        text = render(text, record, index);
+        if (text == null) {
+          text = {}
+        }
+
         tdProps = text.props || {};
+
+        if (typeof text === 'number' || typeof text === 'boolean') {
+          text = String(text)
+        }
 
         if (typeof text !== 'string' && !React.isValidElement(text) && 'children' in text) {
           text = text.children;


### PR DESCRIPTION
虽然 render 返回 非 component 的基本数据类型是不推荐的，但感觉还是应该稍微兼容下.
个人的使用场景是升级antd, 导致 table 出现 broken