### PR TITLE
fix paging columns bug

### DIFF
--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -423,7 +423,7 @@ const Table = React.createClass({
 
   getMaxColumnsPage() {
     const { columnsPageRange, columnsPageSize } = this.props;
-    return Math.floor((columnsPageRange[1] - columnsPageRange[0] + 1) / columnsPageSize);
+    return Math.ceil((columnsPageRange[1] - columnsPageRange[0] + 1) / columnsPageSize) - 1;
   },
 
   goToColumnsPage(currentColumnsPage) {


### PR DESCRIPTION
一开始调试得到的公式是
```
Math.ceil((columnsPageRange[1] - columnsPageRange[0] + 1) / columnsPageSize) - 1;
```
最后 提交的时候 觉的下面的和上面的公式是等价的 没测试换了
```
Math.floor((columnsPageRange[1] - columnsPageRange[0] + 1) / columnsPageSize);
```
最近调试的时候突然发现不对了。。。现在更正过来。