### PR TITLE
fix: customizeScrollBody last flattenColumn, not last hierarhical column

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -543,7 +543,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
         onScroll,
       });
       headerProps.colWidths = flattenColumns.map(({ width }, index) => {
-        const colWidth = index === columns.length - 1 ? (width as number) - scrollbarSize : width;
+        const colWidth = index === flattenColumns.length - 1 ? (width as number) - scrollbarSize : width;
         if (typeof colWidth === 'number' && !Number.isNaN(colWidth)) {
           return colWidth;
         }


### PR DESCRIPTION
It's an issue with defining the last column from "columns" object, when we use hierarchical structure of columns. We should use flattenColumns there