### PR TITLE
fix: when the children of the table column is falsely still recognized as a column group

### DIFF
--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -35,12 +35,12 @@ function parseHeaderRows<RecordType>(
 
       let colSpan: number = 1;
 
-      const columnAlias = column as ColumnGroupType<RecordType>;
-      if (columnAlias.children) {
-        colSpan = fillRowCells(columnAlias.children, currentColIndex, rowIndex + 1).reduce(
-          (total, count) => total + count,
-          0,
-        );
+      if ((column as ColumnGroupType<RecordType>).children) {
+        colSpan = fillRowCells(
+          (column as ColumnGroupType<RecordType>).children,
+          currentColIndex,
+          rowIndex + 1,
+        ).reduce((total, count) => total + count, 0);
         cell.hasSubColumns = true;
       }
 

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { ColumnsType, CellType, StickyOffsets, ColumnType, GetComponentProps } from '../interface';
+import {
+  ColumnsType,
+  CellType,
+  StickyOffsets,
+  ColumnType,
+  GetComponentProps,
+  ColumnGroupType,
+} from '../interface';
 import HeaderRow from './HeaderRow';
 import TableContext from '../context/TableContext';
 
@@ -28,8 +35,9 @@ function parseHeaderRows<RecordType>(
 
       let colSpan: number = 1;
 
-      if ('children' in column) {
-        colSpan = fillRowCells(column.children, currentColIndex, rowIndex + 1).reduce(
+      const columnAlias = column as ColumnGroupType<RecordType>;
+      if (columnAlias.children) {
+        colSpan = fillRowCells(columnAlias.children, currentColIndex, rowIndex + 1).reduce(
           (total, count) => total + count,
           0,
         );

--- a/src/hooks/useColumns.tsx
+++ b/src/hooks/useColumns.tsx
@@ -9,6 +9,7 @@ import {
   GetRowKey,
   TriggerEventHandler,
   RenderExpandIcon,
+  ColumnGroupType,
 } from '../interface';
 import { INTERNAL_COL_DEFINE } from '../utils/legacyUtil';
 
@@ -39,10 +40,11 @@ function flatColumns<RecordType>(columns: ColumnsType<RecordType>): ColumnType<R
     // Convert `fixed='true'` to `fixed='left'` instead
     const parsedFixed = fixed === true ? 'left' : fixed;
 
-    if ('children' in column) {
+    const columnAlias = column as ColumnGroupType<RecordType>;
+    if (columnAlias.children) {
       return [
         ...list,
-        ...flatColumns(column.children).map(subColum => ({
+        ...flatColumns(columnAlias.children).map(subColum => ({
           fixed: parsedFixed,
           ...subColum,
         })),

--- a/src/hooks/useColumns.tsx
+++ b/src/hooks/useColumns.tsx
@@ -40,11 +40,10 @@ function flatColumns<RecordType>(columns: ColumnsType<RecordType>): ColumnType<R
     // Convert `fixed='true'` to `fixed='left'` instead
     const parsedFixed = fixed === true ? 'left' : fixed;
 
-    const columnAlias = column as ColumnGroupType<RecordType>;
-    if (columnAlias.children) {
+    if ((column as ColumnGroupType<RecordType>).children) {
       return [
         ...list,
-        ...flatColumns(columnAlias.children).map(subColum => ({
+        ...flatColumns((column as ColumnGroupType<RecordType>).children).map(subColum => ({
           fixed: parsedFixed,
           ...subColum,
         })),


### PR DESCRIPTION
修复当，外围存在一些逻辑操作columus时如reduce, 会对无效的group 识别为group, 导致列头无法显示（均为空group）

动态组装的columus 肯定会声明column 的children,  比如 {

  children: xxx ? yyy : nnn
}

但是代码中使用的in 操作符，会识别为column group