### PR TITLE
feat: Table summary support fixed column

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -281,4 +281,10 @@
     border-top: 0;
     padding: @cell-padding;
   }
+
+  tfoot {
+    td {
+      background: #fff;
+    }
+  }
 }

--- a/examples/fixedColumns.tsx
+++ b/examples/fixedColumns.tsx
@@ -63,6 +63,20 @@ const Demo = () => (
       expandedRowRender={({ b, c }) => b || c}
       scroll={{ x: 1200 }}
       data={data}
+      summary={() => (
+        <>
+          <tr>
+            <Table.SummaryCell index={0} />
+            <Table.SummaryCell index={1} colSpan={2}>
+              Summary
+            </Table.SummaryCell>
+            <Table.SummaryCell index={3} colSpan={9}>
+              Content
+            </Table.SummaryCell>
+            <Table.SummaryCell index={12}>Right</Table.SummaryCell>
+          </tr>
+        </>
+      )}
     />
   </div>
 );

--- a/examples/fixedColumns.tsx
+++ b/examples/fixedColumns.tsx
@@ -65,16 +65,16 @@ const Demo = () => (
       data={data}
       summary={() => (
         <>
-          <tr>
-            <Table.SummaryCell index={0} />
-            <Table.SummaryCell index={1} colSpan={2}>
+          <Table.Summary.Row>
+            <Table.Summary.Cell index={0} />
+            <Table.Summary.Cell index={1} colSpan={2}>
               Summary
-            </Table.SummaryCell>
-            <Table.SummaryCell index={3} colSpan={9}>
+            </Table.Summary.Cell>
+            <Table.Summary.Cell index={3} colSpan={9}>
               Content
-            </Table.SummaryCell>
-            <Table.SummaryCell index={12}>Right</Table.SummaryCell>
-          </tr>
+            </Table.Summary.Cell>
+            <Table.Summary.Cell index={12}>Right</Table.Summary.Cell>
+          </Table.Summary.Row>
         </>
       )}
     />

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -43,6 +43,7 @@ function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowP
     rowKey,
     getRowKey,
     rowExpandable,
+    expandedKeys,
     onRow,
     indent = 0,
     rowComponent: RowComponent,
@@ -68,7 +69,7 @@ function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowP
   } = React.useContext(BodyContext);
   const [expandRended, setExpandRended] = React.useState(false);
 
-  const expanded = props.expandedKeys.has(props.recordKey);
+  const expanded = expandedKeys && expandedKeys.has(props.recordKey);
 
   React.useEffect(() => {
     if (expanded) {
@@ -76,7 +77,7 @@ function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowP
     }
   }, [expanded]);
 
-  // Move to Body to enhance performance
+  // TODO: Move to Body to enhance performance
   const fixedInfoList = flattenColumns.map((column, colIndex) =>
     getCellFixedInfo(colIndex, colIndex, flattenColumns, stickyOffsets, direction),
   );
@@ -84,7 +85,8 @@ function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowP
   const rowSupportExpand = expandableType === 'row' && (!rowExpandable || rowExpandable(record));
   // Only when row is not expandable and `children` exist in record
   const nestExpandable = expandableType === 'nest';
-  const hasNestChildren = childrenColumnName in record && record[childrenColumnName];
+  const hasNestChildren =
+    childrenColumnName && childrenColumnName in record && record[childrenColumnName];
   const mergedExpandable = rowSupportExpand || nestExpandable;
 
   // =========================== onRow ===========================

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -4,15 +4,7 @@ import Cell from '../Cell';
 import TableContext from '../context/TableContext';
 import BodyContext from '../context/BodyContext';
 import { getColumnsKey } from '../utils/valueUtil';
-import {
-  ColumnType,
-  StickyOffsets,
-  CustomizeComponent,
-  GetComponentProps,
-  Key,
-  GetRowKey,
-} from '../interface';
-import { getCellFixedInfo } from '../utils/fixUtil';
+import { ColumnType, CustomizeComponent, GetComponentProps, Key, GetRowKey } from '../interface';
 import ExpandedRow from './ExpandedRow';
 
 export interface BodyRowProps<RecordType> {
@@ -20,7 +12,6 @@ export interface BodyRowProps<RecordType> {
   index: number;
   className?: string;
   style?: React.CSSProperties;
-  stickyOffsets: StickyOffsets;
   recordKey: Key;
   expandedKeys: Set<Key>;
   rowComponent: CustomizeComponent;
@@ -37,7 +28,6 @@ function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowP
   const {
     className,
     style,
-    stickyOffsets,
     record,
     index,
     rowKey,
@@ -50,7 +40,7 @@ function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowP
     cellComponent,
     childrenColumnName,
   } = props;
-  const { prefixCls, direction } = React.useContext(TableContext);
+  const { prefixCls, fixedInfoList } = React.useContext(TableContext);
   const {
     fixHeader,
     fixColumn,
@@ -76,11 +66,6 @@ function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowP
       setExpandRended(true);
     }
   }, [expanded]);
-
-  // TODO: Move to Body to enhance performance
-  const fixedInfoList = flattenColumns.map((column, colIndex) =>
-    getCellFixedInfo(colIndex, colIndex, flattenColumns, stickyOffsets, direction),
-  );
 
   const rowSupportExpand = expandableType === 'row' && (!rowExpandable || rowExpandable(record));
   // Only when row is not expandable and `children` exist in record

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import ResizeObserver from 'rc-resize-observer';
 import BodyRow from './BodyRow';
 import TableContext from '../context/TableContext';
-import { GetRowKey, StickyOffsets, Key, GetComponentProps } from '../interface';
+import { GetRowKey, Key, GetComponentProps } from '../interface';
 import ExpandedRow from './ExpandedRow';
 import BodyContext from '../context/BodyContext';
 import { getColumnsKey } from '../utils/valueUtil';
@@ -12,7 +12,6 @@ export interface BodyProps<RecordType> {
   data: RecordType[];
   getRowKey: GetRowKey<RecordType>;
   measureColumnWidth: boolean;
-  stickyOffsets: StickyOffsets;
   expandedKeys: Set<Key>;
   onRow: GetComponentProps<RecordType>;
   rowExpandable: (record: RecordType) => boolean;
@@ -24,7 +23,6 @@ function Body<RecordType>({
   data,
   getRowKey,
   measureColumnWidth,
-  stickyOffsets,
   expandedKeys,
   onRow,
   rowExpandable,
@@ -56,7 +54,6 @@ function Body<RecordType>({
             index={index}
             rowComponent={trComponent}
             cellComponent={tdComponent}
-            stickyOffsets={stickyOffsets}
             expandedKeys={expandedKeys}
             onRow={onRow}
             getRowKey={getRowKey}
@@ -112,7 +109,6 @@ function Body<RecordType>({
     prefixCls,
     onRow,
     measureColumnWidth,
-    stickyOffsets,
     expandedKeys,
     getRowKey,
     getComponent,

--- a/src/Footer/Cell.tsx
+++ b/src/Footer/Cell.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import Cell from '../Cell';
+import TableContext from '../context/TableContext';
+
+export interface SummaryCellProps {
+  className?: string;
+  children?: React.ReactNode;
+  index: number;
+  colSpan?: number;
+  rowSpan?: number;
+}
+
+export default function SummaryCell({
+  className,
+  index,
+  children,
+  colSpan,
+  rowSpan,
+}: SummaryCellProps) {
+  const { prefixCls, fixedInfoList } = React.useContext(TableContext);
+
+  const fixedInfo = fixedInfoList[index];
+
+  return (
+    <Cell
+      className={className}
+      index={index}
+      component="td"
+      prefixCls={prefixCls}
+      record={null}
+      dataIndex={null}
+      render={() => ({
+        children,
+        props: {
+          colSpan,
+          rowSpan,
+        },
+      })}
+      {...fixedInfo}
+    />
+  );
+}

--- a/src/Footer/Row.tsx
+++ b/src/Footer/Row.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export interface FooterRowProps {
+  children?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export default function FooterRow(props: FooterRowProps) {
+  return <tr {...props} />;
+}

--- a/src/Footer/index.tsx
+++ b/src/Footer/index.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import TableContext from '../context/TableContext';
+import Cell from './Cell';
+import Row from './Row';
 
 export interface FooterProps<RecordType> {
   children: React.ReactNode;
@@ -11,3 +13,8 @@ function Footer<RecordType>({ children }: FooterProps<RecordType>) {
 }
 
 export default Footer;
+
+export const FooterComponents = {
+  Cell,
+  Row,
+};

--- a/src/Footer/index.tsx
+++ b/src/Footer/index.tsx
@@ -14,7 +14,7 @@ function Footer<RecordType>({ stickyOffsets, children }: FooterProps<RecordType>
   let footer: React.ReactNode;
 
   const { flattenColumns } = React.useContext(BodyContext);
-  const { direction } = React.useContext(TableContext);
+  const { prefixCls, direction } = React.useContext(TableContext);
 
   if (React.isValidElement(children)) {
     footer = children;
@@ -34,6 +34,7 @@ function Footer<RecordType>({ stickyOffsets, children }: FooterProps<RecordType>
               <Cell
                 className={null}
                 component="td"
+                prefixCls={prefixCls}
                 key={cellIndex}
                 record={null}
                 index={index}

--- a/src/Footer/index.tsx
+++ b/src/Footer/index.tsx
@@ -1,11 +1,54 @@
 import * as React from 'react';
+import { SummaryFooter, SummaryFooterArray, StickyOffsets } from '../interface';
+import Cell from '../Cell';
+import BodyContext from '../context/BodyContext';
+import TableContext from '../context/TableContext';
+import { getCellFixedInfo } from '../utils/fixUtil';
 
-export interface FooterProps {
-  children: React.ReactNode;
+export interface FooterProps<RecordType> {
+  stickyOffsets: StickyOffsets;
+  children: SummaryFooter<RecordType>;
 }
 
-function Footer({ children }: FooterProps) {
-  return <tfoot>{children}</tfoot>;
+function Footer<RecordType>({ stickyOffsets, children }: FooterProps<RecordType>) {
+  let footer: React.ReactNode;
+
+  const { flattenColumns } = React.useContext(BodyContext);
+  const { direction } = React.useContext(TableContext);
+
+  if (React.isValidElement(children)) {
+    footer = children;
+  } else if (Array.isArray(children)) {
+    // Move to Body to enhance performance
+    const fixedInfoList = flattenColumns.map((column, colIndex) =>
+      getCellFixedInfo(colIndex, colIndex, flattenColumns, stickyOffsets, direction),
+    );
+
+    footer = (children as SummaryFooterArray<RecordType>).map((row, index) => {
+      return (
+        <tr key={index}>
+          {row.map((cell, cellIndex) => {
+            const fixedInfo = fixedInfoList[cellIndex];
+
+            return (
+              <Cell
+                className={null}
+                component="td"
+                key={cellIndex}
+                record={null}
+                index={index}
+                dataIndex={null}
+                render={() => cell}
+                {...fixedInfo}
+              />
+            );
+          })}
+        </tr>
+      );
+    });
+  }
+
+  return <tfoot>{footer}</tfoot>;
 }
 
 export default Footer;

--- a/src/Footer/index.tsx
+++ b/src/Footer/index.tsx
@@ -1,55 +1,13 @@
 import * as React from 'react';
-import { SummaryFooter, SummaryFooterArray, StickyOffsets } from '../interface';
-import Cell from '../Cell';
-import BodyContext from '../context/BodyContext';
 import TableContext from '../context/TableContext';
-import { getCellFixedInfo } from '../utils/fixUtil';
 
 export interface FooterProps<RecordType> {
-  stickyOffsets: StickyOffsets;
-  children: SummaryFooter<RecordType>;
+  children: React.ReactNode;
 }
 
-function Footer<RecordType>({ stickyOffsets, children }: FooterProps<RecordType>) {
-  let footer: React.ReactNode;
-
-  const { flattenColumns } = React.useContext(BodyContext);
-  const { prefixCls, direction } = React.useContext(TableContext);
-
-  if (React.isValidElement(children)) {
-    footer = children;
-  } else if (Array.isArray(children)) {
-    // Move to Body to enhance performance
-    const fixedInfoList = flattenColumns.map((column, colIndex) =>
-      getCellFixedInfo(colIndex, colIndex, flattenColumns, stickyOffsets, direction),
-    );
-
-    footer = (children as SummaryFooterArray<RecordType>).map((row, index) => {
-      return (
-        <tr key={index}>
-          {row.map((cell, cellIndex) => {
-            const fixedInfo = fixedInfoList[cellIndex];
-
-            return (
-              <Cell
-                className={null}
-                component="td"
-                prefixCls={prefixCls}
-                key={cellIndex}
-                record={null}
-                index={index}
-                dataIndex={null}
-                render={() => cell}
-                {...fixedInfo}
-              />
-            );
-          })}
-        </tr>
-      );
-    });
-  }
-
-  return <tfoot>{footer}</tfoot>;
+function Footer<RecordType>({ children }: FooterProps<RecordType>) {
+  const { prefixCls } = React.useContext(TableContext);
+  return <tfoot className={`${prefixCls}-summary`}>{children}</tfoot>;
 }
 
 export default Footer;

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -32,6 +32,7 @@ import ResizeObserver from 'rc-resize-observer';
 import getScrollBarSize from 'rc-util/lib/getScrollBarSize';
 import ColumnGroup from './sugar/ColumnGroup';
 import Column from './sugar/Column';
+import SummaryCell from './Footer/Cell';
 import FixedHeader from './Header/FixedHeader';
 import Header from './Header/Header';
 import {
@@ -66,6 +67,7 @@ import { getExpandableProps, getDataAndAriaProps } from './utils/legacyUtil';
 import Panel from './Panel';
 import Footer from './Footer';
 import { findAllChildrenKeys, renderExpandIcon } from './utils/expandUtil';
+import { getCellFixedInfo } from './utils/fixUtil';
 
 // Used for conditions cache
 const EMPTY_DATA = [];
@@ -517,9 +519,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     <ColGroup colWidths={flattenColumns.map(({ width }) => width)} columns={flattenColumns} />
   );
 
-  const footerTable = summary && (
-    <Footer stickyOffsets={stickyOffsets}>{summary(mergedData)}</Footer>
-  );
+  const footerTable = summary && <Footer>{summary(mergedData)}</Footer>;
   const customizeScrollBody = getComponent(['body']) as CustomizeScrollBody<RecordType>;
 
   if (
@@ -663,8 +663,11 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       getComponent,
       scrollbarSize,
       direction,
+      fixedInfoList: flattenColumns.map((_, colIndex) =>
+        getCellFixedInfo(colIndex, colIndex, flattenColumns, stickyOffsets, direction),
+      ),
     }),
-    [prefixCls, getComponent, scrollbarSize, direction],
+    [prefixCls, getComponent, scrollbarSize, direction, flattenColumns, stickyOffsets, direction],
   );
 
   const BodyContextValue = React.useMemo(
@@ -718,6 +721,8 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
 Table.Column = Column;
 
 Table.ColumnGroup = ColumnGroup;
+
+Table.SummaryCell = SummaryCell;
 
 Table.defaultProps = {
   rowKey: 'key',

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -32,7 +32,6 @@ import ResizeObserver from 'rc-resize-observer';
 import getScrollBarSize from 'rc-util/lib/getScrollBarSize';
 import ColumnGroup from './sugar/ColumnGroup';
 import Column from './sugar/Column';
-import SummaryCell from './Footer/Cell';
 import FixedHeader from './Header/FixedHeader';
 import Header from './Header/Header';
 import {
@@ -65,7 +64,7 @@ import useStickyOffsets from './hooks/useStickyOffsets';
 import ColGroup from './ColGroup';
 import { getExpandableProps, getDataAndAriaProps } from './utils/legacyUtil';
 import Panel from './Panel';
-import Footer from './Footer';
+import Footer, { FooterComponents } from './Footer';
 import { findAllChildrenKeys, renderExpandIcon } from './utils/expandUtil';
 import { getCellFixedInfo } from './utils/fixUtil';
 
@@ -721,7 +720,7 @@ Table.Column = Column;
 
 Table.ColumnGroup = ColumnGroup;
 
-Table.SummaryCell = SummaryCell;
+Table.Summary = FooterComponents;
 
 Table.defaultProps = {
   rowKey: 'key',

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -505,7 +505,6 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     <Body
       data={mergedData}
       measureColumnWidth={fixHeader || horizonScroll}
-      stickyOffsets={stickyOffsets}
       expandedKeys={mergedExpandedKeys}
       rowExpandable={rowExpandable}
       getRowKey={getRowKey}

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -517,7 +517,9 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     <ColGroup colWidths={flattenColumns.map(({ width }) => width)} columns={flattenColumns} />
   );
 
-  const footerTable = summary && <Footer>{summary(mergedData)}</Footer>;
+  const footerTable = summary && (
+    <Footer stickyOffsets={stickyOffsets}>{summary(mergedData)}</Footer>
+  );
   const customizeScrollBody = getComponent(['body']) as CustomizeScrollBody<RecordType>;
 
   if (

--- a/src/context/TableContext.tsx
+++ b/src/context/TableContext.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
 import { GetComponent } from '../interface';
+import { FixedInfo } from '../utils/fixUtil';
 
 export interface TableContextProps {
   // Table context
   prefixCls: string;
+
   getComponent: GetComponent;
 
   scrollbarSize: number;
 
   direction: 'ltr' | 'rtl';
+
+  fixedInfoList: FixedInfo[];
 }
 
 const TableContext = React.createContext<TableContextProps>(null);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import Table from './Table';
+import SummaryCell from './Footer/Cell';
 import Column from './sugar/Column';
 import ColumnGroup from './sugar/ColumnGroup';
 import { INTERNAL_COL_DEFINE } from './utils/legacyUtil';
 
-export { Column, ColumnGroup, INTERNAL_COL_DEFINE };
+export { SummaryCell, Column, ColumnGroup, INTERNAL_COL_DEFINE };
 
 export default Table;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import Table from './Table';
-import SummaryCell from './Footer/Cell';
+import { FooterComponents as Summary } from './Footer';
 import Column from './sugar/Column';
 import ColumnGroup from './sugar/ColumnGroup';
 import { INTERNAL_COL_DEFINE } from './utils/legacyUtil';
 
-export { SummaryCell, Column, ColumnGroup, INTERNAL_COL_DEFINE };
+export { Summary, Column, ColumnGroup, INTERNAL_COL_DEFINE };
 
 export default Table;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -32,10 +32,6 @@ export type RowClassName<RecordType> = (
   indent: number,
 ) => string;
 
-export type SummaryFooterArray<RecordType> = CellType<RecordType>[][];
-
-export type SummaryFooter<RecordType> = React.ReactNode | SummaryFooterArray<RecordType>;
-
 // =================== Column ===================
 export interface CellType<RecordType> {
   key?: Key;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -32,6 +32,10 @@ export type RowClassName<RecordType> = (
   indent: number,
 ) => string;
 
+export type SummaryFooterArray<RecordType> = CellType<RecordType>[][];
+
+export type SummaryFooter<RecordType> = React.ReactNode | SummaryFooterArray<RecordType>;
+
 // =================== Column ===================
 export interface CellType<RecordType> {
   key?: Key;

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -168,13 +168,14 @@ describe('Table.Basic', () => {
             { dataIndex: 'c', width: 30 },
           ]}
           data={[{ key: 1, a: 2, b: 3, c: 4 }]}
-          summary={() => [
-            [
-              { children: 'Light', props: { colSpan: 2 } },
-              { children: 'Hidden', props: { colSpan: 0 } },
-              { children: 'Bamboo' },
-            ],
-          ]}
+          summary={() => (
+            <tr>
+              <Table.SummaryCell colSpan={2} index={0}>
+                Light
+              </Table.SummaryCell>
+              <Table.SummaryCell index={2}>Bamboo</Table.SummaryCell>
+            </tr>
+          )}
         />,
       );
 

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -169,12 +169,12 @@ describe('Table.Basic', () => {
           ]}
           data={[{ key: 1, a: 2, b: 3, c: 4 }]}
           summary={() => (
-            <tr>
-              <Table.SummaryCell colSpan={2} index={0}>
+            <Table.Summary.Row>
+              <Table.Summary.Cell colSpan={2} index={0}>
                 Light
-              </Table.SummaryCell>
-              <Table.SummaryCell index={2}>Bamboo</Table.SummaryCell>
-            </tr>
+              </Table.Summary.Cell>
+              <Table.Summary.Cell index={2}>Bamboo</Table.Summary.Cell>
+            </Table.Summary.Row>
           )}
         />,
       );

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -144,18 +144,42 @@ describe('Table.Basic', () => {
     ).toEqual('footer');
   });
 
-  it('render summary correctly', () => {
-    const wrapper = mount(
-      createTable({
-        summary: () => (
-          <tr className="summary">
-            <td>Good</td>
-          </tr>
-        ),
-      }),
-    );
+  describe('summary', () => {
+    it('render correctly', () => {
+      const wrapper = mount(
+        createTable({
+          summary: () => (
+            <tr className="summary">
+              <td>Good</td>
+            </tr>
+          ),
+        }),
+      );
 
-    expect(wrapper.find('tfoot').text()).toEqual('Good');
+      expect(wrapper.find('tfoot').text()).toEqual('Good');
+    });
+
+    it('support data type', () => {
+      const wrapper = mount(
+        <Table
+          columns={[
+            { dataIndex: 'a', fixed: 'left', width: 10 },
+            { dataIndex: 'b', fixed: 'left', width: 20 },
+            { dataIndex: 'c', width: 30 },
+          ]}
+          data={[{ key: 1, a: 2, b: 3, c: 4 }]}
+          summary={() => [
+            [
+              { children: 'Light', props: { colSpan: 2 } },
+              { children: 'Hidden', props: { colSpan: 0 } },
+              { children: 'Bamboo' },
+            ],
+          ]}
+        />,
+      );
+
+      expect(wrapper.find('tfoot').render()).toMatchSnapshot();
+    });
   });
 
   it('renders with id correctly', () => {

--- a/tests/__snapshots__/Table.spec.js.snap
+++ b/tests/__snapshots__/Table.spec.js.snap
@@ -664,7 +664,9 @@ exports[`Table.Basic renders rowSpan correctly 1`] = `
 `;
 
 exports[`Table.Basic summary support data type 1`] = `
-<tfoot>
+<tfoot
+  class="rc-table-summary"
+>
   <tr>
     <td
       class="rc-table-cell rc-table-cell-fix-left"

--- a/tests/__snapshots__/Table.spec.js.snap
+++ b/tests/__snapshots__/Table.spec.js.snap
@@ -663,6 +663,25 @@ exports[`Table.Basic renders rowSpan correctly 1`] = `
 </div>
 `;
 
+exports[`Table.Basic summary support data type 1`] = `
+<tfoot>
+  <tr>
+    <td
+      class="rc-table-cell rc-table-cell-fix-left"
+      colspan="2"
+      style="position: sticky; left: 0px;"
+    >
+      Light
+    </td>
+    <td
+      class="rc-table-cell"
+    >
+      Bamboo
+    </td>
+  </tr>
+</tfoot>
+`;
+
 exports[`Table.Basic syntactic sugar 1`] = `
 <div
   class="rc-table"


### PR DESCRIPTION
`summary` 新增一种数据格式，用于支持固定列的展示：

```tsx
<Table
  {...props}
  summary={() => (
    <tr>
      <Table.SummaryCell index={0} colSpan={2}>
        Light
      </Table.SummaryCell>
      <Table.SummaryCell index={2}>Bamboo</Table.SummaryCell>
    </tr>
  )}
/>
```

preview: https://table-git-fixed.react-component.now.sh/iframe.html?id=rc-table--fixedcolumns

------
原：
```tsx
<Table
  {...props}
  summary={() => [
    [
      { children: 'Light', props: { colSpan: 2 } },
      { children: 'Hidden', props: { colSpan: 0 } },
      { children: 'Bamboo' },
    ],
  ]}
/>
```