### PR TITLE
Table scroll 问题。修复。

### DIFF
--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -497,8 +497,6 @@ export default class Table extends React.Component {
           className={`${prefixCls}-header`}
           ref={fixed ? null : 'headTable'}
           style={headStyle}
-          onMouseOver={this.detectScrollTarget}
-          onTouchStart={this.detectScrollTarget}
           onScroll={this.handleBodyScroll}
         >
           {renderTable(true, false)}
@@ -512,8 +510,6 @@ export default class Table extends React.Component {
         className={`${prefixCls}-body`}
         style={bodyStyle}
         ref="bodyTable"
-        onMouseOver={this.detectScrollTarget}
-        onTouchStart={this.detectScrollTarget}
         onScroll={this.handleBodyScroll}
       >
         {renderTable(!useFixedHeader)}
@@ -539,8 +535,6 @@ export default class Table extends React.Component {
             className={`${prefixCls}-body-inner`}
             style={innerBodyStyle}
             ref={refName}
-            onMouseOver={this.detectScrollTarget}
-            onTouchStart={this.detectScrollTarget}
             onScroll={this.handleBodyScroll}
           >
             {renderTable(!useFixedHeader)}
@@ -675,23 +669,15 @@ export default class Table extends React.Component {
     return typeof this.findExpandedRow(record, index) !== 'undefined';
   }
 
-  detectScrollTarget = (e) => {
-    if (this.scrollTarget !== e.currentTarget) {
-      this.scrollTarget = e.currentTarget;
-    }
-  }
-
   hasScrollX() {
     const { scroll = {} } = this.props;
     return 'x' in scroll;
   }
 
   handleBodyScroll = (e) => {
-    // Prevent scrollTop setter trigger onScroll event
-    // http://stackoverflow.com/q/1386696
     const { scroll = {} } = this.props;
     const { headTable, bodyTable, fixedColumnsBodyLeft, fixedColumnsBodyRight } = this.refs;
-    if (scroll.x && e.target.scrollLeft !== this.lastScrollLeft) {
+    if (e.target.scrollLeft !== this.lastScrollLeft && scroll.x) {
       if (e.target === bodyTable && headTable) {
         headTable.scrollLeft = e.target.scrollLeft;
       } else if (e.target === headTable && bodyTable) {
@@ -699,7 +685,7 @@ export default class Table extends React.Component {
       }
       this.setScrollPositionClassName(e.target);
     }
-    if (scroll.y && e.target !== headTable) {
+    if (e.target.scrollTop !== this.lastScrollTop && scroll.y && e.target !== headTable) {
       if (fixedColumnsBodyLeft && e.target !== fixedColumnsBodyLeft) {
         fixedColumnsBodyLeft.scrollTop = e.target.scrollTop;
       }
@@ -710,8 +696,9 @@ export default class Table extends React.Component {
         bodyTable.scrollTop = e.target.scrollTop;
       }
     }
-    // Remember last scrollLeft for scroll direction detecting.
+    // Remember last scrollLeft and scrollTop for scroll direction detecting.
     this.lastScrollLeft = e.target.scrollLeft;
+    this.lastScrollTop = e.target.scrollTop;
   }
 
   handleRowHover = (isHover, key) => {

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -497,7 +497,7 @@ export default class Table extends React.Component {
           className={`${prefixCls}-header`}
           ref={fixed ? null : 'headTable'}
           style={headStyle}
-          onScroll={this.handleBodyScroll}
+          onScroll={this.handleBodyScrollLeft}
         >
           {renderTable(true, false)}
         </div>
@@ -674,31 +674,45 @@ export default class Table extends React.Component {
     return 'x' in scroll;
   }
 
-  handleBodyScroll = (e) => {
+  handleBodyScrollLeft = (e) => {
+    const target = e.target;
+    const { scroll = {} } = this.props;
+    const { headTable, bodyTable } = this.refs;
+    if (target.scrollLeft !== this.lastScrollLeft && scroll.x) {
+      if (target === bodyTable && headTable) {
+        headTable.scrollLeft = target.scrollLeft;
+      } else if (target === headTable && bodyTable) {
+        bodyTable.scrollLeft = target.scrollLeft;
+      }
+      this.setScrollPositionClassName(target);
+    }
+  }
+
+  handleBodyScrollTop = (e) => {
+    const target = e.target;
     const { scroll = {} } = this.props;
     const { headTable, bodyTable, fixedColumnsBodyLeft, fixedColumnsBodyRight } = this.refs;
-    if (e.target.scrollLeft !== this.lastScrollLeft && scroll.x) {
-      if (e.target === bodyTable && headTable) {
-        headTable.scrollLeft = e.target.scrollLeft;
-      } else if (e.target === headTable && bodyTable) {
-        bodyTable.scrollLeft = e.target.scrollLeft;
+    if (target.scrollTop !== this.lastScrollTop && scroll.y && target !== headTable) {
+      const scrollTop = target.scrollTop;
+      if (fixedColumnsBodyLeft && target !== fixedColumnsBodyLeft) {
+        fixedColumnsBodyLeft.scrollTop = scrollTop;
       }
-      this.setScrollPositionClassName(e.target);
-    }
-    if (e.target.scrollTop !== this.lastScrollTop && scroll.y && e.target !== headTable) {
-      if (fixedColumnsBodyLeft && e.target !== fixedColumnsBodyLeft) {
-        fixedColumnsBodyLeft.scrollTop = e.target.scrollTop;
+      if (fixedColumnsBodyRight && target !== fixedColumnsBodyRight) {
+        fixedColumnsBodyRight.scrollTop = scrollTop;
       }
-      if (fixedColumnsBodyRight && e.target !== fixedColumnsBodyRight) {
-        fixedColumnsBodyRight.scrollTop = e.target.scrollTop;
-      }
-      if (bodyTable && e.target !== bodyTable) {
-        bodyTable.scrollTop = e.target.scrollTop;
+      if (bodyTable && target !== bodyTable) {
+        bodyTable.scrollTop = scrollTop;
       }
     }
+  }
+
+  handleBodyScroll = (e) => {
+    const target = e.target;
+    this.handleBodyScrollLeft(e);
+    this.handleBodyScrollTop(e);
     // Remember last scrollLeft and scrollTop for scroll direction detecting.
-    this.lastScrollLeft = e.target.scrollLeft;
-    this.lastScrollTop = e.target.scrollTop;
+    this.lastScrollLeft = target.scrollLeft;
+    this.lastScrollTop = target.scrollTop;
   }
 
   handleRowHover = (isHover, key) => {

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -686,6 +686,8 @@ export default class Table extends React.Component {
       }
       this.setScrollPositionClassName(target);
     }
+    // Remember last scrollLeft for scroll direction detecting.
+    this.lastScrollLeft = target.scrollLeft;
   }
 
   handleBodyScrollTop = (e) => {
@@ -704,15 +706,13 @@ export default class Table extends React.Component {
         bodyTable.scrollTop = scrollTop;
       }
     }
+    // Remember last scrollTop for scroll direction detecting.
+    this.lastScrollTop = target.scrollTop;
   }
 
   handleBodyScroll = (e) => {
-    const target = e.target;
     this.handleBodyScrollLeft(e);
     this.handleBodyScrollTop(e);
-    // Remember last scrollLeft and scrollTop for scroll direction detecting.
-    this.lastScrollLeft = target.scrollLeft;
-    this.lastScrollTop = target.scrollTop;
   }
 
   handleRowHover = (isHover, key) => {

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -689,9 +689,6 @@ export default class Table extends React.Component {
   handleBodyScroll = (e) => {
     // Prevent scrollTop setter trigger onScroll event
     // http://stackoverflow.com/q/1386696
-    if (e.target !== this.scrollTarget) {
-      return;
-    }
     const { scroll = {} } = this.props;
     const { headTable, bodyTable, fixedColumnsBodyLeft, fixedColumnsBodyRight } = this.refs;
     if (scroll.x && e.target.scrollLeft !== this.lastScrollLeft) {
@@ -702,7 +699,7 @@ export default class Table extends React.Component {
       }
       this.setScrollPositionClassName(e.target);
     }
-    if (scroll.y) {
+    if (scroll.y && e.target !== headTable) {
       if (fixedColumnsBodyLeft && e.target !== fixedColumnsBodyLeft) {
         fixedColumnsBodyLeft.scrollTop = e.target.scrollTop;
       }


### PR DESCRIPTION
目前遇到scroll的问题。

见 [https://github.com/ant-design/ant-design/issues/6537](https://github.com/ant-design/ant-design/issues/6537)。

目前测试 横向纵向 scroll 都没问题，mac + win 测过没问题。

旧的 pr 在 [https://github.com/react-component/table/pull/147](https://github.com/react-component/table/pull/147)

if (e.target !== this.scrollTarget) 的判断，加了这个判断的话，假设会避免 scrollTop 的循环触发的问题，那应该能够通过存储 this.lastScrollTop 来避免。所以 scrollTarget 应该不用判断了。