### PR TITLE
call syncFixedTableRowHeight only if any columns fixed

### DIFF
--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -96,9 +96,9 @@ const Table = React.createClass({
 
   componentDidMount() {
     this.resetScrollY();
-    this.syncFixedTableRowHeight();
     const isAnyColumnsFixed = this.isAnyColumnsFixed();
     if (isAnyColumnsFixed) {
+      this.syncFixedTableRowHeight();
       this.resizeEvent = addEventListener(
         window, 'resize', debounce(this.syncFixedTableRowHeight, 150)
       );


### PR DESCRIPTION
没有  fixed columns 的时候可以减少一次 render。