### PR TITLE
Add react and react-dom as peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "coverage": "father test --coverage"
   },
   "peerDependencies": {
-    "react": ">=16.9.0",
-    "react-dom": ">=16.9.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.10.1",


### PR DESCRIPTION
Fixes errors using Yarn 2 (berry).

See https://github.com/ant-design/ant-design/issues/27339 for details.
