### PR TITLE
If no columns there is nothing to perform the unshift against.

### DIFF
--- a/src/ExpandableTable.js
+++ b/src/ExpandableTable.js
@@ -108,7 +108,7 @@ class ExpandableTable extends React.Component {
 
   renderExpandIndentCell = (rows, fixed) => {
     const { prefixCls, expandIconAsCell } = this.props;
-    if (!expandIconAsCell || fixed === 'right') {
+    if (!expandIconAsCell || fixed === 'right' || !rows.length) {
       return;
     }
 


### PR DESCRIPTION
Ideally no columns should probably exit the entire table creation process and instead just render out the box saying no headers or something along that line. However given how unlikely / infrequent this specific case is I think this is an okay solution to allow expandable tables to have the columns updated later by dynamic content and prevent an error.

In reference to Antd issue 8941:
https://github.com/ant-design/ant-design/issues/8941