### PR TITLE
fix table icon cannot expand when has expandRowByClick

### DIFF
--- a/examples/expandIcon.tsx
+++ b/examples/expandIcon.tsx
@@ -42,7 +42,6 @@ const Demo = () => (
     columns={columns}
     data={data}
     expandable={{
-      expandRowByClick: true,
       expandedRowRender: record => <p>extra: {record.a}</p>,
       onExpand,
       expandIcon: CustomExpandIcon,

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -342,7 +342,8 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       expandable: !!expandedRowRender,
       expandedKeys: mergedExpandedKeys,
       getRowKey,
-      onTriggerExpand: expandRowByClick ? () => {} : onTriggerExpand,
+      // https://github.com/ant-design/ant-design/issues/23894
+      onTriggerExpand: expandRowByClick && expandIcon ? () => {} : onTriggerExpand,
       expandIcon: mergedExpandIcon,
       expandIconColumnIndex,
       direction,

--- a/tests/ExpandRow.spec.js
+++ b/tests/ExpandRow.spec.js
@@ -399,4 +399,32 @@ describe('Table.Expand', () => {
     expect(onExpand).toHaveBeenCalledWith(false, data[0]);
     expect(onExpand).toHaveBeenCalledTimes(2);
   });
+
+  // https://github.com/ant-design/ant-design/issues/23894
+  it('should be collapsible when `expandRowByClick` without custom `expandIcon`', () => {
+    const data = [{ key: 0, name: 'Lucy', age: 27, children: [{ key: 1, name: 'Jack', age: 28 }] }];
+    const onExpand = jest.fn();
+    const wrapper = mount(
+      createTable({
+        expandable: {
+          expandedRowRender,
+          expandRowByClick: true,
+          onExpand,
+        },
+        data,
+      }),
+    );
+    wrapper
+      .find('.rc-table-row-expand-icon')
+      .first()
+      .simulate('click');
+    expect(onExpand).toHaveBeenCalledWith(true, data[0]);
+    expect(onExpand).toHaveBeenCalledTimes(1);
+    wrapper
+      .find('.rc-table-row-expand-icon')
+      .first()
+      .simulate('click');
+    expect(onExpand).toHaveBeenCalledWith(false, data[0]);
+    expect(onExpand).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/23894

https://github.com/react-component/table/pull/468