### PR TITLE
If <Table /> is hidden, don't recalculate rowHeight.

### DIFF
--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -583,6 +583,12 @@ export default class Table extends React.Component {
   }
 
   syncFixedTableRowHeight = () => {
+    const tableRect = this.tableNode.getBoundingClientRect();
+    // If tableNode's height less than 0, suppose it is hidden and don't recalculate rowHeight.
+    // see: https://github.com/ant-design/ant-design/issues/4836
+    if (tableRect.height <= 0) {
+      return;
+    }
     const { prefixCls } = this.props;
     const headRows = this.refs.headTable ?
             this.refs.headTable.querySelectorAll('thead') :

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -586,7 +586,7 @@ export default class Table extends React.Component {
     const tableRect = this.tableNode.getBoundingClientRect();
     // If tableNode's height less than 0, suppose it is hidden and don't recalculate rowHeight.
     // see: https://github.com/ant-design/ant-design/issues/4836
-    if (tableRect.height <= 0) {
+    if (tableRect.height !== undefined && tableRect.height <= 0) {
       return;
     }
     const { prefixCls } = this.props;

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -102,6 +102,80 @@ describe('Table', () => {
       const wrapper = render(createTable({ scroll: { y: 200 } }));
       expect(renderToJson(wrapper)).toMatchSnapshot();
     });
+
+    it('fire scroll event', () => {
+      const newColumns = [
+        { title: 'title1', dataIndex: 'a', key: 'a', width: 100, fixed: 'left' },
+        { title: 'title2', dataIndex: 'b', key: 'b' },
+        { title: 'title3', dataIndex: 'c', key: 'c' },
+        { title: 'title4', dataIndex: 'd', key: 'd', width: 100, fixed: 'right' },
+      ];
+      const newData = [
+        { a: '123', b: 'xxxxxxxx', c: 3, d: 'hehe', key: '1' },
+        { a: 'cdd', b: 'edd12221', c: 3, d: 'haha', key: '2' },
+      ];
+      const wrapper = mount(
+        <Table
+          columns={newColumns}
+          data={newData}
+          scroll={{
+            x: 200,
+            y: 200,
+          }}
+        />
+      );
+      const inst = wrapper.instance();
+      const headTable = wrapper.ref('headTable');
+      const bodyTable = wrapper.ref('bodyTable');
+      const fixedColumnsBodyLeft = wrapper.ref('fixedColumnsBodyLeft');
+      const fixedColumnsBodyRight = wrapper.ref('fixedColumnsBodyRight');
+
+      expect(inst.lastScrollLeft).toBe(undefined);
+
+      // fire headTable scroll.
+      headTable.getNode().scrollTop = 0;
+      headTable.getNode().scrollLeft = 20;
+      headTable.simulate('mouseover');
+      headTable.simulate('scroll');
+      expect(bodyTable.getNode().scrollLeft).toBe(20);
+      expect(fixedColumnsBodyLeft.getNode().scrollTop).toBe(0);
+      expect(fixedColumnsBodyRight.getNode().scrollTop).toBe(0);
+
+      expect(inst.lastScrollLeft).toBe(20);
+
+      // fire bodyTable scroll.
+      bodyTable.getNode().scrollTop = 10;
+      bodyTable.getNode().scrollLeft = 40;
+      bodyTable.simulate('mouseover');
+      bodyTable.simulate('scroll');
+      expect(headTable.getNode().scrollLeft).toBe(40);
+      expect(fixedColumnsBodyLeft.getNode().scrollTop).toBe(10);
+      expect(fixedColumnsBodyRight.getNode().scrollTop).toBe(10);
+
+      expect(inst.lastScrollLeft).toBe(40);
+
+      // fire fixedColumnsBodyLeft scroll.
+      fixedColumnsBodyLeft.getNode().scrollTop = 30;
+      fixedColumnsBodyLeft.simulate('mouseover');
+      fixedColumnsBodyLeft.simulate('scroll');
+      expect(headTable.getNode().scrollLeft).toBe(40);
+      expect(bodyTable.getNode().scrollLeft).toBe(40);
+      expect(bodyTable.getNode().scrollTop).toBe(30);
+      expect(fixedColumnsBodyRight.getNode().scrollTop).toBe(30);
+
+      expect(inst.lastScrollLeft).toBe(0);
+
+      // fire fixedColumnsBodyRight scroll.
+      fixedColumnsBodyRight.getNode().scrollTop = 15;
+      fixedColumnsBodyRight.simulate('mouseover');
+      fixedColumnsBodyRight.simulate('scroll');
+      expect(headTable.getNode().scrollLeft).toBe(40);
+      expect(bodyTable.getNode().scrollLeft).toBe(40);
+      expect(bodyTable.getNode().scrollTop).toBe(15);
+      expect(fixedColumnsBodyLeft.getNode().scrollTop).toBe(15);
+
+      expect(inst.lastScrollLeft).toBe(0);
+    });
   });
 
   describe('row click', () => {


### PR DESCRIPTION
fix [ant-design #4836](https://github.com/ant-design/ant-design/issues/4836)

然后在写测试时发现使用`enzyme` 渲染组件，[无法获取元素的宽高](https://github.com/airbnb/enzyme/issues/49#issuecomment-270250193)，所以就没补上测试。