### PR TITLE
Fix invalid click when expandRowByClick prop is enabled

### DIFF
--- a/src/ExpandableTable.js
+++ b/src/ExpandableTable.js
@@ -94,7 +94,6 @@ class ExpandableTable extends React.Component {
 
   handleExpandChange = (expanded, record, event, rowKey, destroy = false) => {
     if (event) {
-      event.preventDefault();
       event.stopPropagation();
     }
 


### PR DESCRIPTION
Fix => https://github.com/ant-design/ant-design/issues/16175

Note: The root cause of not being able to click links on the table cell is because the default behavior is being disabled.