### PR TITLE
Add functionality for custom header render

### DIFF
--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -4,6 +4,7 @@ import TableRow from './TableRow';
 import TableHeader from './TableHeader';
 import { measureScrollbar, debounce, warningOnce } from './utils';
 import shallowequal from 'shallowequal';
+import get from 'lodash.get';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
 import ColumnManager from './ColumnManager';
 import createStore from './createStore';
@@ -231,10 +232,15 @@ export default class Table extends React.Component {
           rows.push([]);
         }
       }
+
+      const children = column.headerRender
+        ? column.headerRender(get(column, ['title', 'props', 'children', 0], column.title))
+        : column.title;
+
       const cell = {
         key: column.key,
         className: column.className || '',
-        children: column.title,
+        children,
       };
       if (column.children) {
         this.getHeaderRows(column.children, currentRow + 1, rows);

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -231,6 +231,21 @@ describe('Table', () => {
     expect(renderToJson(wrapper)).toMatchSnapshot();
   });
 
+  it('renders custom header correctly', () => {
+    const columns = [
+      {
+        title: 'Name',
+        dataIndex: 'name',
+        key: 'name',
+        className: 'name-class',
+        width: 100,
+        headerRender: (text) => <h1>{text}</h1>,
+      },
+    ];
+    const wrapper = render(createTable({ columns }));
+    expect(renderToJson(wrapper)).toMatchSnapshot();
+  });
+
   it('renders custom cell correctly', () => {
     const columns = [
       {

--- a/tests/__snapshots__/Table.spec.js.snap
+++ b/tests/__snapshots__/Table.spec.js.snap
@@ -273,6 +273,59 @@ exports[`Table renders custom cell correctly 1`] = `
 </div>
 `;
 
+exports[`Table renders custom header correctly 1`] = `
+<div
+  class="rc-table rc-table-scroll-position-left">
+  <div
+    class="rc-table-content">
+    <div
+      class="rc-table-body">
+      <table
+        class="">
+        <colgroup>
+          <col
+            style="width:100px;min-width:100px;" />
+        </colgroup>
+        <thead
+          class="rc-table-thead">
+          <tr>
+            <th
+              class="name-class">
+              <h1>
+                Name
+              </h1>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="rc-table-tbody">
+          <tr
+            class="rc-table-row  rc-table-row-level-0">
+            <td
+              class="name-class">
+              <span
+                class="rc-table-row-indent indent-level-0"
+                style="padding-left:0px;" />
+              Lucy
+            </td>
+          </tr>
+          <tr
+            class="rc-table-row  rc-table-row-level-0">
+            <td
+              class="name-class">
+              <span
+                class="rc-table-row-indent indent-level-0"
+                style="padding-left:0px;" />
+              Jack
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Table renders empty text correctly 1`] = `
 <div
   class="rc-table rc-table-scroll-position-left">


### PR DESCRIPTION
My company has begun using ant-design's table in our application, which, of course, relies on the react-component table, and we recently ran into the occasion where we'd like to render a custom header component in place of the default `span` wrapper.

Instances that warrant this usage might include using a tooltip or anchor tag. Hence, this PR.

The following PR includes the following changes:

* Add functionality for custom header render

* Add test