### PR TITLE
delete table double scroll bar

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -326,11 +326,16 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
   let scrollXStyle: React.CSSProperties;
   let scrollYStyle: React.CSSProperties;
   let scrollTableStyle: React.CSSProperties;
+  let fixHeaderStyle: React.CSSProperties;
 
   if (fixHeader) {
     scrollYStyle = {
-      overflowY: 'scroll',
       maxHeight: scroll.y,
+    };
+    fixHeaderStyle = {
+      position: 'sticky',
+      top: 0,
+      zIndex: 99,
     };
   }
   if (fixColumn) {
@@ -500,7 +505,6 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       bodyContent = (
         <div
           style={{
-            ...scrollXStyle,
             ...scrollYStyle,
           }}
           onScroll={onScroll}
@@ -527,7 +531,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
         {showHeader !== false && (
           <div
             style={{
-              ...scrollXStyle,
+              ...fixHeaderStyle,
               marginBottom: fixColumn ? -scrollbarSize : null,
             }}
             onScroll={onScroll}
@@ -589,7 +593,14 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       {...ariaProps}
     >
       {title && <Panel className={`${prefixCls}-title`}>{title(mergedData)}</Panel>}
-      <div className={`${prefixCls}-container`}>{groupTableNode}</div>
+      <div
+        className={`${prefixCls}-container`}
+        style={{
+          ...scrollXStyle,
+        }}
+      >
+        {groupTableNode}
+      </div>
       {footer && <Panel className={`${prefixCls}-footer`}>{footer(mergedData)}</Panel>}
     </div>
   );


### PR DESCRIPTION
fix: Fixed columns and header table double scroll bar
![image](https://user-images.githubusercontent.com/11746742/69604422-5bb55b80-1058-11ea-9ebd-58e2222c7fcc.png)

![image](https://user-images.githubusercontent.com/11746742/69604336-0da05800-1058-11ea-9d71-74a6254e3afc.png)

引入了新bug：右上角的线有空白的情况