### PR TITLE
Extract hover state by creating a global state

### DIFF
--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -5,6 +5,7 @@ import { measureScrollbar, debounce } from './utils';
 import shallowequal from 'shallowequal';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import ColumnManager from './ColumnManager';
+import createStore from './createStore';
 
 const Table = React.createClass({
   propTypes: {
@@ -68,9 +69,12 @@ const Table = React.createClass({
 
   getInitialState() {
     const props = this.props;
-    this.columnManager = new ColumnManager(props.columns);
     let expandedRowKeys = [];
     let rows = [...props.data];
+
+    this.columnManager = new ColumnManager(props.columns);
+    this.store = createStore({ currentHoverKey: null });
+
     if (props.defaultExpandAllRows) {
       for (let i = 0; i < rows.length; i++) {
         const row = rows[i];
@@ -269,6 +273,7 @@ const Table = React.createClass({
         prefixCls={`${prefixCls}-expanded-row`}
         indent={1}
         expandable={false}
+        store={this.store}
       />
     );
   },
@@ -299,10 +304,7 @@ const Table = React.createClass({
       if (expandedRowRender && isRowExpanded) {
         expandedRowContent = expandedRowRender(record, i, indent);
       }
-      let className = rowClassName(record, i, indent);
-      if (this.state.currentHoverKey === key) {
-        className += ` ${props.prefixCls}-row-hover`;
-      }
+      const className = rowClassName(record, i, indent);
 
       const onHoverProps = {};
       if (this.columnManager.isAnyColumnsFixed()) {
@@ -348,6 +350,7 @@ const Table = React.createClass({
           key={key}
           hoverKey={key}
           ref={rowRef(record, i, indent)}
+          store={this.store}
         />
       );
 
@@ -652,7 +655,7 @@ const Table = React.createClass({
   },
 
   handleRowHover(isHover, key) {
-    this.setState({
+    this.store.setState({
       currentHoverKey: isHover ? key : null,
     });
   },

--- a/src/TableRow.jsx
+++ b/src/TableRow.jsx
@@ -29,6 +29,7 @@ const TableRow = React.createClass({
     indentSize: PropTypes.number,
     expandIconAsCell: PropTypes.bool,
     expandRowByClick: PropTypes.bool,
+    store: PropTypes.object.isRequired,
   },
 
   getDefaultProps() {
@@ -42,12 +43,33 @@ const TableRow = React.createClass({
     };
   },
 
-  shouldComponentUpdate(nextProps) {
-    return !shallowequal(nextProps, this.props);
+  getInitialState() {
+    return {
+      hovered: false,
+    };
+  },
+
+  componentDidMount() {
+    const { store, hoverKey } = this.props;
+    this.unsubscribe = store.subscribe(() => {
+      if (store.getState().currentHoverKey === hoverKey) {
+        this.setState({ hovered: true });
+      } else if (this.state.hovered === true) {
+        this.setState({ hovered: false });
+      }
+    });
+  },
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return !shallowequal(nextProps, this.props) ||
+           !shallowequal(nextState, this.state);
   },
 
   componentWillUnmount() {
     this.props.onDestroy(this.props.record);
+    if (this.unsubscribe) {
+      this.unsubscribe();
+    }
   },
 
   onRowClick(event) {
@@ -85,8 +107,14 @@ const TableRow = React.createClass({
     const {
       prefixCls, columns, record, height, visible, index,
       expandIconColumnIndex, expandIconAsCell, expanded, expandRowByClick,
-      expandable, onExpand, needIndentSpaced, className, indent, indentSize,
+      expandable, onExpand, needIndentSpaced, indent, indentSize,
     } = this.props;
+
+    let { className } = this.props;
+
+    if (this.state.hovered) {
+      className += ` ${prefixCls}-hover`;
+    }
 
     const cells = [];
 

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,0 +1,30 @@
+export default function createStore(initialState) {
+  let state = initialState;
+  const listeners = [];
+
+  function setState(partial) {
+    state = { ...state, ...partial };
+    for (let i = 0; i < listeners.length; i++) {
+      listeners[i]();
+    }
+  }
+
+  function getState() {
+    return state;
+  }
+
+  function subscribe(listener) {
+    listeners.push(listener);
+
+    return function unsubscribe() {
+      const index = listeners.indexOf(listener);
+      listeners.splice(index, 1);
+    };
+  }
+
+  return {
+    setState,
+    getState,
+    subscribe,
+  };
+}

--- a/tests/createStore.spec.js
+++ b/tests/createStore.spec.js
@@ -1,0 +1,25 @@
+const expect = require('expect.js');
+const createStore = require('../src/createStore');
+
+describe('createStore', () => {
+  it('create with initial state', () => {
+    const store = createStore({ a: 1 });
+    expect(store.getState()).to.eql({ a: 1 });
+  });
+
+  it('setState', () => {
+    const store = createStore({ a: 1 });
+    store.setState({ a: 2 });
+    expect(store.getState()).to.eql({ a: 2 });
+  });
+
+  it('subscribe', () => {
+    const store = createStore({ a: 1 });
+    const unsubscribe = store.subscribe(() => {
+      expect(store.getState()).to.eql({ a: 2 });
+    });
+    store.setState({ a: 2 });
+    unsubscribe();
+    store.setState({ a: 3 });
+  });
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,5 +1,2 @@
-require('./basic.spec.js');
-require('./groupingColumnTitle.spec.js');
-require('./rowClick.spec.js');
-require('./fixedColumns.spec.js');
-require('./ColumnManager.spec.js');
+const req = require.context('.', false, /\.spec\.js$/);
+req.keys().forEach(req);


### PR DESCRIPTION
写了个类似 redux 的 store，把 hover 状态提了出来，这样 hover 状态变化的时候就不需要渲染整个 Table 了。

https://github.com/ant-design/ant-design/issues/3096