### PR TITLE
fix: Default provides width even when no data

### DIFF
--- a/src/Body/MeasureCell.tsx
+++ b/src/Body/MeasureCell.tsx
@@ -21,7 +21,9 @@ export default function MeasureCell({ columnKey, onColumnResize }: MeasureCellPr
         onColumnResize(columnKey, offsetWidth);
       }}
     >
-      <td ref={cellRef} style={{ padding: 0, border: 0, height: 0 }} />
+      <td ref={cellRef} style={{ padding: 0, border: 0, height: 0 }}>
+        <div style={{ height: 0, overflow: 'hidden' }}>&nbsp;</div>
+      </td>
     </ResizeObserver>
   );
 }

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -407,14 +407,8 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     if (!fixHeader) {
       scrollYStyle = { overflowY: 'hidden' };
     }
-    let scrollTableWidth = scroll.x === true ? 'auto' : scroll.x;
-    // fix empty data columns style
-    // https://github.com/ant-design/ant-design/issues/26701
-    if (!hasData) {
-      scrollTableWidth = undefined;
-    }
     scrollTableStyle = {
-      width: scrollTableWidth,
+      width: scroll.x === true ? 'auto' : scroll.x,
       minWidth: '100%',
     };
   }

--- a/tests/__snapshots__/ExpandRow.spec.js.snap
+++ b/tests/__snapshots__/ExpandRow.spec.js.snap
@@ -244,16 +244,40 @@ exports[`Table.Expand renders fixed column correctly work 1`] = `
           >
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
           </tr>
           <tr
             class="rc-table-row rc-table-row-level-0"

--- a/tests/__snapshots__/FixedColumn.spec.js.snap
+++ b/tests/__snapshots__/FixedColumn.spec.js.snap
@@ -113,40 +113,112 @@ exports[`Table.FixedColumn fixed column renders correctly RTL 1`] = `
           >
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
           </tr>
           <tr
             class="rc-table-row rc-table-row-level-0"
@@ -736,40 +808,112 @@ exports[`Table.FixedColumn renders correctly scrollX - with data 1`] = `
           >
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
           </tr>
           <tr
             class="rc-table-row rc-table-row-level-0"
@@ -1258,7 +1402,7 @@ exports[`Table.FixedColumn renders correctly scrollX - without data 1`] = `
       style="overflow-x: auto; overflow-y: hidden;"
     >
       <table
-        style="min-width: 100%; table-layout: fixed;"
+        style="width: 1200px; min-width: 100%; table-layout: fixed;"
       >
         <colgroup>
           <col
@@ -1359,40 +1503,112 @@ exports[`Table.FixedColumn renders correctly scrollX - without data 1`] = `
           >
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
           </tr>
           <tr
             class="rc-table-placeholder"
@@ -1583,40 +1799,112 @@ exports[`Table.FixedColumn renders correctly scrollXY - with data 1`] = `
           >
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
           </tr>
           <tr
             class="rc-table-row rc-table-row-level-0"
@@ -2228,7 +2516,7 @@ exports[`Table.FixedColumn renders correctly scrollXY - without data 1`] = `
       style="overflow-x: auto; overflow-y: scroll; max-height: 100px;"
     >
       <table
-        style="min-width: 100%; table-layout: fixed;"
+        style="width: 1200px; min-width: 100%; table-layout: fixed;"
       >
         <colgroup>
           <col
@@ -2260,40 +2548,112 @@ exports[`Table.FixedColumn renders correctly scrollXY - without data 1`] = `
           >
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
           </tr>
           <tr
             class="rc-table-placeholder"

--- a/tests/__snapshots__/Table.spec.js.snap
+++ b/tests/__snapshots__/Table.spec.js.snap
@@ -136,13 +136,31 @@ exports[`Table.Basic custom components renders fixed column and header correctly
           >
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
             <td
               style="padding: 0px; border: 0px; height: 0px;"
-            />
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
           </tr>
           <tr
             class="rc-table-row rc-table-row-level-0"


### PR DESCRIPTION
columns 超过宽度时去掉 scrollX 会导致无数据下被挤到一起的问题。

ref https://github.com/react-component/table/commit/fab74ef6a3b08c4f95cbaddb9078024d8dc3f6cd