### PR TITLE
feat: Not hide icon if `expandIcon` provided

### DIFF
--- a/src/ExpandableRow.js
+++ b/src/ExpandableRow.js
@@ -27,11 +27,15 @@ class ExpandableRow extends React.Component {
     this.handleDestroy();
   }
 
+  // Show icon within first column
   hasExpandIcon = columnIndex => {
-    const { expandRowByClick } = this.props;
-    return (
-      !this.expandIconAsCell && !expandRowByClick && columnIndex === this.expandIconColumnIndex
-    );
+    const { expandRowByClick, expandIcon } = this.props;
+
+    if (this.expandIconAsCell || columnIndex !== this.expandIconColumnIndex) {
+      return false;
+    }
+
+    return !!expandIcon || !expandRowByClick;
   };
 
   handleExpandChange = (record, event) => {

--- a/tests/Table.expandRow.spec.js
+++ b/tests/Table.expandRow.spec.js
@@ -236,4 +236,17 @@ describe('Table.expand', () => {
     expect(onExpandedRowsChange).toBeCalledWith([]);
     expect(onExpandedRowsChange.mock.calls.length).toEqual(1);
   });
+
+  it('show icon if use `expandIcon` & `expandRowByClick`', () => {
+    const wrapper = mount(
+      createTable({
+        expandedRowRender,
+        expandRowByClick: true,
+        expandIcon: () => <span className="should-display" />,
+        data: [{ key: 0, name: 'Lucy', age: 27, children: [{ key: 1, name: 'Jack', age: 28 }] }],
+      }),
+    );
+
+    expect(wrapper.find('.should-display').length).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Related issue: https://github.com/ant-design/ant-design/issues/17720

antd should also update to use `expandIcon` instead of css icon.