### PR TITLE
fix: onRowMouseEnter onRowMouseLeave is not a function

### DIFF
--- a/src/TableRow.jsx
+++ b/src/TableRow.jsx
@@ -40,6 +40,8 @@ export default class TableRow extends React.Component {
   static defaultProps = {
     onRowClick() {},
     onRowDoubleClick() {},
+    onRowMouseEnter() {},
+    onRowMouseLeave() {},
     onDestroy() {},
     expandIconColumnIndex: 0,
     expandRowByClick: false,


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/6775