### PR TITLE
TableCell数据为空时支持默认占位符

### DIFF
--- a/examples/cell-empty-text.js
+++ b/examples/cell-empty-text.js
@@ -1,0 +1,36 @@
+/* eslint-disable no-console,func-names,react/no-multi-comp */
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Table from 'rc-table';
+import 'rc-table/assets/index.less';
+
+const columns = [
+  { title: 'title1', dataIndex: 'a', key: 'a' },
+  { id: '123', title: 'title2', dataIndex: 'b', key: 'b' },
+  { title: 'title3', dataIndex: 'c', key: 'c' },
+  {
+    title: 'Operations',
+    dataIndex: '',
+    key: 'd',
+    render() {
+      return <a href="#">Operations</a>;
+    },
+  },
+];
+
+const data = [
+  { a: '123', key: '1' },
+  { a: 'cdd', b: 'edd', key: '2' },
+  { a: '1333', c: 'eee', d: 2, key: '3' },
+];
+
+ReactDOM.render(
+  <div>
+    <Table
+      columns={columns}
+      data={data}
+      cellEmptyText={<span style={{ color: '#f00' }}>暂无数据</span>}
+    />
+  </div>,
+  document.getElementById('__react-content'),
+);

--- a/examples/cell-empty-text.js
+++ b/examples/cell-empty-text.js
@@ -5,7 +5,7 @@ import Table from 'rc-table';
 import 'rc-table/assets/index.less';
 
 const columns = [
-  { title: 'title1', dataIndex: 'a', key: 'a' },
+  { title: 'title1', dataIndex: null, key: 'a' },
   { id: '123', title: 'title2', dataIndex: 'b', key: 'b' },
   { title: 'title3', dataIndex: 'c', key: 'c' },
   {

--- a/src/Table.js
+++ b/src/Table.js
@@ -74,7 +74,7 @@ class Table extends React.Component {
     scroll: {},
     rowRef: () => null,
     emptyText: () => 'No Data',
-    cellEmptyText: '-',
+    cellEmptyText: '',
   };
 
   constructor(props) {

--- a/src/Table.js
+++ b/src/Table.js
@@ -34,6 +34,7 @@ class Table extends React.Component {
     id: PropTypes.string,
     footer: PropTypes.func,
     emptyText: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
+    cellEmptyText: PropTypes.node,
     scroll: PropTypes.object,
     rowRef: PropTypes.func,
     getBodyWrapper: PropTypes.func,
@@ -73,11 +74,11 @@ class Table extends React.Component {
     scroll: {},
     rowRef: () => null,
     emptyText: () => 'No Data',
+    cellEmptyText: '-',
   };
 
   constructor(props) {
     super(props);
-
     [
       'onRowClick',
       'onRowDoubleClick',
@@ -96,6 +97,7 @@ class Table extends React.Component {
     this.columnManager = new ColumnManager(props.columns, props.children);
 
     this.store = create({
+      cellEmptyText: props.cellEmptyText,
       currentHoverKey: null,
       fixedColumnsHeadRowsHeight: [],
       fixedColumnsBodyRowsHeight: {},

--- a/src/TableCell.js
+++ b/src/TableCell.js
@@ -6,7 +6,8 @@ function isInvalidRenderCellText(text) {
   return (
     text &&
     !React.isValidElement(text) &&
-    Object.prototype.toString.call(text) === '[object Object]'
+    (Object.prototype.toString.call(text) === '[object Object]' ||
+      (Object.prototype.toString.call(text) === '[object Array]' && !text.length))
   );
 }
 
@@ -20,6 +21,7 @@ export default class TableCell extends React.Component {
     column: PropTypes.object,
     expandIcon: PropTypes.node,
     component: PropTypes.any,
+    cellEmptyText: PropTypes.node,
   };
 
   handleClick = e => {
@@ -42,6 +44,7 @@ export default class TableCell extends React.Component {
       expandIcon,
       column,
       component: BodyCell,
+      cellEmptyText,
     } = this.props;
     const { dataIndex, render, className = '' } = column;
 
@@ -59,6 +62,11 @@ export default class TableCell extends React.Component {
     let colSpan;
     let rowSpan;
 
+    // Fix https://github.com/ant-design/ant-design/issues/1202
+    if (isInvalidRenderCellText(text)) {
+      text = null;
+    }
+
     if (render) {
       text = render(text, record, index);
       if (isInvalidRenderCellText(text)) {
@@ -67,15 +75,12 @@ export default class TableCell extends React.Component {
         rowSpan = tdProps.rowSpan;
         text = text.children;
       }
+    } else if (text === '' || text === undefined || text === null) {
+      text = cellEmptyText;
     }
 
     if (column.onCell) {
       tdProps = { ...tdProps, ...column.onCell(record, index) };
-    }
-
-    // Fix https://github.com/ant-design/ant-design/issues/1202
-    if (isInvalidRenderCellText(text)) {
-      text = null;
     }
 
     const indentText = expandIcon ? (

--- a/src/TableHeaderRow.js
+++ b/src/TableHeaderRow.js
@@ -35,6 +35,7 @@ TableHeaderRow.propTypes = {
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   components: PropTypes.any,
   onHeaderRow: PropTypes.func,
+  prefixCls: PropTypes.string,
 };
 
 function getRowHeight(state, props) {

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -36,6 +36,7 @@ class TableRow extends React.Component {
     expandedRow: PropTypes.bool,
     isAnyColumnsFixed: PropTypes.bool,
     ancestorKeys: PropTypes.array.isRequired,
+    cellEmptyText: PropTypes.node,
   };
 
   static defaultProps = {
@@ -195,6 +196,7 @@ class TableRow extends React.Component {
       hasExpandIcon,
       renderExpandIcon,
       renderExpandIconCell,
+      cellEmptyText,
     } = this.props;
 
     const BodyRow = components.body.row;
@@ -229,6 +231,7 @@ class TableRow extends React.Component {
           key={column.key || column.dataIndex}
           expandIcon={hasExpandIcon(i) && renderExpandIcon()}
           component={BodyCell}
+          cellEmptyText={cellEmptyText}
         />,
       );
     }
@@ -290,12 +293,12 @@ function getRowHeight(state, props) {
 polyfill(TableRow);
 
 export default connect((state, props) => {
-  const { currentHoverKey, expandedRowKeys } = state;
+  const { currentHoverKey, expandedRowKeys, cellEmptyText } = state;
   const { rowKey, ancestorKeys } = props;
   const visible = ancestorKeys.length === 0 || ancestorKeys.every(k => ~expandedRowKeys.indexOf(k));
-
   return {
     visible,
+    cellEmptyText,
     hovered: currentHoverKey === rowKey,
     height: getRowHeight(state, props),
   };

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -296,7 +296,7 @@ describe('Table', () => {
           },
         ];
         mount(createTable({ columns }));
-        expect(cellRender).toBeCalledWith(data[0], data[0], 0);
+        expect(cellRender).toBeCalledWith(null, data[1], 1);
       });
     });
 


### PR DESCRIPTION
目前处理表格字段为空的方式是通过column.render，如果项目里面需要默认展示空字段的占位符就需要各自处理，感觉但是这样不太方便。

用法如下：

```javascript
    <Table
      columns={columns}
      data={data}
      cellEmptyText={<span style={{ color: '#f00' }}>暂无数据</span>}
    />
```