### PR TITLE
fix: Browser not scroll-able by key

### DIFF
--- a/src/BodyTable.js
+++ b/src/BodyTable.js
@@ -84,9 +84,12 @@ export default function BodyTable(props, { table }) {
     );
   }
 
+  // Should provides `tabIndex` if use scroll to enable keyboard scroll
+  const useTabIndex = scroll && (scroll.x || scroll.y);
+
   return (
     <div
-      tabIndex={scroll ? -1 : undefined}
+      tabIndex={useTabIndex ? -1 : undefined}
       key="bodyTable"
       className={`${prefixCls}-body`}
       style={bodyStyle}

--- a/src/BodyTable.js
+++ b/src/BodyTable.js
@@ -86,6 +86,7 @@ export default function BodyTable(props, { table }) {
 
   return (
     <div
+      tabIndex={scroll ? -1 : undefined}
       key="bodyTable"
       className={`${prefixCls}-body`}
       style={bodyStyle}

--- a/tests/__snapshots__/Table.fixedColumns.spec.js.snap
+++ b/tests/__snapshots__/Table.fixedColumns.spec.js.snap
@@ -13,6 +13,7 @@ exports[`Table.fixedColumns renders correctly 1`] = `
       <div
         class="rc-table-body"
         style="overflow-x:scroll;-webkit-transform:translate3d (0, 0, 0)"
+        tabindex="-1"
       >
         <table
           class="rc-table-fixed"

--- a/tests/__snapshots__/Table.spec.js.snap
+++ b/tests/__snapshots__/Table.spec.js.snap
@@ -288,6 +288,7 @@ exports[`Table custom components renders fixed column and header correctly 1`] =
       <div
         class="rc-table-body"
         style="max-height:100px;overflow-y:scroll"
+        tabindex="-1"
       >
         <table
           class=""
@@ -1683,6 +1684,7 @@ exports[`Table scroll renders scroll.x is a number 1`] = `
       <div
         class="rc-table-body"
         style="overflow-x:scroll;-webkit-transform:translate3d (0, 0, 0)"
+        tabindex="-1"
       >
         <table
           class="rc-table-fixed"
@@ -1754,6 +1756,7 @@ exports[`Table scroll renders scroll.x is true 1`] = `
       <div
         class="rc-table-body"
         style="overflow-x:scroll;-webkit-transform:translate3d (0, 0, 0)"
+        tabindex="-1"
       >
         <table
           class="rc-table-fixed"
@@ -1847,6 +1850,7 @@ exports[`Table scroll renders scroll.y is a number 1`] = `
       <div
         class="rc-table-body"
         style="max-height:200px;overflow-y:scroll"
+        tabindex="-1"
       >
         <table
           class=""


### PR DESCRIPTION
add `tabIndex` to support scroll by key.

fix: https://github.com/ant-design/ant-design/issues/17643