### PR TITLE
fix: table fixed height

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -394,8 +394,8 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
 
   if (fixHeader) {
     scrollYStyle = {
-      overflowY: 'scroll',
-      maxHeight: scroll.y,
+      overflowY: 'auto',
+      height: scroll.y,
     };
   }
 


### PR DESCRIPTION
Table固定高度，内容小于最大高度时，表格高度不正确，分页没有固定在底部。需要使用height设置表格的body的高度，这样才能固定表格高度，并且控制分页栏的位置。