### PR TITLE
调整合并表头的高度计算

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -6,7 +6,6 @@
 @table-head-background-color: #f7f7f7;
 @vertical-padding: 16px;
 @horizontal-padding: 8px;
-@row-height: @font-size-base * @line-height + @vertical-padding * 2;
 
 .@{tablePrefixCls} {
   font-size: @font-size-base;
@@ -174,15 +173,6 @@
     table {
       width: auto;
       background: #fff;
-    }
-
-    .generate-rowspan(10);
-
-    .generate-rowspan(@n, @i: 1) when (@i =< @n) {
-      th.@{tablePrefixCls}-rowspan-@{i} {
-        height: @row-height * @i - @vertical-padding * 2;
-      }
-      .generate-rowspan(@n, (@i + 1));
     }
   }
 

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -194,16 +194,13 @@ const Table = React.createClass({
     if (expandIconAsCell && fixed !== 'right') {
       rows[0].unshift({
         key: 'rc-table-expandIconAsCell',
-        className: `${prefixCls}-expand-icon-th ${prefixCls}-rowspan-${rows.length}`,
+        className: `${prefixCls}-expand-icon-th`,
         title: '',
         rowSpan: rows.length,
       });
     }
 
-    const { fixedColumnsHeadRowsHeight } = this.state;
-    const trStyle = (fixedColumnsHeadRowsHeight[0] && columns) ? {
-      height: fixedColumnsHeadRowsHeight[0],
-    } : null;
+    const trStyle = this.getHeaderRowStyle(columns, rows);
 
     return showHeader ? (
       <TableHeader
@@ -215,8 +212,6 @@ const Table = React.createClass({
   },
 
   getHeaderRows(columns, currentRow = 0, rows) {
-    const { prefixCls } = this.props;
-
     rows = rows || [];
     rows[currentRow] = rows[currentRow] || [];
 
@@ -239,13 +234,12 @@ const Table = React.createClass({
       }
       if ('rowSpan' in column) {
         cell.rowSpan = column.rowSpan;
-        cell.className += ` ${prefixCls}-rowspan-${cell.rowSpan}`;
       }
       if (cell.colSpan !== 0) {
         rows[currentRow].push(cell);
       }
     });
-    return rows;
+    return rows.filter(row => row.length > 0);
   },
 
   getExpandedRow(key, content, visible, className, fixed) {
@@ -565,6 +559,18 @@ const Table = React.createClass({
     return this.getLeafColumns(columns).length;
   },
 
+  getHeaderRowStyle(columns, rows) {
+    const { fixedColumnsHeadRowsHeight } = this.state;
+    const headerHeight = fixedColumnsHeadRowsHeight[0];
+    if (headerHeight && columns) {
+      if (headerHeight === 'auto') {
+        return { height: 'auto' };
+      }
+      return { height: headerHeight / rows.length };
+    }
+    return null;
+  },
+
   // add appropriate rowspan and colspan to column
   groupColumns(columns, currentRow = 0, parentColumn = {}, rows = []) {
     // track how many rows we got
@@ -607,8 +613,8 @@ const Table = React.createClass({
   syncFixedTableRowHeight() {
     const { prefixCls } = this.props;
     const headRows = this.refs.headTable ?
-            this.refs.headTable.querySelectorAll('tr') :
-            this.refs.bodyTable.querySelectorAll('thead > tr');
+            this.refs.headTable.querySelectorAll('thead') :
+            this.refs.bodyTable.querySelectorAll('thead');
     const bodyRows = this.refs.bodyTable.querySelectorAll(`.${prefixCls}-row`) || [];
     const fixedColumnsHeadRowsHeight = [].map.call(
       headRows, row => row.getBoundingClientRect().height || 'auto'

--- a/tests/groupingColumnTitle.spec.js
+++ b/tests/groupingColumnTitle.spec.js
@@ -114,12 +114,12 @@ describe('Table with grouping columns', () => {
       div
     );
 
+    const fixedRows = node.find('.rc-table-fixed-left thead tr');
     const titleA = node.find('.rc-table-fixed-left .title-a');
     const titleE = node.find('.rc-table-fixed-right .title-e');
 
+    expect(fixedRows.length).to.be(1);
     expect(titleA.attr('rowspan')).to.be('2');
-    expect(titleA.hasClass('rc-table-rowspan-2')).to.be(true);
     expect(titleE.attr('rowspan')).to.be('2');
-    expect(titleE.hasClass('rc-table-rowspan-2')).to.be(true);
   });
 });


### PR DESCRIPTION
原来用 CSS 的计算方式是有问题的，因为表头可能被里面的内容撑得超过 CSS 计算的高度。

另外有两个疑问：

- [这里](https://github.com/react-component/table/blob/6a5debb0a8fc155287715fa685ce243a6ce2cf1e/src/Table.jsx#L614) 什么情况下会有 `row.getBoundingClientRect().height == false` ?
- [这里](https://github.com/react-component/table/blob/6a5debb0a8fc155287715fa685ce243a6ce2cf1e/src/Table.jsx#L623-L628) 为什么要用 `setTimeout`，这样会导致在测试里没法同步拿到设置的高度。