### PR TITLE
fix: legacy context with function and class nesting cause RHL patch failed

### DIFF
--- a/src/BodyTable.tsx
+++ b/src/BodyTable.tsx
@@ -15,105 +15,107 @@ export interface BodyTableProps<ValueType> {
   isAnyColumnsFixed?: boolean;
 }
 
-export default function BodyTable<ValueType>(props: BodyTableProps<ValueType>, { table }) {
-  const { prefixCls, scroll } = table.props;
-  const {
-    columns,
-    fixed,
-    tableClassName,
-    getRowKey,
-    handleBodyScroll,
-    handleWheel,
-    expander,
-    isAnyColumnsFixed,
-  } = props;
-  const { saveRef } = table;
-  let { useFixedHeader } = table.props;
-  const bodyStyle = { ...table.props.bodyStyle };
-  const innerBodyStyle: React.CSSProperties = {};
+export default class BodyTable<ValueType> extends React.PureComponent<BodyTableProps<ValueType>> {
+  static contextTypes = {
+    table: PropTypes.any,
+  };
 
-  if (scroll.x || fixed) {
-    bodyStyle.overflowX = bodyStyle.overflowX || 'scroll';
-    // Fix weird webkit render bug
-    // https://github.com/ant-design/ant-design/issues/7783
-    bodyStyle.WebkitTransform = 'translate3d (0, 0, 0)';
-  }
+  render() {
+    const { prefixCls, scroll } = this.context.table.props;
+    const {
+      columns,
+      fixed,
+      tableClassName,
+      getRowKey,
+      handleBodyScroll,
+      handleWheel,
+      expander,
+      isAnyColumnsFixed,
+    } = this.props;
+    const { saveRef } = this.context.table;
+    let { useFixedHeader } = this.context.table.props;
+    const bodyStyle = { ...this.context.table.props.bodyStyle };
+    const innerBodyStyle: React.CSSProperties = {};
 
-  if (scroll.y) {
-    // maxHeight will make fixed-Table scrolling not working
-    // so we only set maxHeight to body-Table here
-    if (fixed) {
-      innerBodyStyle.maxHeight = bodyStyle.maxHeight || scroll.y;
-      innerBodyStyle.overflowY = bodyStyle.overflowY || 'scroll';
-    } else {
-      bodyStyle.maxHeight = bodyStyle.maxHeight || scroll.y;
+    if (scroll.x || fixed) {
+      bodyStyle.overflowX = bodyStyle.overflowX || 'scroll';
+      // Fix weird webkit render bug
+      // https://github.com/ant-design/ant-design/issues/7783
+      bodyStyle.WebkitTransform = 'translate3d (0, 0, 0)';
     }
-    bodyStyle.overflowY = bodyStyle.overflowY || 'scroll';
-    useFixedHeader = true;
 
-    // Add negative margin bottom for scroll bar overflow bug
-    const scrollbarWidth = measureScrollbar({ direction: 'vertical' });
-    if (scrollbarWidth > 0 && fixed) {
-      bodyStyle.marginBottom = `-${scrollbarWidth}px`;
-      bodyStyle.paddingBottom = '0px';
+    if (scroll.y) {
+      // maxHeight will make fixed-Table scrolling not working
+      // so we only set maxHeight to body-Table here
+      if (fixed) {
+        innerBodyStyle.maxHeight = bodyStyle.maxHeight || scroll.y;
+        innerBodyStyle.overflowY = bodyStyle.overflowY || 'scroll';
+      } else {
+        bodyStyle.maxHeight = bodyStyle.maxHeight || scroll.y;
+      }
+      bodyStyle.overflowY = bodyStyle.overflowY || 'scroll';
+      useFixedHeader = true;
+
+      // Add negative margin bottom for scroll bar overflow bug
+      const scrollbarWidth = measureScrollbar({ direction: 'vertical' });
+      if (scrollbarWidth > 0 && fixed) {
+        bodyStyle.marginBottom = `-${scrollbarWidth}px`;
+        bodyStyle.paddingBottom = '0px';
+      }
     }
-  }
 
-  const baseTable = (
-    <BaseTable
-      tableClassName={tableClassName}
-      hasHead={!useFixedHeader}
-      hasBody
-      fixed={fixed}
-      columns={columns}
-      expander={expander}
-      getRowKey={getRowKey}
-      isAnyColumnsFixed={isAnyColumnsFixed}
-    />
-  );
+    const baseTable = (
+      <BaseTable
+        tableClassName={tableClassName}
+        hasHead={!useFixedHeader}
+        hasBody
+        fixed={fixed}
+        columns={columns}
+        expander={expander}
+        getRowKey={getRowKey}
+        isAnyColumnsFixed={isAnyColumnsFixed}
+      />
+    );
 
-  if (fixed && columns.length) {
-    let refName: string;
-    if (columns[0].fixed === 'left' || columns[0].fixed === true) {
-      refName = 'fixedColumnsBodyLeft';
-    } else if (columns[0].fixed === 'right') {
-      refName = 'fixedColumnsBodyRight';
-    }
-    delete bodyStyle.overflowX;
-    delete bodyStyle.overflowY;
-    return (
-      <div key="bodyTable" className={`${prefixCls}-body-outer`} style={{ ...bodyStyle }}>
-        <div
-          className={`${prefixCls}-body-inner`}
-          style={innerBodyStyle}
-          ref={saveRef(refName)}
-          onWheel={handleWheel}
-          onScroll={handleBodyScroll}
-        >
-          {baseTable}
+    if (fixed && columns.length) {
+      let refName: string;
+      if (columns[0].fixed === 'left' || columns[0].fixed === true) {
+        refName = 'fixedColumnsBodyLeft';
+      } else if (columns[0].fixed === 'right') {
+        refName = 'fixedColumnsBodyRight';
+      }
+      delete bodyStyle.overflowX;
+      delete bodyStyle.overflowY;
+      return (
+        <div key="bodyTable" className={`${prefixCls}-body-outer`} style={{ ...bodyStyle }}>
+          <div
+            className={`${prefixCls}-body-inner`}
+            style={innerBodyStyle}
+            ref={saveRef(refName)}
+            onWheel={handleWheel}
+            onScroll={handleBodyScroll}
+          >
+            {baseTable}
+          </div>
         </div>
+      );
+    }
+
+    // Should provides `tabIndex` if use scroll to enable keyboard scroll
+    const useTabIndex = scroll && (scroll.x || scroll.y);
+
+    return (
+      <div
+        tabIndex={useTabIndex ? -1 : undefined}
+        key="bodyTable"
+        className={`${prefixCls}-body`}
+        style={bodyStyle}
+        ref={saveRef('bodyTable')}
+        onWheel={handleWheel}
+        onScroll={handleBodyScroll}
+      >
+        {baseTable}
       </div>
     );
   }
-
-  // Should provides `tabIndex` if use scroll to enable keyboard scroll
-  const useTabIndex = scroll && (scroll.x || scroll.y);
-
-  return (
-    <div
-      tabIndex={useTabIndex ? -1 : undefined}
-      key="bodyTable"
-      className={`${prefixCls}-body`}
-      style={bodyStyle}
-      ref={saveRef('bodyTable')}
-      onWheel={handleWheel}
-      onScroll={handleBodyScroll}
-    >
-      {baseTable}
-    </div>
-  );
 }
-
-BodyTable.contextTypes = {
-  table: PropTypes.any,
-};

--- a/src/ColGroup.tsx
+++ b/src/ColGroup.tsx
@@ -9,37 +9,38 @@ export interface ColGroupProps {
   columns?: ColumnType[];
 }
 
-const ColGroup: React.FC<ColGroupProps> = (props, { table }) => {
-  const { prefixCls, expandIconAsCell } = table.props;
-  const { fixed } = props;
+export default class ColGroup extends React.PureComponent<ColGroupProps> {
+  static contextTypes = {
+    table: PropTypes.any,
+  };
 
-  let cols: React.ReactElement[] = [];
+  render() {
+    const { prefixCls, expandIconAsCell } = this.context.table.props;
+    const { fixed } = this.props;
 
-  if (expandIconAsCell && fixed !== 'right') {
-    cols.push(<col className={`${prefixCls}-expand-icon-col`} key="rc-table-expand-icon-col" />);
+    let cols: React.ReactElement[] = [];
+
+    if (expandIconAsCell && fixed !== 'right') {
+      cols.push(<col className={`${prefixCls}-expand-icon-col`} key="rc-table-expand-icon-col" />);
+    }
+
+    let leafColumns: InternalColumnType[];
+
+    if (fixed === 'left') {
+      leafColumns = this.context.table.columnManager.leftLeafColumns();
+    } else if (fixed === 'right') {
+      leafColumns = this.context.table.columnManager.rightLeafColumns();
+    } else {
+      leafColumns = this.context.table.columnManager.leafColumns();
+    }
+
+    cols = cols.concat(
+      leafColumns.map(({ key, dataIndex, width, [INTERNAL_COL_DEFINE]: additionalProps }) => {
+        const mergedKey = key !== undefined ? key : dataIndex;
+        return <col key={mergedKey} style={{ width, minWidth: width }} {...additionalProps} />;
+      }),
+    );
+
+    return <colgroup>{cols}</colgroup>;
   }
-
-  let leafColumns: InternalColumnType[];
-
-  if (fixed === 'left') {
-    leafColumns = table.columnManager.leftLeafColumns();
-  } else if (fixed === 'right') {
-    leafColumns = table.columnManager.rightLeafColumns();
-  } else {
-    leafColumns = table.columnManager.leafColumns();
-  }
-  cols = cols.concat(
-    leafColumns.map(({ key, dataIndex, width, [INTERNAL_COL_DEFINE]: additionalProps }) => {
-      const mergedKey = key !== undefined ? key : dataIndex;
-      return <col key={mergedKey} style={{ width, minWidth: width }} {...additionalProps} />;
-    }),
-  );
-
-  return <colgroup>{cols}</colgroup>;
-};
-
-ColGroup.contextTypes = {
-  table: PropTypes.any,
-};
-
-export default ColGroup;
+}

--- a/src/HeadTable.tsx
+++ b/src/HeadTable.tsx
@@ -13,56 +13,58 @@ export interface HeadTableProps {
   expander: Expander;
 }
 
-export default function HeadTable(props: HeadTableProps, { table }) {
-  const { prefixCls, scroll, showHeader } = table.props;
-  const { columns, fixed, tableClassName, handleBodyScrollLeft, expander } = props;
-  const { saveRef } = table;
-  let { useFixedHeader } = table.props;
-  const headStyle: React.CSSProperties = {};
-  const scrollbarWidth = measureScrollbar({ direction: 'vertical' });
+export default class HeadTable extends React.PureComponent<HeadTableProps> {
+  static contextTypes = {
+    table: PropTypes.any,
+  };
 
-  if (scroll.y) {
-    useFixedHeader = true;
-    // https://github.com/ant-design/ant-design/issues/17051
-    const scrollbarWidthOfHeader = measureScrollbar({ direction: 'horizontal', prefixCls });
-    // Add negative margin bottom for scroll bar overflow bug
-    if (scrollbarWidthOfHeader > 0 && !fixed) {
-      headStyle.marginBottom = `-${scrollbarWidthOfHeader}px`;
-      headStyle.paddingBottom = '0px';
-      // https://github.com/ant-design/ant-design/pull/19986
-      headStyle.minWidth = `${scrollbarWidth}px`;
+  render() {
+    const { prefixCls, scroll, showHeader } = this.context.table.props;
+    const { columns, fixed, tableClassName, handleBodyScrollLeft, expander } = this.props;
+    const { saveRef } = this.context.table;
+    let { useFixedHeader } = this.context.table.props;
+    const headStyle: React.CSSProperties = {};
+    const scrollbarWidth = measureScrollbar({ direction: 'vertical' });
+
+    if (scroll.y) {
+      useFixedHeader = true;
       // https://github.com/ant-design/ant-design/issues/17051
-      headStyle.overflowX = 'scroll';
-      headStyle.overflowY = scrollbarWidth === 0 ? 'hidden' : 'scroll';
+      const scrollbarWidthOfHeader = measureScrollbar({ direction: 'horizontal', prefixCls });
+      // Add negative margin bottom for scroll bar overflow bug
+      if (scrollbarWidthOfHeader > 0 && !fixed) {
+        headStyle.marginBottom = `-${scrollbarWidthOfHeader}px`;
+        headStyle.paddingBottom = '0px';
+        // https://github.com/ant-design/ant-design/pull/19986
+        headStyle.minWidth = `${scrollbarWidth}px`;
+        // https://github.com/ant-design/ant-design/issues/17051
+        headStyle.overflowX = 'scroll';
+        headStyle.overflowY = scrollbarWidth === 0 ? 'hidden' : 'scroll';
+      }
     }
-  }
 
-  if (!useFixedHeader || !showHeader) {
-    return null;
-  }
+    if (!useFixedHeader || !showHeader) {
+      return null;
+    }
 
-  return (
-    <div
-      key="headTable"
-      ref={fixed ? null : saveRef('headTable')}
-      className={classNames(`${prefixCls}-header`, {
-        [`${prefixCls}-hide-scrollbar`]: scrollbarWidth > 0,
-      })}
-      style={headStyle}
-      onScroll={handleBodyScrollLeft}
-    >
-      <BaseTable
-        tableClassName={tableClassName}
-        hasHead
-        hasBody={false}
-        fixed={fixed}
-        columns={columns}
-        expander={expander}
-      />
-    </div>
-  );
+    return (
+      <div
+        key="headTable"
+        ref={fixed ? null : saveRef('headTable')}
+        className={classNames(`${prefixCls}-header`, {
+          [`${prefixCls}-hide-scrollbar`]: scrollbarWidth > 0,
+        })}
+        style={headStyle}
+        onScroll={handleBodyScrollLeft}
+      >
+        <BaseTable
+          tableClassName={tableClassName}
+          hasHead
+          hasBody={false}
+          fixed={fixed}
+          columns={columns}
+          expander={expander}
+        />
+      </div>
+    );
+  }
 }
-
-HeadTable.contextTypes = {
-  table: PropTypes.any,
-};

--- a/src/TableHeader.tsx
+++ b/src/TableHeader.tsx
@@ -66,42 +66,42 @@ export interface TableHeaderProps {
   onHeaderRow?: GetComponentProps<ColumnType[]>;
 }
 
-const TableHeader: React.FC<TableHeaderProps> = (props, { table }) => {
-  const { components } = table;
-  const { prefixCls, showHeader, onHeaderRow } = table.props;
-  const { expander, columns, fixed } = props;
+export default class TableHeader extends React.PureComponent<TableHeaderProps> {
+  static contextTypes = {
+    table: PropTypes.any,
+  };
 
-  if (!showHeader) {
-    return null;
+  render() {
+    const { components } = this.context.table;
+    const { prefixCls, showHeader, onHeaderRow } = this.context.table.props;
+    const { expander, columns, fixed } = this.props;
+
+    if (!showHeader) {
+      return null;
+    }
+
+    const rows = getHeaderRows({ columns });
+
+    expander.renderExpandIndentCell(rows, fixed);
+
+    const HeaderWrapper = components.header.wrapper;
+
+    return (
+      <HeaderWrapper className={`${prefixCls}-thead`}>
+        {rows.map((row, index) => (
+          <TableHeaderRow
+            prefixCls={prefixCls}
+            key={index}
+            index={index}
+            fixed={fixed}
+            columns={columns}
+            rows={rows}
+            row={row}
+            components={components}
+            onHeaderRow={onHeaderRow}
+          />
+        ))}
+      </HeaderWrapper>
+    );
   }
-
-  const rows = getHeaderRows({ columns });
-
-  expander.renderExpandIndentCell(rows, fixed);
-
-  const HeaderWrapper = components.header.wrapper;
-
-  return (
-    <HeaderWrapper className={`${prefixCls}-thead`}>
-      {rows.map((row, index) => (
-        <TableHeaderRow
-          prefixCls={prefixCls}
-          key={index}
-          index={index}
-          fixed={fixed}
-          columns={columns}
-          rows={rows}
-          row={row}
-          components={components}
-          onHeaderRow={onHeaderRow}
-        />
-      ))}
-    </HeaderWrapper>
-  );
-};
-
-TableHeader.contextTypes = {
-  table: PropTypes.any,
-};
-
-export default TableHeader;
+}


### PR DESCRIPTION
该 PR 为了修复 Ant Design 3.x issue [#22136](https://github.com/ant-design/ant-design/issues/22136)

Table 表格使用了已经废弃的 `Context` 处理方式，因为 `class` 和 `function` 的嵌套，导致 React Hot Loader patch 更新的时候失败。从 RHL 的 issue 中找到了点[蛛丝马迹](https://github.com/gaearon/react-hot-loader/issues/1115)，由此处理了这个问题。

此 PR 将所有的 `stateless function component` 改为了 `pure class component` 的形式。

**注意：这本不是 `rc-table` 的问题，但是 RHL 似乎停止了对 Legacy Context 的支持，只能设置为[忽略热更新](https://github.com/gaearon/react-hot-loader/issues/1274)，所以由 `rc-table` 修复问题。**