### PR TITLE
scroll className should change as table width is changed

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -17,6 +17,10 @@
 
   .@{tablePrefixCls}-scroll {
     overflow: auto;
+    table {
+      width: auto;
+      min-width: 100%;
+    }
   }
 
   .@{tablePrefixCls}-header {
@@ -92,12 +96,13 @@
 
   th, td {
     padding: @vertical-padding @horizontal-padding;
+    white-space: nowrap;
   }
 }
 
 .@{tablePrefixCls} {
   &-expand-icon-col {
-    width: 10px;
+    width: 34px;
   }
   &-row, &-expanded-row {
     &-expand-icon {

--- a/examples/fixedColumnsWhenResize.js
+++ b/examples/fixedColumnsWhenResize.js
@@ -38,7 +38,7 @@ ReactDOM.render(
       columns={columns}
       expandedRowRender={record => record.title}
       expandIconAsCell
-      scroll={{ x: true }}
+      scroll={{ x: 800 }}
       data={data}
     />
   </div>

--- a/examples/fixedColumnsWhenResize.js
+++ b/examples/fixedColumnsWhenResize.js
@@ -1,0 +1,45 @@
+/* eslint-disable no-console,func-names,react/no-multi-comp */
+const React = require('react');
+const ReactDOM = require('react-dom');
+const Table = require('rc-table');
+require('rc-table/assets/index.less');
+
+const columns = [
+  { title: 'title1', dataIndex: 'a', key: 'a', width: 100, fixed: 'left' },
+  { title: 'title2', dataIndex: 'b', key: 'b', width: 100, fixed: 'left' },
+  { title: 'title3', dataIndex: 'c', key: 'c' },
+  { title: 'title4', dataIndex: 'b', key: 'd' },
+  { title: 'title5', dataIndex: 'b', key: 'e' },
+  { title: 'title6', dataIndex: 'b', key: 'f' },
+  { title: <div>title7<br /><br /><br />Hello world!</div>, dataIndex: 'b', key: 'g' },
+  { title: 'title8', dataIndex: 'b', key: 'h' },
+  { title: 'title9', dataIndex: 'b', key: 'i' },
+  { title: 'title10', dataIndex: 'b', key: 'j' },
+  { title: 'title11', dataIndex: 'b', key: 'k' },
+  { title: 'title12', dataIndex: 'b', key: 'l', width: 100, fixed: 'right' },
+];
+
+const data = [
+  { a: '123', b: 'xxxxxxxx', d: 3, key: '1' },
+  { a: 'cdd', b: 'edd12221', d: 3, key: '2' },
+  { a: '133', c: 'edd12221', d: 2, key: '3' },
+  { a: '133', c: 'edd12221', d: 2, key: '4' },
+  { a: '133', c: 'edd12221', d: 2, key: '5' },
+  { a: '133', c: 'edd12221', d: 2, key: '6' },
+  { a: '133', c: 'edd12221', d: 2, key: '7' },
+  { a: '133', c: 'edd12221', d: 2, key: '8' },
+  { a: '133', c: 'edd12221', d: 2, key: '9' },
+];
+
+ReactDOM.render(
+  <div>
+    <h2>See fixed columns when you resize window</h2>
+    <Table
+      columns={columns}
+      expandedRowRender={record => record.title}
+      expandIconAsCell
+      scroll={{ x: true }}
+      data={data}
+    />
+  </div>
+, document.getElementById('__react-content'));


### PR DESCRIPTION
根据这里的例子 https://github.com/ant-design/ant-design/issues/4965#issuecomment-281287015 优化了样式效果。

1. 当不需要滚动条时，不应该出现阴影。
2. 随着 React 组件变化和窗口大小变化，阴影效果动态响应。
3. 修正了自带样式的一些小问题。