### PR TITLE
Optimize shouldComponentUpdate

### DIFF
--- a/src/ColumnManager.js
+++ b/src/ColumnManager.js
@@ -1,0 +1,132 @@
+export default class ColumnManager {
+  _cached = {}
+
+  constructor(columns) {
+    this.columns = columns;
+  }
+
+  isAnyColumnsFixed() {
+    return this._cache('isAnyColumnsFixed', () => {
+      return this.columns.some(column => !!column.fixed);
+    });
+  }
+
+  isAnyColumnsLeftFixed() {
+    return this._cache('isAnyColumnsLeftFixed', () => {
+      return this.columns.some(
+        column => column.fixed === 'left' || column.fixed === true
+      );
+    });
+  }
+
+  isAnyColumnsRightFixed() {
+    return this._cache('isAnyColumnsRightFixed', () => {
+      return this.columns.some(
+        column => column.fixed === 'right'
+      );
+    });
+  }
+
+  leftColumns() {
+    return this._cache('leftColumns', () => {
+      return this.groupedColumns().filter(
+        column => column.fixed === 'left' || column.fixed === true
+      );
+    });
+  }
+
+  rightColumns() {
+    return this._cache('rightColumns', () => {
+      return this.groupedColumns().filter(
+        column => column.fixed === 'right'
+      );
+    });
+  }
+
+  leafColumns() {
+    return this._cache('leafColumns', () =>
+      this._leafColumns(this.columns)
+    );
+  }
+
+  leftLeafColumns() {
+    return this._cache('leftLeafColumns', () =>
+      this._leafColumns(this.leftColumns())
+    );
+  }
+
+  rightLeafColumns() {
+    return this._cache('rightLeafColumns', () =>
+      this._leafColumns(this.rightColumns())
+    );
+  }
+
+  // add appropriate rowspan and colspan to column
+  groupedColumns() {
+    return this._cache('groupedColumns', () => {
+      const _groupColumns = (columns, currentRow = 0, parentColumn = {}, rows = []) => {
+        // track how many rows we got
+        if (!~rows.indexOf(currentRow)) {
+          rows.push(currentRow);
+        }
+        const grouped = [];
+        const setRowSpan = column => {
+          const rowSpan = rows.length - currentRow;
+          if (column &&
+            !column.children && // parent columns are supposed to be one row
+            rowSpan > 1 &&
+            (!column.rowSpan || column.rowSpan < rowSpan)
+          ) {
+            column.rowSpan = rowSpan;
+          }
+        };
+        columns.forEach((column, index) => {
+          const newColumn = { ...column };
+          parentColumn.colSpan = parentColumn.colSpan || 0;
+          if (newColumn.children && newColumn.children.length > 0) {
+            newColumn.children = _groupColumns(newColumn.children, currentRow + 1, newColumn, rows);
+            parentColumn.colSpan = parentColumn.colSpan + newColumn.colSpan;
+          } else {
+            parentColumn.colSpan++;
+          }
+          // update rowspan to all previous columns
+          for (let i = 0; i < index; ++i) {
+            setRowSpan(grouped[i]);
+          }
+          // last column, update rowspan immediately
+          if (index + 1 === columns.length) {
+            setRowSpan(newColumn);
+          }
+          grouped.push(newColumn);
+        });
+        return grouped;
+      };
+      return _groupColumns(this.columns);
+    });
+  }
+
+  reset(columns) {
+    this.columns = columns;
+    this._cache = {};
+  }
+
+  _cache(name, fn) {
+    if (name in this._cached) {
+      return this._cached[name];
+    }
+    this._cached[name] = fn();
+    return this._cached[name];
+  }
+
+  _leafColumns(columns) {
+    const leafColumns = [];
+    columns.forEach(column => {
+      if (!column.children) {
+        leafColumns.push(column);
+      } else {
+        leafColumns.push(...this._leafColumns(column.children));
+      }
+    });
+    return leafColumns;
+  }
+}

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -4,6 +4,7 @@ import TableHeader from './TableHeader';
 import { measureScrollbar, debounce } from './utils';
 import shallowequal from 'shallowequal';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
+import ColumnManager from './ColumnManager';
 
 const Table = React.createClass({
   propTypes: {
@@ -67,6 +68,7 @@ const Table = React.createClass({
 
   getInitialState() {
     const props = this.props;
+    this.columnManager = new ColumnManager(props.columns);
     let expandedRowKeys = [];
     let rows = [...props.data];
     if (props.defaultExpandAllRows) {
@@ -90,8 +92,7 @@ const Table = React.createClass({
 
   componentDidMount() {
     this.resetScrollY();
-    const isAnyColumnsFixed = this.isAnyColumnsFixed();
-    if (isAnyColumnsFixed) {
+    if (this.columnManager.isAnyColumnsFixed()) {
       this.syncFixedTableRowHeight();
       this.resizeEvent = addEventListener(
         window, 'resize', debounce(this.syncFixedTableRowHeight, 150)
@@ -114,9 +115,7 @@ const Table = React.createClass({
       });
     }
     if (nextProps.columns !== this.props.columns) {
-      delete this.isAnyColumnsFixedCache;
-      delete this.isAnyColumnsLeftFixedCache;
-      delete this.isAnyColumnsRightFixedCache;
+      this.columnManager.reset(nextProps.columns);
     }
   },
 
@@ -183,13 +182,7 @@ const Table = React.createClass({
 
   getHeader(columns, fixed) {
     const { showHeader, expandIconAsCell, prefixCls } = this.props;
-    let rows;
-    if (columns) {
-      // columns are passed from fixed table function that already grouped.
-      rows = this.getHeaderRows(columns);
-    } else {
-      rows = this.getHeaderRows(this.groupColumns(this.props.columns));
-    }
+    const rows = this.getHeaderRows(columns);
 
     if (expandIconAsCell && fixed !== 'right') {
       rows[0].unshift({
@@ -244,11 +237,19 @@ const Table = React.createClass({
 
   getExpandedRow(key, content, visible, className, fixed) {
     const { prefixCls, expandIconAsCell } = this.props;
+    let colCount;
+    if (fixed === 'left') {
+      colCount = this.columnManager.leftLeafColumns().length;
+    } else if (fixed === 'right') {
+      colCount = this.columnManager.rightLeafColumns().length;
+    } else {
+      colCount = this.columnManager.leafColumns().length;
+    }
     const columns = [{
       key: 'extra-row',
       render: () => ({
         props: {
-          colSpan: this.getLeafColumnsCount(this.props.columns),
+          colSpan: colCount,
         },
         children: fixed !== 'right' ? content : '&nbsp;',
       }),
@@ -285,7 +286,6 @@ const Table = React.createClass({
     const needIndentSpaced = props.data.some(record => record[childrenColumnName]);
     const onRowClick = props.onRowClick;
     const onRowDoubleClick = props.onRowDoubleClick;
-    const isAnyColumnsFixed = this.isAnyColumnsFixed();
 
     const expandIconAsCell = fixed !== 'right' ? props.expandIconAsCell : false;
     const expandIconColumnIndex = fixed !== 'right' ? props.expandIconColumnIndex : -1;
@@ -305,7 +305,7 @@ const Table = React.createClass({
       }
 
       const onHoverProps = {};
-      if (isAnyColumnsFixed) {
+      if (this.columnManager.isAnyColumnsFixed()) {
         onHoverProps.onHover = this.handleRowHover;
       }
 
@@ -313,7 +313,14 @@ const Table = React.createClass({
         height: fixedColumnsBodyRowsHeight[i],
       } : {};
 
-      const leafColumns = this.getLeafColumns(columns || props.columns);
+      let leafColumns;
+      if (fixed === 'left') {
+        leafColumns = this.columnManager.leftLeafColumns();
+      } else if (fixed === 'right') {
+        leafColumns = this.columnManager.rightLeafColumns();
+      } else {
+        leafColumns = this.columnManager.leafColumns();
+      }
 
       rst.push(
         <TableRow
@@ -374,7 +381,14 @@ const Table = React.createClass({
         />
       );
     }
-    const leafColumns = this.getLeafColumns(columns || this.props.columns);
+    let leafColumns;
+    if (fixed === 'left') {
+      leafColumns = this.columnManager.leftLeafColumns();
+    } else if (fixed === 'right') {
+      leafColumns = this.columnManager.rightLeafColumns();
+    } else {
+      leafColumns = this.columnManager.leafColumns();
+    }
     cols = cols.concat(leafColumns.map(c => {
       return <col key={c.key} style={{ width: c.width, minWidth: c.width }} />;
     }));
@@ -382,21 +396,15 @@ const Table = React.createClass({
   },
 
   getLeftFixedTable() {
-    const { columns } = this.props;
-    const fixedColumns = this.groupColumns(columns).filter(
-      column => column.fixed === 'left' || column.fixed === true
-    );
     return this.getTable({
-      columns: fixedColumns,
+      columns: this.columnManager.leftColumns(),
       fixed: 'left',
     });
   },
 
   getRightFixedTable() {
-    const { columns } = this.props;
-    const fixedColumns = this.groupColumns(columns).filter(column => column.fixed === 'right');
     return this.getTable({
-      columns: fixedColumns,
+      columns: this.columnManager.rightColumns(),
       fixed: 'right',
     });
   },
@@ -458,11 +466,12 @@ const Table = React.createClass({
     };
 
     let headTable;
+
     if (useFixedHeader) {
       headTable = (
         <div
           className={`${prefixCls}-header`}
-          ref={columns ? null : 'headTable'}
+          ref={fixed ? null : 'headTable'}
           style={headStyle}
           onMouseOver={this.detectScrollTarget}
           onTouchStart={this.detectScrollTarget}
@@ -486,7 +495,7 @@ const Table = React.createClass({
       </div>
     );
 
-    if (columns && columns.length) {
+    if (fixed && columns.length) {
       let refName;
       if (columns[0].fixed === 'left' || columns[0].fixed === true) {
         refName = 'fixedColumnsBodyLeft';
@@ -543,22 +552,6 @@ const Table = React.createClass({
     ) : null;
   },
 
-  getLeafColumns(columns) {
-    const leafColumns = [];
-    columns.forEach(column => {
-      if (!column.children) {
-        leafColumns.push(column);
-      } else {
-        leafColumns.push(...this.getLeafColumns(column.children));
-      }
-    });
-    return leafColumns;
-  },
-
-  getLeafColumnsCount(columns) {
-    return this.getLeafColumns(columns).length;
-  },
-
   getHeaderRowStyle(columns, rows) {
     const { fixedColumnsHeadRowsHeight } = this.state;
     const headerHeight = fixedColumnsHeadRowsHeight[0];
@@ -569,45 +562,6 @@ const Table = React.createClass({
       return { height: headerHeight / rows.length };
     }
     return null;
-  },
-
-  // add appropriate rowspan and colspan to column
-  groupColumns(columns, currentRow = 0, parentColumn = {}, rows = []) {
-    // track how many rows we got
-    if (!~rows.indexOf(currentRow)) {
-      rows.push(currentRow);
-    }
-    const grouped = [];
-    const setRowSpan = column => {
-      const rowSpan = rows.length - currentRow;
-      if (column &&
-          !column.children && // parent columns are supposed to be one row
-          rowSpan > 1 &&
-          (!column.rowSpan || column.rowSpan < rowSpan)
-      ) {
-        column.rowSpan = rowSpan;
-      }
-    };
-    columns.forEach((column, index) => {
-      const newColumn = { ...column };
-      parentColumn.colSpan = parentColumn.colSpan || 0;
-      if (newColumn.children && newColumn.children.length > 0) {
-        newColumn.children = this.groupColumns(newColumn.children, currentRow + 1, newColumn, rows);
-        parentColumn.colSpan = parentColumn.colSpan + newColumn.colSpan;
-      } else {
-        parentColumn.colSpan++;
-      }
-      // update rowspan to all previous columns
-      for (let i = 0; i < index; ++i) {
-        setRowSpan(grouped[i]);
-      }
-      // last column, update rowspan immediately
-      if (index + 1 === columns.length) {
-        setRowSpan(newColumn);
-      }
-      grouped.push(newColumn);
-    });
-    return grouped;
   },
 
   syncFixedTableRowHeight() {
@@ -656,34 +610,6 @@ const Table = React.createClass({
     if (this.scrollTarget !== e.currentTarget) {
       this.scrollTarget = e.currentTarget;
     }
-  },
-
-  isAnyColumnsFixed() {
-    if ('isAnyColumnsFixedCache' in this) {
-      return this.isAnyColumnsFixedCache;
-    }
-    this.isAnyColumnsFixedCache = this.props.columns.some(column => !!column.fixed);
-    return this.isAnyColumnsFixedCache;
-  },
-
-  isAnyColumnsLeftFixed() {
-    if ('isAnyColumnsLeftFixedCache' in this) {
-      return this.isAnyColumnsLeftFixedCache;
-    }
-    this.isAnyColumnsLeftFixedCache = this.props.columns.some(
-      column => column.fixed === 'left' || column.fixed === true
-    );
-    return this.isAnyColumnsLeftFixedCache;
-  },
-
-  isAnyColumnsRightFixed() {
-    if ('isAnyColumnsRightFixedCache' in this) {
-      return this.isAnyColumnsRightFixedCache;
-    }
-    this.isAnyColumnsRightFixedCache = this.props.columns.some(
-      column => column.fixed === 'right'
-    );
-    return this.isAnyColumnsRightFixedCache;
   },
 
   handleBodyScroll(e) {
@@ -744,22 +670,24 @@ const Table = React.createClass({
     }
     className += ` ${prefixCls}-scroll-position-${this.state.scrollPosition}`;
 
-    const isTableScroll = this.isAnyColumnsFixed() || props.scroll.x || props.scroll.y;
+    const isTableScroll = this.columnManager.isAnyColumnsFixed() ||
+                          props.scroll.x ||
+                          props.scroll.y;
 
     return (
       <div className={className} style={props.style}>
         {this.getTitle()}
         <div className={`${prefixCls}-content`}>
-          {this.isAnyColumnsLeftFixed() &&
+          {this.columnManager.isAnyColumnsLeftFixed() &&
           <div className={`${prefixCls}-fixed-left`}>
             {this.getLeftFixedTable()}
           </div>}
           <div className={isTableScroll ? `${prefixCls}-scroll` : ''}>
-            {this.getTable()}
+            {this.getTable({ columns: this.columnManager.groupedColumns() })}
             {this.getEmptyText()}
             {this.getFooter()}
           </div>
-          {this.isAnyColumnsRightFixed() &&
+          {this.columnManager.isAnyColumnsRightFixed() &&
           <div className={`${prefixCls}-fixed-right`}>
             {this.getRightFixedTable()}
           </div>}

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -309,9 +309,9 @@ const Table = React.createClass({
         onHoverProps.onHover = this.handleRowHover;
       }
 
-      const style = (fixed && fixedColumnsBodyRowsHeight[i]) ? {
-        height: fixedColumnsBodyRowsHeight[i],
-      } : {};
+      const height = (fixed && fixedColumnsBodyRowsHeight[i]) ?
+        fixedColumnsBodyRowsHeight[i] : null;
+
 
       let leafColumns;
       if (fixed === 'left') {
@@ -343,7 +343,7 @@ const Table = React.createClass({
           expandIconColumnIndex={expandIconColumnIndex}
           onRowClick={onRowClick}
           onRowDoubleClick={onRowDoubleClick}
-          style={style}
+          height={height}
           {...onHoverProps}
           key={key}
           hoverKey={key}

--- a/src/TableRow.jsx
+++ b/src/TableRow.jsx
@@ -13,7 +13,10 @@ const TableRow = React.createClass({
     expandIconColumnIndex: PropTypes.number,
     onHover: PropTypes.func,
     columns: PropTypes.array,
-    style: PropTypes.object,
+    height: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+    ]),
     visible: PropTypes.bool,
     index: PropTypes.number,
     hoverKey: PropTypes.any,
@@ -80,7 +83,7 @@ const TableRow = React.createClass({
 
   render() {
     const {
-      prefixCls, columns, record, style, visible, index,
+      prefixCls, columns, record, height, visible, index,
       expandIconColumnIndex, expandIconAsCell, expanded, expandRowByClick,
       expandable, onExpand, needIndentSpaced, className, indent, indentSize,
     } = this.props;
@@ -124,6 +127,10 @@ const TableRow = React.createClass({
         />
       );
     }
+    const style = { height };
+    if (!visible) {
+      style.display = 'none';
+    }
 
     return (
       <tr
@@ -132,7 +139,7 @@ const TableRow = React.createClass({
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
         className={`${prefixCls} ${className} ${prefixCls}-level-${indent}`}
-        style={visible ? style : { ...style, display: 'none' }}
+        style={style}
       >
         {cells}
       </tr>

--- a/tests/ColumnManager.spec.js
+++ b/tests/ColumnManager.spec.js
@@ -1,0 +1,72 @@
+/* eslint-disable no-console,func-names,react/no-multi-comp,indent */
+const expect = require('expect.js');
+const ColumnManager = require('../src/ColumnManager');
+
+describe('ColumnManager', () => {
+  describe('groupedColumns', () => {
+    it('add appropriate rowspan and colspan to column', () => {
+      const columns = [
+        { title: '表头A', className: 'title-a', dataIndex: 'a', key: 'a' },
+        { title: '表头B', className: 'title-b', dataIndex: 'b', key: 'b' },
+        { title: '表头C', className: 'title-c', children:
+          [
+            { title: '表头D', className: 'title-d', dataIndex: 'c', key: 'c' },
+            { title: '表头E', className: 'title-e', children:
+              [
+                { title: '表头F', className: 'title-f', dataIndex: 'd', key: 'd' },
+                { title: '表头G', className: 'title-g', children:
+                  [
+                    { title: '表头H', className: 'title-h', dataIndex: 'e', key: 'e' },
+                    { title: '表头I', className: 'title-i', dataIndex: 'f', key: 'f' },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        { title: '表头J', className: 'title-j', children:
+          [
+            { title: '表头K', className: 'title-k', dataIndex: 'g', key: 'g' },
+            { title: '表头L', className: 'title-l', dataIndex: 'h', key: 'h' },
+          ],
+        },
+        { title: '表头M', className: 'title-m', dataIndex: 'i', key: 'i' },
+      ];
+
+      const columnManager = new ColumnManager(columns);
+      const groupedColumns = columnManager.groupedColumns();
+
+      expect(groupedColumns).to.eql([
+        { title: '表头A', className: 'title-a', dataIndex: 'a', key: 'a', rowSpan: 4 },
+        { title: '表头B', className: 'title-b', dataIndex: 'b', key: 'b', rowSpan: 4 },
+        { title: '表头C', className: 'title-c', children:
+          [
+            { title: '表头D', className: 'title-d', dataIndex: 'c', key: 'c', rowSpan: 3 },
+            { title: '表头E', className: 'title-e', children:
+              [
+                { title: '表头F', className: 'title-f', dataIndex: 'd', key: 'd', rowSpan: 2 },
+                { title: '表头G', className: 'title-g', children:
+                  [
+                    { title: '表头H', className: 'title-h', dataIndex: 'e', key: 'e' },
+                    { title: '表头I', className: 'title-i', dataIndex: 'f', key: 'f' },
+                  ],
+                  colSpan: 2,
+                },
+              ],
+              colSpan: 3,
+            },
+          ],
+          colSpan: 4,
+        },
+        { title: '表头J', className: 'title-j', children:
+          [
+            { title: '表头K', className: 'title-k', dataIndex: 'g', key: 'g', rowSpan: 3 },
+            { title: '表头L', className: 'title-l', dataIndex: 'h', key: 'h', rowSpan: 3 },
+          ],
+          colSpan: 2,
+        },
+        { title: '表头M', className: 'title-m', dataIndex: 'i', key: 'i', rowSpan: 4 },
+      ]);
+    });
+  });
+});

--- a/tests/index.js
+++ b/tests/index.js
@@ -2,3 +2,4 @@ require('./basic.spec.js');
 require('./groupingColumnTitle.spec.js');
 require('./rowClick.spec.js');
 require('./fixedColumns.spec.js');
+require('./ColumnManager.spec.js');


### PR DESCRIPTION
1. 把所有 columns 相关的计算都抽出来，并对计算结果进行缓存，避免每次都生成新的 columns 对象；
1. 不直接给 TableRow 传 style，避免每次都生成新的 style 对象。

这样改完后发现 #95 其实不需要了， shouldComponentUpdate 可以正常工作了。