### PR TITLE
fix: remove body row array wrapper

### DIFF
--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -45,7 +45,7 @@ function Body<RecordType>({
       rows = data.map((record, index) => {
         const key = getRowKey(record, index);
 
-        return [
+        return (
           <BodyRow
             key={key}
             rowKey={key}
@@ -59,8 +59,8 @@ function Body<RecordType>({
             getRowKey={getRowKey}
             rowExpandable={rowExpandable}
             childrenColumnName={childrenColumnName}
-          />,
-        ];
+          />
+        );
       });
     } else {
       rows = (


### PR DESCRIPTION
@afc163 This seem like a typo. But it will slow down antd 4 table render.

Let me show you detail:

In a non-empty table. The `rows` is `[[BodyRow], [BodyRow2] ...]` currently. Every time user insert data into table. Existed rows will recreate even they have same keys. I think most user show table with pagination. So people ignore this for a long time.

This pr fix https://github.com/ant-design/ant-design/issues/25224 , you can try reproduction demo in that issue. There are two gif show the difference between ant3 and ant4.
