### PR TITLE
Add Feature: virtual list at Y-axis when use table tag

### DIFF
--- a/examples/scrollY.tsx
+++ b/examples/scrollY.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import Table from '../src';
 import '../assets/index.less';
+import DropDown from 'rc-dropdown';
+import Menu, { Item, Divider } from 'rc-menu';
+import 'rc-dropdown/assets/index.css';
 
-const data = [];
+const dataSource = [];
 for (let i = 0; i < 10; i += 1) {
-  data.push({
+  dataSource.push({
     key: i,
     a: `a${i}`,
     b: `b${i}`,
@@ -15,16 +18,88 @@ for (let i = 0; i < 10; i += 1) {
 class Demo extends React.Component {
   state = {
     showBody: true,
+    visible: false,
+    data: dataSource,
+  };
+
+  filters = [];
+
+  handleVisibleChange = visible => {
+    this.setState({ visible });
   };
 
   toggleBody = () => {
     this.setState(({ showBody }) => ({ showBody: !showBody }));
   };
 
+  handleSelect = selected => {
+    this.filters.push(selected.key);
+  };
+
+  handleDeselect = unSelect => {
+    const index = this.filters.indexOf(unSelect.key);
+    if (index !== -1) {
+      this.filters.splice(index, 1);
+    }
+  };
+
+  confirmFilter = () => {
+    this.setState(prev  => {
+      const newD = dataSource.filter(item => this.filters.includes(item.a) || !this.filters.length)
+
+      return {
+        ...prev,
+        visible: false,
+        data: newD
+      }
+    })
+  };
+
+
   render() {
-    const { showBody } = this.state;
+    const { showBody, data } = this.state;
+    const menu = (
+      <Menu
+        style={{ width: 200 }}
+        multiple
+        onSelect={this.handleSelect}
+        onDeselect={this.handleDeselect}
+      >
+        <Item key="a0">a0</Item>
+        <Item key="a1">a1</Item>
+        <Item key="a2">a2</Item>
+        <Divider />
+        <Item disabled>
+          <button
+            type="button"
+            style={{
+              cursor: 'pointer',
+              color: '#000',
+              pointerEvents: 'visible',
+            }}
+            onClick={this.confirmFilter}
+          >
+            确定
+          </button>
+        </Item>
+      </Menu>
+    );
+
+
     const columns = [
-      { title: 'title1', key: 'a', dataIndex: 'a', width: 100 },
+      { title: (
+        <div>
+          title1
+          <DropDown
+            trigger={['click']}
+            onVisibleChange={this.handleVisibleChange}
+            visible={this.state.visible}
+            overlay={menu}
+          >
+            <a href="#">filter</a>
+          </DropDown>
+        </div>
+      ), key: 'a', dataIndex: 'a', width: 100  },
       { id: '123', title: 'title2', dataIndex: 'b', key: 'b', width: 100 },
       { title: 'title3', key: 'c', dataIndex: 'c', width: 200 },
       {

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -72,7 +72,7 @@ function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowP
   React.useEffect(() => {
     if (rowRef.current) {
       const rowHeight = rowRef.current ? rowRef.current.offsetHeight : 0
-      onRowResize(index, rowRef.current.offsetHeight);
+      onRowResize(index, rowHeight);
     }
   }, [data, expanded])
 

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -22,7 +22,11 @@ export interface BodyRowProps<RecordType> {
   rowKey: React.Key;
   getRowKey: GetRowKey<RecordType>;
   childrenColumnName: string;
+  onRowResize: (idx: number, height: number) => void;
+  data: RecordType[];
 }
+
+console.log(ExpandedRow, 111)
 
 function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowProps<RecordType>) {
   const {
@@ -35,12 +39,16 @@ function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowP
     rowExpandable,
     expandedKeys,
     onRow,
+    onRowResize,
     indent = 0,
     rowComponent: RowComponent,
     cellComponent,
     childrenColumnName,
+    data
   } = props;
   const { prefixCls, fixedInfoList } = React.useContext(TableContext);
+  const rowRef = React.useRef<HTMLTableRowElement>()
+  const expandedRowRef = React.useRef<HTMLTableRowElement>()
   const {
     fixHeader,
     fixColumn,
@@ -62,8 +70,18 @@ function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowP
   const expanded = expandedKeys && expandedKeys.has(props.recordKey);
 
   React.useEffect(() => {
+    if (rowRef.current) {
+      const rowHeight = rowRef.current ? rowRef.current.offsetHeight : 0
+      onRowResize(index, rowRef.current.offsetHeight);
+    }
+  }, [data, expanded])
+
+  React.useEffect(() => {
     if (expanded) {
       setExpandRended(true);
+      const rowHeight = rowRef.current ? rowRef.current.offsetHeight : 0
+      const expandedRowHeight = expandedRowRef.current ? expandedRowRef.current.offsetHeight : 0
+      onRowResize(index, rowHeight + expandedRowHeight);
     }
   }, [expanded]);
 
@@ -100,6 +118,7 @@ function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowP
   const columnsKey = getColumnsKey(flattenColumns);
   const baseRowNode = (
     <RowComponent
+      ref={rowRef}
       {...additionalProps}
       data-row-key={rowKey}
       className={classNames(
@@ -176,6 +195,7 @@ function BodyRow<RecordType extends { children?: RecordType[] }>(props: BodyRowP
       expandedRowClassName && expandedRowClassName(record, index, indent);
     expandRowNode = (
       <ExpandedRow
+        ref={expandedRowRef}
         expanded={expanded}
         className={classNames(
           `${prefixCls}-expanded-row`,

--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -17,19 +17,21 @@ export interface ExpandedRowProps<RecordType> {
   colSpan: number;
 }
 
-function ExpandedRow<RecordType>({
-  prefixCls,
-  children,
-  component: Component,
-  cellComponent,
-  fixHeader,
-  fixColumn,
-  horizonScroll,
-  className,
-  expanded,
-  componentWidth,
-  colSpan,
-}: ExpandedRowProps<RecordType>) {
+const ExpandedRow: React.ForwardRefRenderFunction<any, ExpandedRowProps<any>>  = ((props, ref) => {
+
+  const {
+    prefixCls,
+    children,
+    component: Component,
+    cellComponent,
+    fixHeader,
+    fixColumn,
+    horizonScroll,
+    className,
+    expanded,
+    componentWidth,
+    colSpan,
+  } = props;
   const { scrollbarSize } = React.useContext(TableContext);
 
   // Cache render node
@@ -39,6 +41,7 @@ function ExpandedRow<RecordType>({
     if (fixColumn) {
       contentNode = (
         <div
+          ref={ref}
           style={{
             width: componentWidth - (fixHeader ? scrollbarSize : 0),
             position: 'sticky',
@@ -54,6 +57,7 @@ function ExpandedRow<RecordType>({
 
     return (
       <Component
+        ref={ref}
         className={className}
         style={{
           display: expanded ? null : 'none',
@@ -75,6 +79,6 @@ function ExpandedRow<RecordType>({
     colSpan,
     scrollbarSize,
   ]);
-}
+})
 
-export default ExpandedRow;
+export default React.forwardRef(ExpandedRow);

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -17,6 +17,9 @@ export interface BodyProps<RecordType> {
   rowExpandable: (record: RecordType) => boolean;
   emptyNode: React.ReactNode;
   childrenColumnName: string;
+  scrollTop: number;
+  start: number;
+  end: number;
 }
 
 function Body<RecordType>({
@@ -28,8 +31,10 @@ function Body<RecordType>({
   rowExpandable,
   emptyNode,
   childrenColumnName,
+  start,
+  end,
 }: BodyProps<RecordType>) {
-  const { onColumnResize } = React.useContext(ResizeContext);
+  const { onColumnResize, onRowResize } = React.useContext(ResizeContext);
   const { prefixCls, getComponent } = React.useContext(TableContext);
   const { fixHeader, horizonScroll, flattenColumns, componentWidth } = React.useContext(
     BodyContext,
@@ -42,26 +47,29 @@ function Body<RecordType>({
 
     let rows: React.ReactNode;
     if (data.length) {
-      rows = data.map((record, index) => {
+      rows = [];
+      for (let index = start; index <= end; index++) {
+        const record = data[index]
         const key = getRowKey(record, index);
-
-        return (
+        (rows as any[]).push((
           <BodyRow
             key={key}
             rowKey={key}
             record={record}
             recordKey={key}
             index={index}
+            data={data}
             rowComponent={trComponent}
             cellComponent={tdComponent}
             expandedKeys={expandedKeys}
+            onRowResize={(...p) =>onRowResize(...p, end)}
             onRow={onRow}
             getRowKey={getRowKey}
             rowExpandable={rowExpandable}
             childrenColumnName={childrenColumnName}
           />
-        );
-      });
+        ));
+      };
     } else {
       rows = (
         <ExpandedRow
@@ -84,18 +92,18 @@ function Body<RecordType>({
     const columnsKey = getColumnsKey(flattenColumns);
 
     return (
-      <WrapperComponent className={`${prefixCls}-tbody`}>
-        {/* Measure body column width with additional hidden col */}
-        {measureColumnWidth && (
-          <tr aria-hidden="true" className={`${prefixCls}-measure-row`} style={{ height: 0 }}>
-            {columnsKey.map(columnKey => (
-              <MeasureCell key={columnKey} columnKey={columnKey} onColumnResize={onColumnResize} />
-            ))}
-          </tr>
-        )}
+        <WrapperComponent className={`${prefixCls}-tbody`}>
+          {/* Measure body column width with additional hidden col */}
+          {measureColumnWidth && (
+            <tr aria-hidden="true" className={`${prefixCls}-measure-row`} style={{ height: 0 }}>
+              {columnsKey.map(columnKey => (
+                <MeasureCell key={columnKey} columnKey={columnKey} onColumnResize={onColumnResize} />
+              ))}
+            </tr>
+          )}
 
-        {rows}
-      </WrapperComponent>
+          {rows}
+        </WrapperComponent>
     );
   }, [
     data,
@@ -108,6 +116,8 @@ function Body<RecordType>({
     componentWidth,
     emptyNode,
     flattenColumns,
+    start,
+    end,
   ]);
 }
 

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -71,7 +71,6 @@ import { findAllChildrenKeys, renderExpandIcon } from './utils/expandUtil';
 import { getCellFixedInfo } from './utils/fixUtil';
 import StickyScrollBar from './stickyScrollBar';
 import useSticky from './hooks/useSticky';
-import useDidUpdate from './hooks/useDidUpdate';
 
 // Used for conditions cache
 const EMPTY_DATA = [];
@@ -527,11 +526,13 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
         const str = String(v)
         if (isNumber(str)) {
           size = Number(v)
-        } else if (str.indexOf('px') === str.length - 2) {
-          const n = str.replace('px', '')
-          size = isNumber(n) ? Number('n') : 'auto'
+        } else {
+          const idx = str.indexOf('px')
+          if (idx !== -1 && idx === str.length - 2) {
+            const n = str.replace('px', '')
+            size = isNumber(n) ? Number(n) : 'auto'
+          }
         }
-        size = isNumber(size as string) ? Number(size) : 'auto'
       }
       return size
     }

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -405,6 +405,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
   let scrollYStyle: React.CSSProperties;
   let scrollTableStyle: React.CSSProperties;
 
+    // reset start end and rowsHeights when data change
   if (recordPrevDatas.current !== data) {
     recordEnd.current = 0
     recordRowsHeights.current = []
@@ -452,8 +453,6 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       forceUpdate({});
     }
   }, [])
-
-  //  recordRowsHeights.current ? recordRowsHeights.current.reduce((a, b) => a + b, 0) : 'auto'
   
   const bodyHeight = React.useMemo(() => {
     const rowsHeights = recordRowsHeights.current
@@ -484,7 +483,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     const mergedScrollLeft = typeof scrollLeft === 'number' ? scrollLeft : currentTarget.scrollLeft;
 
     const compareTarget = currentTarget || EMPTY_SCROLL_TARGET;
-    // 当不存在 或者 存在和 target 相等的时候
+
     if (!getScrollTarget() || getScrollTarget() === compareTarget) {
       setScrollTarget(compareTarget);
 
@@ -519,8 +518,6 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       triggerOnScroll();
     }
   }, [horizonScroll]);
-  
-  // reset start end and when data change
 
   const bodyBoxSize: [number | 'auto', number | 'auto'] = React.useMemo(() => {
 

--- a/src/context/ResizeContext.tsx
+++ b/src/context/ResizeContext.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 interface ResizeContextProps {
   onColumnResize: (columnKey: React.Key, width: number) => void;
+  onRowResize: (idx: number, height: number, end: number) => void;
 }
 
 const ResizeContext = React.createContext<ResizeContextProps>(null);


### PR DESCRIPTION
Ant Design virtual list are only for the table that div tag simulates.
So I add virtual list at the Y-axis for the  table that write by table tag.
And I do a simple test for some situations that I know, there are no changes about test code, but the dom struct has been changed.
Looking forward to your reply and code review. Thanks