### PR TITLE
feat: add columnWidth prop for expandable config

### DIFF
--- a/src/hooks/useColumns.tsx
+++ b/src/hooks/useColumns.tsx
@@ -119,6 +119,7 @@ function useColumns<RecordType>(
     expandIconColumnIndex,
     direction,
     expandRowByClick,
+    columnWidth,
   }: {
     prefixCls?: string;
     columns?: ColumnsType<RecordType>;
@@ -132,6 +133,7 @@ function useColumns<RecordType>(
     expandIconColumnIndex?: number;
     direction?: 'ltr' | 'rtl';
     expandRowByClick?: boolean;
+    columnWidth?: number | string;
   },
   transformColumns: (columns: ColumnsType<RecordType>) => ColumnsType<RecordType>,
 ): [ColumnsType<RecordType>, ColumnType<RecordType>[]] {
@@ -153,6 +155,7 @@ function useColumns<RecordType>(
         title: '',
         fixed: prevColumn ? prevColumn.fixed : null,
         className: `${prefixCls}-row-expand-icon-cell`,
+        width: columnWidth,
         render: (_, record, index) => {
           const rowKey = getRowKey(record, index);
           const expanded = expandedKeys.has(rowKey);

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -210,6 +210,7 @@ export interface ExpandableConfig<RecordType> {
   expandedRowClassName?: RowClassName<RecordType>;
   childrenColumnName?: string;
   rowExpandable?: (record: RecordType) => boolean;
+  columnWidth?: number | string;
 }
 
 // =================== Render ===================


### PR DESCRIPTION
- [x] expandable 新增 columnWidth 属性

[table的expandable的icon宽度可设置](https://github.com/ant-design/ant-design/issues/28147)