### PR TITLE
[WIP]Tweak should component update

### DIFF
--- a/src/ColumnManager.js
+++ b/src/ColumnManager.js
@@ -107,7 +107,7 @@ export default class ColumnManager {
 
   reset(columns) {
     this.columns = columns;
-    this._cache = {};
+    this._cached = {};
   }
 
   _cache(name, fn) {

--- a/src/ColumnManager.js
+++ b/src/ColumnManager.js
@@ -5,6 +5,10 @@ export default class ColumnManager {
     this.columns = columns;
   }
 
+  static includesCustomRender(columns) {
+    return columns.some(column => !!column.render);
+  }
+
   isAnyColumnsFixed() {
     return this._cache('isAnyColumnsFixed', () => {
       return this.columns.some(column => !!column.fixed);

--- a/src/TableCell.jsx
+++ b/src/TableCell.jsx
@@ -13,7 +13,7 @@ const TableCell = React.createClass({
     expandIcon: PropTypes.node,
   },
   shouldComponentUpdate(nextProps) {
-    return !shallowequal(nextProps, this.props);
+    return !shallowequal(nextProps, this.props) || !!nextProps.column.render;
   },
   isInvalidRenderCellText(text) {
     return text && !React.isValidElement(text) &&

--- a/src/TableRow.jsx
+++ b/src/TableRow.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import shallowequal from 'shallowequal';
 import TableCell from './TableCell';
 import ExpandIcon from './ExpandIcon';
+import ColumnManager from './ColumnManager';
 
 const TableRow = React.createClass({
   propTypes: {
@@ -62,7 +63,8 @@ const TableRow = React.createClass({
 
   shouldComponentUpdate(nextProps, nextState) {
     return !shallowequal(nextProps, this.props) ||
-           !shallowequal(nextState, this.state);
+           !shallowequal(nextState, this.state) ||
+           ColumnManager.includesCustomRender(nextProps.columns);
   },
 
   componentWillUnmount() {

--- a/tests/ColumnManager.spec.js
+++ b/tests/ColumnManager.spec.js
@@ -3,6 +3,31 @@ const expect = require('expect.js');
 const ColumnManager = require('../src/ColumnManager');
 
 describe('ColumnManager', () => {
+  describe('includesCustomRender', () => {
+    it('return true', () => {
+      const columns = [
+        {
+          title: 'a',
+          dataIndex: 'a',
+          render: () => 'a',
+        },
+      ];
+
+      expect(ColumnManager.includesCustomRender(columns)).to.be(true);
+    });
+
+    it('return false', () => {
+      const columns = [
+        {
+          title: 'a',
+          dataIndex: 'a',
+        },
+      ];
+
+      expect(ColumnManager.includesCustomRender(columns)).to.be(false);
+    });
+  });
+
   describe('groupedColumns', () => {
     it('add appropriate rowspan and colspan to column', () => {
       const columns = [


### PR DESCRIPTION
发现一个问题，因为现在 columns 允许 render 是一个 function，这导致 TableRow 其实不是一个 pure component，不能用简单的 shouldComponentUpdate 去优化（例子：http://codepen.io/yesmeck/pen/oYNWwM?editors=001 ）。我想后面再看看 Table 里的状态能不能像 `currentHoverKey` 那样抽到 store 里，然后把 shouldComponentUpdate 去掉，现在其实 shouldComponentUpdate 有点鸡肋。