### PR TITLE
feat: Expanded row with multiple columns

### DIFF
--- a/src/ExpandableRow.js
+++ b/src/ExpandableRow.js
@@ -16,7 +16,7 @@ class ExpandableRow extends React.Component {
     expandIconAsCell: PropTypes.bool,
     expandIconColumnIndex: PropTypes.number,
     childrenColumnName: PropTypes.string,
-    expandedRowRender: PropTypes.func,
+    expandedRowRender: PropTypes.oneOfType([PropTypes.func, PropTypes.arrayOf(PropTypes.func)]),
     onExpandedChange: PropTypes.func.isRequired,
     onRowClick: PropTypes.func,
     children: PropTypes.func.isRequired,

--- a/src/ExpandableTable.js
+++ b/src/ExpandableTable.js
@@ -8,12 +8,13 @@ import { remove } from './utils';
 class ExpandableTable extends React.Component {
   static propTypes = {
     expandIconAsCell: PropTypes.bool,
+    nonSpanningExpandedRow: PropTypes.bool,
     expandedRowKeys: PropTypes.array,
     expandedRowClassName: PropTypes.func,
     defaultExpandAllRows: PropTypes.bool,
     defaultExpandedRowKeys: PropTypes.array,
     expandIconColumnIndex: PropTypes.number,
-    expandedRowRender: PropTypes.func,
+    expandedRowRender: PropTypes.oneOfType([PropTypes.func, PropTypes.arrayOf(PropTypes.func)]),
     childrenColumnName: PropTypes.string,
     indentSize: PropTypes.number,
     onExpand: PropTypes.func,
@@ -28,6 +29,7 @@ class ExpandableTable extends React.Component {
 
   static defaultProps = {
     expandIconAsCell: false,
+    nonSpanningExpandedRow: false,
     expandedRowClassName: () => '',
     expandIconColumnIndex: 0,
     defaultExpandAllRows: false,
@@ -127,26 +129,34 @@ class ExpandableTable extends React.Component {
   };
 
   renderExpandedRow(record, index, render, className, ancestorKeys, indent, fixed) {
-    const { prefixCls, expandIconAsCell, indentSize } = this.props;
+    const { prefixCls, expandIconAsCell, nonSpanningExpandedRow, indentSize } = this.props;
     let colCount;
-    if (fixed === 'left') {
-      colCount = this.columnManager.leftLeafColumns().length;
-    } else if (fixed === 'right') {
-      colCount = this.columnManager.rightLeafColumns().length;
+    let columns;
+    if (nonSpanningExpandedRow && Array.isArray(render)) {
+      columns = render.map((columnRenderer, columnIndex) => ({
+        key: `extra-row-column-${columnIndex}`,
+        render: columnRenderer,
+      }));
     } else {
-      colCount = this.columnManager.leafColumns().length;
+      if (fixed === 'left') {
+        colCount = this.columnManager.leftLeafColumns().length;
+      } else if (fixed === 'right') {
+        colCount = this.columnManager.rightLeafColumns().length;
+      } else {
+        colCount = this.columnManager.leafColumns().length;
+      }
+      columns = [
+        {
+          key: 'extra-row',
+          render: () => ({
+            props: {
+              colSpan: colCount,
+            },
+            children: fixed !== 'right' ? render(record, index, indent) : '&nbsp;',
+          }),
+        },
+      ];
     }
-    const columns = [
-      {
-        key: 'extra-row',
-        render: () => ({
-          props: {
-            colSpan: colCount,
-          },
-          children: fixed !== 'right' ? render(record, index, indent) : '&nbsp;',
-        }),
-      },
-    ];
     if (expandIconAsCell && fixed !== 'right') {
       columns.unshift({
         key: 'expand-icon-placeholder',

--- a/src/ExpandableTable.js
+++ b/src/ExpandableTable.js
@@ -135,7 +135,7 @@ class ExpandableTable extends React.Component {
     if (nonSpanningExpandedRow && Array.isArray(render)) {
       columns = render.map((columnRenderer, columnIndex) => ({
         key: `extra-row-column-${columnIndex}`,
-        render: columnRenderer,
+        render: () => columnRenderer(record, index, indent),
       }));
     } else {
       if (fixed === 'left') {

--- a/tests/Table.expandRow.spec.js
+++ b/tests/Table.expandRow.spec.js
@@ -60,8 +60,8 @@ describe('Table.expand', () => {
 
   it('should render a non spanning row correctly', () => {
     const nonSpanningExpandedRowRender = [
-      () => <div>first non spanning row</div>,
-      () => <div>second non spanning row</div>,
+      data => <div>{`This is ${data.name}`}</div>,
+      data => <div>{`${data.name} is ${data.age} years old`}</div>,
     ];
     const wrapper = render(
       createTable({

--- a/tests/Table.expandRow.spec.js
+++ b/tests/Table.expandRow.spec.js
@@ -58,6 +58,33 @@ describe('Table.expand', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should render a non spanning row correctly', () => {
+    const nonSpanningExpandedRowRender = [
+      () => <div>first non spanning row</div>,
+      () => <div>second non spanning row</div>,
+    ];
+    const wrapper = render(
+      createTable({
+        expandedRowRender: nonSpanningExpandedRowRender,
+        nonSpanningExpandedRow: true,
+        expandedRowKeys: [0],
+      }),
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render a spanning column if only passed one render function', () => {
+    const nonSpanningExpandedRowRender = () => <div>first non spanning row</div>;
+    const wrapper = render(
+      createTable({
+        expandedRowRender: nonSpanningExpandedRowRender,
+        nonSpanningExpandedRow: true,
+        expandedRowKeys: [0],
+      }),
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('renders expand icon to the specify column', () => {
     const wrapper = render(
       createTable({

--- a/tests/__snapshots__/Table.expandRow.spec.js.snap
+++ b/tests/__snapshots__/Table.expandRow.spec.js.snap
@@ -1264,3 +1264,203 @@ exports[`Table.expand renders tree row correctly 1`] = `
   </div>
 </div>
 `;
+
+exports[`Table.expand should render a non spanning row correctly 1`] = `
+<div
+  class="rc-table rc-table-scroll-position-left"
+>
+  <div
+    class="rc-table-content"
+  >
+    <div
+      class="rc-table-body"
+    >
+      <table
+        class=""
+      >
+        <colgroup>
+          <col />
+          <col />
+        </colgroup>
+        <thead
+          class="rc-table-thead"
+        >
+          <tr>
+            <th
+              class=""
+            >
+              Name
+            </th>
+            <th
+              class=""
+            >
+              Age
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="rc-table-tbody"
+        >
+          <tr
+            class="rc-table-row  rc-table-row-level-0"
+          >
+            <td
+              class=""
+            >
+              <span
+                class="rc-table-row-indent indent-level-0"
+                style="padding-left:0px"
+              />
+              <span
+                class="rc-table-row-expand-icon rc-table-row-expanded"
+              />
+              Lucy
+            </td>
+            <td
+              class=""
+            >
+              27
+            </td>
+          </tr>
+          <tr
+            class="rc-table-expanded-row  rc-table-expanded-row-level-1"
+          >
+            <td
+              class=""
+            >
+              <div>
+                first non spanning row
+              </div>
+            </td>
+            <td
+              class=""
+            >
+              <div>
+                second non spanning row
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="rc-table-row  rc-table-row-level-0"
+          >
+            <td
+              class=""
+            >
+              <span
+                class="rc-table-row-indent indent-level-0"
+                style="padding-left:0px"
+              />
+              <span
+                class="rc-table-row-expand-icon rc-table-row-collapsed"
+              />
+              Jack
+            </td>
+            <td
+              class=""
+            >
+              28
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Table.expand should render a spanning column if only passed one render function 1`] = `
+<div
+  class="rc-table rc-table-scroll-position-left"
+>
+  <div
+    class="rc-table-content"
+  >
+    <div
+      class="rc-table-body"
+    >
+      <table
+        class=""
+      >
+        <colgroup>
+          <col />
+          <col />
+        </colgroup>
+        <thead
+          class="rc-table-thead"
+        >
+          <tr>
+            <th
+              class=""
+            >
+              Name
+            </th>
+            <th
+              class=""
+            >
+              Age
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="rc-table-tbody"
+        >
+          <tr
+            class="rc-table-row  rc-table-row-level-0"
+          >
+            <td
+              class=""
+            >
+              <span
+                class="rc-table-row-indent indent-level-0"
+                style="padding-left:0px"
+              />
+              <span
+                class="rc-table-row-expand-icon rc-table-row-expanded"
+              />
+              Lucy
+            </td>
+            <td
+              class=""
+            >
+              27
+            </td>
+          </tr>
+          <tr
+            class="rc-table-expanded-row  rc-table-expanded-row-level-1"
+          >
+            <td
+              class=""
+              colspan="2"
+            >
+              <div>
+                first non spanning row
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="rc-table-row  rc-table-row-level-0"
+          >
+            <td
+              class=""
+            >
+              <span
+                class="rc-table-row-indent indent-level-0"
+                style="padding-left:0px"
+              />
+              <span
+                class="rc-table-row-expand-icon rc-table-row-collapsed"
+              />
+              Jack
+            </td>
+            <td
+              class=""
+            >
+              28
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;

--- a/tests/__snapshots__/Table.expandRow.spec.js.snap
+++ b/tests/__snapshots__/Table.expandRow.spec.js.snap
@@ -1329,14 +1329,14 @@ exports[`Table.expand should render a non spanning row correctly 1`] = `
               class=""
             >
               <div>
-                first non spanning row
+                This is Lucy
               </div>
             </td>
             <td
               class=""
             >
               <div>
-                second non spanning row
+                Lucy is 27 years old
               </div>
             </td>
           </tr>


### PR DESCRIPTION
Use case: In the current functionality, an expanded row will span across all the columns of the table. Instead, I wanted the extra row to have the same amount of columns as the previous rows and for each cell to have its own custom renderer. 

To achieve this, I have enhanced the `expandedRowRender` to also accept an array of render functions. Assuming there may be future use cases to have more or less columns in the expanded row, I have allowed the row to accept any amount of row renderers to generate as many columns as needed.