### PR TITLE
Set maxHeight to inner body

### DIFF
--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -428,11 +428,13 @@ export default class Table extends React.Component {
       bodyStyle.overflowX = bodyStyle.overflowX || 'auto';
     }
 
+    const innerBodyStyle = {};
     if (scroll.y) {
       // maxHeight will make fixed-Table scrolling not working
       // so we only set maxHeight to body-Table here
       if (fixed) {
-        bodyStyle.height = bodyStyle.height || scroll.y;
+        innerBodyStyle.maxHeight = bodyStyle.maxHeight || scroll.y;
+        innerBodyStyle.overflowY = bodyStyle.overflowY || 'scroll';
       } else {
         bodyStyle.maxHeight = bodyStyle.maxHeight || scroll.y;
       }
@@ -520,6 +522,7 @@ export default class Table extends React.Component {
         >
           <div
             className={`${prefixCls}-body-inner`}
+            style={innerBodyStyle}
             ref={refName}
             onMouseOver={this.detectScrollTarget}
             onTouchStart={this.detectScrollTarget}


### PR DESCRIPTION
Fix https://github.com/ant-design/ant-design/issues/4893

假设有 `<Table columns={columns} data={data} scroll={{ y: 300 }} />`，当数据量很少的时候，table 的高度实际上达不到 300px，但是在 fixed table 上设置了 `height="300px"`，导致 scroll table 的滚动条被 fixed table 挡住。