### PR TITLE
fix(tableRow): 修复tableRow某些情况下rowRef为null时, saveRef会引发页面crash

### DIFF
--- a/src/TableRow.tsx
+++ b/src/TableRow.tsx
@@ -178,7 +178,7 @@ class TableRow<ValueType> extends React.Component<TableRowProps<ValueType>, Tabl
 
     const { isAnyColumnsFixed, fixed, expandedRow, ancestorKeys } = this.props;
 
-    if (!isAnyColumnsFixed) {
+    if (!isAnyColumnsFixed || !this.rowRef) {
       return;
     }
 

--- a/tests/Table.fixedColumns.spec.js
+++ b/tests/Table.fixedColumns.spec.js
@@ -163,20 +163,20 @@ describe('Table.fixedColumns', () => {
     simulateTableShow();
     wrapper.setProps({});
     fixedLeftRows.forEach((tr, i) => {
-      expect(tr.style.height).toBe(i === 0 ? '29.5px' : rowHeight);
+      expect(tr.style.height).toBe(rowHeight);
     });
     fixedRightRows.forEach((tr, i) => {
-      expect(tr.style.height).toBe(i === 0 ? '29.5px' : rowHeight);
+      expect(tr.style.height).toBe(rowHeight);
     });
 
     // <Table /> is hidden.
     simulateTableHidden();
     wrapper.update();
     fixedLeftRows.forEach((tr, i) => {
-      expect(tr.style.height).toBe(i === 0 ? '29.5px' : rowHeight);
+      expect(tr.style.height).toBe(rowHeight);
     });
     fixedRightRows.forEach((tr, i) => {
-      expect(tr.style.height).toBe(i === 0 ? '29.5px' : rowHeight);
+      expect(tr.style.height).toBe(rowHeight);
     });
   });
 


### PR DESCRIPTION
using react-dnd to make BodyRow, set some column to fixed. In some case, this will make tableRow render function to return a null object, then saveRef function will call getBoundingRect on a null object which cause crash.