### PR TITLE
The "emptyText" prop can either be one React node or a function that returns one React node

### DIFF
--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -33,7 +33,7 @@ export default class Table extends React.Component {
     showHeader: PropTypes.bool,
     title: PropTypes.func,
     footer: PropTypes.func,
-    emptyText: PropTypes.func,
+    emptyText: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
     scroll: PropTypes.object,
     rowRef: PropTypes.func,
     getBodyWrapper: PropTypes.func,
@@ -63,7 +63,7 @@ export default class Table extends React.Component {
     scroll: {},
     rowRef: () => null,
     getBodyWrapper: body => body,
-    emptyText: () => 'No Data',
+    emptyText: 'No Data',
   }
 
   constructor(props) {
@@ -558,7 +558,7 @@ export default class Table extends React.Component {
     const { emptyText, prefixCls, data } = this.props;
     return !data.length ? (
       <div className={`${prefixCls}-placeholder`} key="emptyText">
-        {emptyText()}
+        {(typeof emptyText === 'function') ? emptyText() : emptyText}
       </div>
     ) : null;
   }

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -63,7 +63,7 @@ export default class Table extends React.Component {
     scroll: {},
     rowRef: () => null,
     getBodyWrapper: body => body,
-    emptyText: 'No Data',
+    emptyText: () => 'No Data',
   }
 
   constructor(props) {

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -31,6 +31,13 @@ describe('Table', () => {
     expect(renderToJson(wrapper)).toMatchSnapshot();
   });
 
+  it('renders empty text correctly', () => {
+    const wrapper1 = render(createTable({ data: [], emptyText: 'No data' }));
+    const wrapper2 = render(createTable({ data: [], emptyText: () => 'No data' }));
+    expect(renderToJson(wrapper1)).toMatchSnapshot();
+    expect(renderToJson(wrapper2)).toMatchSnapshot();
+  });
+
   it('renders without header', () => {
     const wrapper = render(createTable({ showHeader: false }));
     expect(renderToJson(wrapper)).toMatchSnapshot();

--- a/tests/__snapshots__/Table.spec.js.snap
+++ b/tests/__snapshots__/Table.spec.js.snap
@@ -273,6 +273,72 @@ exports[`Table renders custom cell correctly 1`] = `
 </div>
 `;
 
+exports[`Table renders empty text correctly 1`] = `
+<div
+  class="rc-table rc-table-scroll-position-left">
+  <div
+    class="rc-table-content">
+    <div
+      class="rc-table-body">
+      <table
+        class="">
+        <colgroup>
+          <col />
+        </colgroup>
+        <thead
+          class="rc-table-thead">
+          <tr>
+            <th
+              class="">
+              Name
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="rc-table-tbody" />
+      </table>
+    </div>
+    <div
+      class="rc-table-placeholder">
+      No data
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Table renders empty text correctly 2`] = `
+<div
+  class="rc-table rc-table-scroll-position-left">
+  <div
+    class="rc-table-content">
+    <div
+      class="rc-table-body">
+      <table
+        class="">
+        <colgroup>
+          <col />
+        </colgroup>
+        <thead
+          class="rc-table-thead">
+          <tr>
+            <th
+              class="">
+              Name
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="rc-table-tbody" />
+      </table>
+    </div>
+    <div
+      class="rc-table-placeholder">
+      No data
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Table renders fixed header correctly 1`] = `
 <div
   class="rc-table rc-table-fixed-header rc-table-scroll-position-left">


### PR DESCRIPTION
We usually pass a string (or React node) instead of function to the "emptyText" prop, it will be great if the "emptyText" prop can accept either node or function type.