### PR TITLE
Add id property to container div

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ React.render(<Table columns={columns} data={data} />, mountNode);
       <td>additional className</td>
     </tr>
     <tr>
+      <td>id</td>
+      <td>String</td>
+      <td></td>
+      <td>identifier of the container div</td>
+    </tr>
+    <tr>
       <td>useFixedHeader</td>
       <td>Boolean</td>
       <td>false</td>

--- a/src/Table.js
+++ b/src/Table.js
@@ -30,6 +30,7 @@ export default class Table extends React.Component {
     onRowMouseLeave: PropTypes.func,
     showHeader: PropTypes.bool,
     title: PropTypes.func,
+    id: PropTypes.string,
     footer: PropTypes.func,
     emptyText: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
     scroll: PropTypes.object,
@@ -454,6 +455,7 @@ export default class Table extends React.Component {
                 ref={this.saveRef('tableNode')}
                 className={className}
                 style={props.style}
+                id={props.id}
               >
                 {this.renderTitle()}
                 <div className={`${prefixCls}-content`}>

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -72,6 +72,12 @@ describe('Table', () => {
     spy.mockRestore();
   });
 
+  it('renders with id correctly', () => {
+    const testId = 'test-identifier';
+    const wrapper = mount(createTable({ id: testId }));
+    expect(wrapper.find(`div#${testId}`)).toHaveLength(1);
+  });
+
   xit('sets row refs', () => {
     const wrapper = mount(createTable({ rowRef: (record) => record.key }));
     expect(wrapper.instance().refs.key0).toBe(wrapper.find('TableRow').at(0).instance());


### PR DESCRIPTION
This PR adds an id property to the root table div, simplifying automated browser testing with multiple table instances on one page.

**current behavior**
_table:_ document.querySelectorAll(div.rc-table>table)**[nth]**
_title  :_ document.querySelectorAll(div.rc-table>.rc-table-title)**[nth]**

**afterwards**
_table :_ document.querySelector(#id>table)
_title :_ document.querySelector(#id>.rc-table-title)