### PR TITLE
bug fix: treeData table state.fixedColumnsBodyRowsHeight include empty items

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -249,17 +249,17 @@ class Table extends React.Component {
       row => row.getBoundingClientRect().height || 'auto',
     );
     const state = this.store.getState();
-    if (
-      shallowequal(state.fixedColumnsHeadRowsHeight, fixedColumnsHeadRowsHeight) &&
-      shallowequal(state.fixedColumnsBodyRowsHeight, fixedColumnsBodyRowsHeight)
+    if (!shallowequal(state.fixedColumnsHeadRowsHeight, fixedColumnsHeadRowsHeight)) {
+      this.store.setState({
+        fixedColumnsHeadRowsHeight,
+      });
+    } else if (
+      !shallowequal(state.fixedColumnsBodyRowsHeight.filter(n => n), fixedColumnsBodyRowsHeight)
     ) {
-      return;
+      this.store.setState({
+        fixedColumnsBodyRowsHeight,
+      });
     }
-
-    this.store.setState({
-      fixedColumnsHeadRowsHeight,
-      fixedColumnsBodyRowsHeight,
-    });
   };
 
   resetScrollX() {


### PR DESCRIPTION
treeData table state.fixedColumnsBodyRowsHeight is [1,empty, 1], but row.getBoundingClientRect() got state.fixedColumnsBodyRowsHeight is [1,1], so table row height will render badly