### PR TITLE
Issue 162: rowClassName should accept strings too, not just functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ React.render(<Table columns={columns} data={data} />, mountNode);
     </tr>
     <tr>
       <td>rowClassName</td>
-      <td>Function(record, index, indent):string</td>
+      <td>string or Function(record, index, indent):string</td>
       <td></td>
       <td>get row's className</td>
     </tr>

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -22,7 +22,7 @@ export default class Table extends React.Component {
     bodyStyle: PropTypes.object,
     style: PropTypes.object,
     rowKey: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-    rowClassName: PropTypes.func,
+    rowClassName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     expandedRowClassName: PropTypes.func,
     childrenColumnName: PropTypes.string,
     onExpand: PropTypes.func,
@@ -325,7 +325,9 @@ export default class Table extends React.Component {
       if (expandedRowRender && isRowExpanded) {
         expandedRowContent = expandedRowRender(record, i, indent);
       }
-      const className = rowClassName(record, i, indent);
+      const className = typeof rowClassName === 'string'
+          ? rowClassName
+          : rowClassName(record, i, indent);
 
       const onHoverProps = {};
       if (this.columnManager.isAnyColumnsFixed()) {

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -428,4 +428,18 @@ describe('Table', () => {
     wrapper.find('.rc-table-row').first().simulate('mouseLeave');
     expect(handleRowMouseLeave).toBeCalledWith(data[0], 0, expect.anything());
   });
+
+  it('renders correctly RowClassName as string', () => {
+    const wrapper = render(createTable({
+      rowClassName: 'test-row-class-name-asStr',
+    }));
+    expect(renderToJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('renders correctly RowClassName as function', () => {
+    const wrapper = render(createTable({
+      rowClassName: () => 'test-row-class-name-asFn',
+    }));
+    expect(renderToJson(wrapper)).toMatchSnapshot();
+  });
 });

--- a/tests/__snapshots__/Table.spec.js.snap
+++ b/tests/__snapshots__/Table.spec.js.snap
@@ -219,6 +219,106 @@ exports[`Table renders correctly 1`] = `
 </div>
 `;
 
+exports[`Table renders correctly RowClassName as function 1`] = `
+<div
+  class="rc-table rc-table-scroll-position-left">
+  <div
+    class="rc-table-content">
+    <div
+      class="rc-table-body">
+      <table
+        class="">
+        <colgroup>
+          <col />
+        </colgroup>
+        <thead
+          class="rc-table-thead">
+          <tr>
+            <th
+              class="">
+              Name
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="rc-table-tbody">
+          <tr
+            class="rc-table-row test-row-class-name-asFn rc-table-row-level-0">
+            <td
+              class="">
+              <span
+                class="rc-table-row-indent indent-level-0"
+                style="padding-left:0px;" />
+              Lucy
+            </td>
+          </tr>
+          <tr
+            class="rc-table-row test-row-class-name-asFn rc-table-row-level-0">
+            <td
+              class="">
+              <span
+                class="rc-table-row-indent indent-level-0"
+                style="padding-left:0px;" />
+              Jack
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Table renders correctly RowClassName as string 1`] = `
+<div
+  class="rc-table rc-table-scroll-position-left">
+  <div
+    class="rc-table-content">
+    <div
+      class="rc-table-body">
+      <table
+        class="">
+        <colgroup>
+          <col />
+        </colgroup>
+        <thead
+          class="rc-table-thead">
+          <tr>
+            <th
+              class="">
+              Name
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="rc-table-tbody">
+          <tr
+            class="rc-table-row test-row-class-name-asStr rc-table-row-level-0">
+            <td
+              class="">
+              <span
+                class="rc-table-row-indent indent-level-0"
+                style="padding-left:0px;" />
+              Lucy
+            </td>
+          </tr>
+          <tr
+            class="rc-table-row test-row-class-name-asStr rc-table-row-level-0">
+            <td
+              class="">
+              <span
+                class="rc-table-row-indent indent-level-0"
+                style="padding-left:0px;" />
+              Jack
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Table renders custom cell correctly 1`] = `
 <div
   class="rc-table rc-table-scroll-position-left">


### PR DESCRIPTION
**Summary**

This is a fix for this issue https://github.com/react-component/table/issues/162

New feature to let Table deal with strings values in 'rowClassName' property so make code become easier in some implementations.