### PR TITLE
fix: defaultExpandAllRows should work with childrenColumnName

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ env:
   matrix:
     - TEST_TYPE=lint
     - TEST_TYPE=test
+    - TEST_TYPE=compile

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -272,7 +272,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       return defaultExpandedRowKeys;
     }
     if (defaultExpandAllRows) {
-      return findAllChildrenKeys<RecordType>(mergedData, getRowKey);
+      return findAllChildrenKeys<RecordType>(mergedData, getRowKey, mergedChildrenColumnName);
     }
     return [];
   });

--- a/src/utils/expandUtil.tsx
+++ b/src/utils/expandUtil.tsx
@@ -34,6 +34,7 @@ export function renderExpandIcon<RecordType>({
 export function findAllChildrenKeys<RecordType>(
   data: RecordType[],
   getRowKey: GetRowKey<RecordType>,
+  childrenColumnName: string,
 ): Key[] {
   const keys: Key[] = [];
 
@@ -41,7 +42,7 @@ export function findAllChildrenKeys<RecordType>(
     (list || []).forEach((item, index) => {
       keys.push(getRowKey(item, index));
 
-      dig(((item as unknown) as { children: RecordType[] }).children);
+      dig((item as any)[childrenColumnName]);
     });
   }
 

--- a/tests/ExpandRow.spec.js
+++ b/tests/ExpandRow.spec.js
@@ -354,4 +354,18 @@ describe('Table.Expand', () => {
         .hasClass('rc-table-row-collapsed'),
     ).toBeTruthy();
   });
+
+  // https://github.com/ant-design/ant-design/issues/21788
+  it('`defaultExpandAllRows` with `childrenColumnName`', () => {
+    const data = [
+      {
+        key: 0,
+        sub: [{ key: 1, sub: [{ key: 2 }] }],
+      },
+    ];
+    const wrapper = mount(
+      createTable({ data, childrenColumnName: 'sub', expandable: { defaultExpandAllRows: true } }),
+    );
+    expect(wrapper.find('tbody tr')).toHaveLength(3);
+  });
 });


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/21788