### PR TITLE
Fix always visible scrollbar

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -383,13 +383,13 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
 
   if (fixHeader) {
     scrollYStyle = {
-      overflowY: 'scroll',
+      overflowY: 'auto',
       maxHeight: scroll.y,
     };
   }
 
   if (horizonScroll) {
-    scrollXStyle = { overflowX: 'scroll' };
+    scrollXStyle = { overflowX: 'auto' };
     // When no vertical scrollbar, should hide it
     // https://github.com/ant-design/ant-design/pull/20705
     // https://github.com/ant-design/ant-design/issues/21879

--- a/tests/Scroll.spec.js
+++ b/tests/Scroll.spec.js
@@ -15,7 +15,7 @@ describe('Table.Scroll', () => {
   it('renders scroll.x is true', () => {
     const wrapper = mount(createTable({ scroll: { x: true } }));
     expect(wrapper.find('table').props().style.width).toEqual('auto');
-    expect(wrapper.find('.rc-table-content').props().style.overflowX).toEqual('scroll');
+    expect(wrapper.find('.rc-table-content').props().style.overflowX).toEqual('auto');
     expect(wrapper.find('.rc-table-content').props().style.overflowY).toEqual('hidden');
   });
 
@@ -31,8 +31,8 @@ describe('Table.Scroll', () => {
 
   it('renders scroll.x and scroll.y are both true', () => {
     const wrapper = mount(createTable({ scroll: { x: true, y: 200 } }));
-    expect(wrapper.find('.rc-table-body').props().style.overflowX).toEqual('scroll');
-    expect(wrapper.find('.rc-table-body').props().style.overflowY).toEqual('scroll');
+    expect(wrapper.find('.rc-table-body').props().style.overflowX).toEqual('auto');
+    expect(wrapper.find('.rc-table-body').props().style.overflowY).toEqual('auto');
   });
 
   it('fire scroll event', () => {


### PR DESCRIPTION
Use overflowX: 'auto' and overflowY: 'auto' instead of 'scroll' to avoid scrollbars when they are not neccesary.

Use case: responsive Table container that matches the window size.