### PR TITLE
feature: add columnExtraInfo when column render

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ React.render(<Table columns={columns} data={data} />, mountNode);
         The columns config of table, see table below
       </td>
     </tr>
+    <tr>
+      <td>columnExtraInfo</td>
+      <td>any</td>
+      <td></td>
+      <td>
+        With this prop, Column render will accept the forth argument, columnExtraInfo.
+      </td>
+    </tr>
   </tbody>
 </table>
 
@@ -285,7 +293,7 @@ React.render(<Table columns={columns} data={data} />, mountNode);
     </tr>
     <tr>
       <td>render</td>
-      <td>Function(value, row, index)</td>
+      <td>Function(value, row, index, columnExtraInfo)</td>
       <td></td>
       <td>The render function of cell, has three params: the text of this cell, the record of this row, the index of this row, it's return an object:{ children: value, props: { colSpan: 1, rowSpan:1 } } ==> 'children' is the text of this cell, props is some setting of this cell, eg: 'colspan' set td colspan, 'rowspan' set td rowspan</td>
     </tr>

--- a/examples/column-extra-info.js
+++ b/examples/column-extra-info.js
@@ -1,0 +1,63 @@
+/* eslint-disable no-console,func-names,react/no-multi-comp */
+const React = require('react');
+const ReactDOM = require('react-dom');
+const Table = require('rc-table');
+require('rc-table/assets/index.less');
+
+const PAGE_STATUS_EDIT = 'EDIT';
+const PAGE_STATUS_READ = 'READ';
+
+const columns = [
+  { title: 'title1', dataIndex: 'a', key: 'a', width: 100 },
+  { id: '123', title: 'title2', dataIndex: 'b', key: 'b', width: 100 },
+  { title: 'title3', dataIndex: 'c', key: 'c', width: 200 },
+  {
+    title: 'Operations', dataIndex: '', key: 'd', render(text, record, index, context) {
+      if (context.state.pageStatus === PAGE_STATUS_EDIT) {
+        return <a href="#">Editable</a>;
+      }
+      return 'ReadOnly';
+    },
+  },
+];
+
+const data = [
+  { a: '123', key: '1' },
+  { a: 'cdd', b: 'edd', key: '2' },
+  { a: '1333', c: 'eee', d: 2, key: '3' },
+];
+
+class List extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      pageStatus: PAGE_STATUS_EDIT,
+    };
+    this.handleSwitchPageStatus = this.handleSwitchPageStatus.bind(this);
+  }
+
+  handleSwitchPageStatus() {
+    let pageStatus;
+    if (this.state.pageStatus === PAGE_STATUS_EDIT) {
+      pageStatus = PAGE_STATUS_READ;
+    } else {
+      pageStatus = PAGE_STATUS_EDIT;
+    }
+    this.setState({ pageStatus });
+  }
+
+  render() {
+    return (
+      <div>
+        <h2>ColumnExtraInfo table</h2>
+        <button type="button" onClick={this.handleSwitchPageStatus}>Switch</button>
+        <Table columns={columns} data={data} columnExtraInfo={this} />
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(
+  <List />,
+  document.getElementById('__react-content')
+);

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -16,6 +16,7 @@ const Table = React.createClass({
     defaultExpandedRowKeys: PropTypes.array,
     useFixedHeader: PropTypes.bool,
     columns: PropTypes.array,
+    columnExtraInfo: PropTypes.any,
     prefixCls: PropTypes.string,
     bodyStyle: PropTypes.object,
     style: PropTypes.object,
@@ -244,7 +245,7 @@ const Table = React.createClass({
   },
 
   getExpandedRow(key, content, visible, className, fixed) {
-    const { prefixCls, expandIconAsCell } = this.props;
+    const { prefixCls, expandIconAsCell, columnExtraInfo } = this.props;
     let colCount;
     if (fixed === 'left') {
       colCount = this.columnManager.leftLeafColumns().length;
@@ -271,6 +272,7 @@ const Table = React.createClass({
     return (
       <TableRow
         columns={columns}
+        columnExtraInfo={columnExtraInfo}
         visible={visible}
         className={className}
         key={`${key}-extra-row`}
@@ -346,6 +348,7 @@ const Table = React.createClass({
           prefixCls={`${props.prefixCls}-row`}
           childrenColumnName={childrenColumnName}
           columns={leafColumns}
+          columnExtraInfo={props.columnExtraInfo}
           expandIconColumnIndex={expandIconColumnIndex}
           onRowClick={onRowClick}
           onRowDoubleClick={onRowDoubleClick}

--- a/src/TableCell.jsx
+++ b/src/TableCell.jsx
@@ -9,6 +9,7 @@ const TableCell = React.createClass({
     indent: PropTypes.number,
     indentSize: PropTypes.number,
     column: PropTypes.object,
+    columnExtraInfo: PropTypes.any,
     expandIcon: PropTypes.node,
   },
   isInvalidRenderCellText(text) {
@@ -23,7 +24,7 @@ const TableCell = React.createClass({
   },
   render() {
     const { record, indentSize, prefixCls, indent,
-            index, expandIcon, column } = this.props;
+            index, expandIcon, column, columnExtraInfo } = this.props;
     const { dataIndex, render, className = '' } = column;
 
     let text = objectPath.get(record, dataIndex);
@@ -32,7 +33,7 @@ const TableCell = React.createClass({
     let rowSpan;
 
     if (render) {
-      text = render(text, record, index);
+      text = render(text, record, index, columnExtraInfo);
       if (this.isInvalidRenderCellText(text)) {
         tdProps = text.props || {};
         rowSpan = tdProps.rowSpan;

--- a/src/TableRow.jsx
+++ b/src/TableRow.jsx
@@ -12,6 +12,7 @@ const TableRow = React.createClass({
     expandIconColumnIndex: PropTypes.number,
     onHover: PropTypes.func,
     columns: PropTypes.array,
+    columnExtraInfo: PropTypes.any,
     height: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number,
@@ -100,7 +101,7 @@ const TableRow = React.createClass({
 
   render() {
     const {
-      prefixCls, columns, record, height, visible, index,
+      prefixCls, columns, columnExtraInfo, record, height, visible, index,
       expandIconColumnIndex, expandIconAsCell, expanded, expandRowByClick,
       expandable, onExpand, needIndentSpaced, indent, indentSize,
     } = this.props;
@@ -145,6 +146,7 @@ const TableRow = React.createClass({
           indent={indent}
           index={index}
           column={columns[i]}
+          columnExtraInfo={columnExtraInfo}
           key={columns[i].key}
           expandIcon={isColumnHaveExpandIcon ? expandIcon : null}
         />


### PR DESCRIPTION
在不使用jsx语法以及将columns放在外面时，render函数是无法访问到一些额外的信息的，比如说Table父组件的state或者一些全局状态。因此增加一个columnExtraInfo，当render时可额外访问到这个信息。