### PR TITLE
bug fix: treeData table state.fixedColumnsBodyRowsHeight include empty items

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -249,16 +249,21 @@ class Table extends React.Component {
       row => row.getBoundingClientRect().height || 'auto',
     );
     const state = this.store.getState();
+    const fixedColumnsBodyRowsHeightEqual = shallowequal(
+      state.fixedColumnsBodyRowsHeight.filter(n => n),
+      fixedColumnsBodyRowsHeight,
+    );
     if (
       shallowequal(state.fixedColumnsHeadRowsHeight, fixedColumnsHeadRowsHeight) &&
-      shallowequal(state.fixedColumnsBodyRowsHeight, fixedColumnsBodyRowsHeight)
+      fixedColumnsBodyRowsHeightEqual
     ) {
       return;
     }
-
     this.store.setState({
       fixedColumnsHeadRowsHeight,
-      fixedColumnsBodyRowsHeight,
+      fixedColumnsBodyRowsHeight: fixedColumnsBodyRowsHeightEqual
+        ? state.fixedColumnsBodyRowsHeight
+        : fixedColumnsBodyRowsHeight,
     });
   };
 


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/11337
这里其实还是有点问题，当子级的树没有展开的时候还是会有错位的情况发生，看了下原因是state.fixedColumnsBodyRowsHeight里没有展开的高度的值为empty，而通过row.getBoundingClientRect().height得到数组其实没不是整个树的...