### PR TITLE
feat: add expandable fixed

### DIFF
--- a/docs/examples/expandedRowRender.tsx
+++ b/docs/examples/expandedRowRender.tsx
@@ -38,6 +38,7 @@ const Demo = () => {
   const [scrollX, scrollXProps] = useCheckbox(false);
   const [fixHeader, fixHeaderProps] = useCheckbox(false);
   const [expandIconPosition, expandIconPositionProps] = useCheckbox(false);
+  const [fixExpand, setFixExpand] = useCheckbox(false);
 
   const remove = (index: number) => {
     const newData = data.slice();
@@ -62,6 +63,13 @@ const Demo = () => {
     columns.unshift({ title: 'fix left 2', dataIndex: 'a', width: 100, fixed: 'left' });
     columns.unshift({ title: 'fix left 1', dataIndex: 'a', width: 100, fixed: true });
     columns.push({ title: 'fix right', dataIndex: 'a', width: 100, fixed: 'right' });
+  }
+
+  if (fixExpand) {
+    columns.unshift({ title: 'test ', dataIndex: 'a', width: 200 });
+    columns.unshift({ title: 'test ', dataIndex: 'a', width: 200 });
+    columns.unshift({ title: 'test ', dataIndex: 'a', width: 200 });
+    columns.unshift({ title: 'test ', dataIndex: 'a', width: 200 });
   }
 
   const onExpand = (expanded, record) => {
@@ -116,6 +124,10 @@ const Demo = () => {
         <input {...expandIconPositionProps} />
         Change Expand Icon Position
       </label>
+      <label>
+        <input {...setFixExpand} />
+        Change Expand Icon Fixed
+      </label>
       <Table<RecordType>
         columns={columns}
         expandable={{
@@ -127,6 +139,7 @@ const Demo = () => {
           onExpand,
           rowExpandable,
           expandIconColumnIndex: expandIconPosition ? 1 : null,
+          fixed: fixExpand,
         }}
         scroll={{ x: fixColumns || scrollX ? 2000 : null, y: fixHeader ? 300 : null }}
         data={data}

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -382,7 +382,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
   const colWidths = React.useMemo(() => pureColWidths, [pureColWidths.join('_')]);
   const stickyOffsets = useStickyOffsets(colWidths, flattenColumns.length, direction);
   const fixHeader = scroll && validateValue(scroll.y);
-  const horizonScroll = scroll && validateValue(scroll.x);
+  const horizonScroll = (scroll && validateValue(scroll.x)) || expandableConfig.fixed;
   const fixColumn = horizonScroll && flattenColumns.some(({ fixed }) => fixed);
 
   // Sticky
@@ -530,7 +530,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     stickyOffsets,
     onHeaderRow,
     fixHeader,
-    scroll
+    scroll,
   };
 
   // Empty

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -382,7 +382,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
   const colWidths = React.useMemo(() => pureColWidths, [pureColWidths.join('_')]);
   const stickyOffsets = useStickyOffsets(colWidths, flattenColumns.length, direction);
   const fixHeader = scroll && validateValue(scroll.y);
-  const horizonScroll = (scroll && validateValue(scroll.x)) || expandableConfig.fixed;
+  const horizonScroll = (scroll && validateValue(scroll.x)) || Boolean(expandableConfig.fixed);
   const fixColumn = horizonScroll && flattenColumns.some(({ fixed }) => fixed);
 
   // Sticky

--- a/src/hooks/useColumns.tsx
+++ b/src/hooks/useColumns.tsx
@@ -153,7 +153,7 @@ function useColumns<RecordType>(
       let fixedColumn: FixedType | null;
       if ((fixed === 'left' || fixed) && !expandIconColumnIndex) {
         fixedColumn = 'left';
-      } else if (fixed === 'right' && expandIconColumnIndex === baseColumns.length) {
+      } else if ((fixed === 'right' || fixed) && expandIconColumnIndex === baseColumns.length) {
         fixedColumn = 'right';
       } else {
         fixedColumn = prevColumn ? prevColumn.fixed : null;

--- a/src/hooks/useColumns.tsx
+++ b/src/hooks/useColumns.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import warning from 'rc-util/lib/warning';
 import toArray from 'rc-util/lib/Children/toArray';
-import {
+import type {
   ColumnsType,
   ColumnType,
   FixedType,
@@ -120,6 +120,7 @@ function useColumns<RecordType>(
     direction,
     expandRowByClick,
     columnWidth,
+    fixed,
   }: {
     prefixCls?: string;
     columns?: ColumnsType<RecordType>;
@@ -134,6 +135,7 @@ function useColumns<RecordType>(
     direction?: 'ltr' | 'rtl';
     expandRowByClick?: boolean;
     columnWidth?: number | string;
+    fixed?: FixedType;
   },
   transformColumns: (columns: ColumnsType<RecordType>) => ColumnsType<RecordType>,
 ): [ColumnsType<RecordType>, readonly ColumnType<RecordType>[]] {
@@ -148,12 +150,21 @@ function useColumns<RecordType>(
       const expandColIndex = expandIconColumnIndex || 0;
       const prevColumn = baseColumns[expandColIndex];
 
+      let fixedColumn: FixedType | null;
+      if ((fixed === 'left' || fixed) && !expandIconColumnIndex) {
+        fixedColumn = 'left';
+      } else if (fixed === 'right' && expandIconColumnIndex === baseColumns.length) {
+        fixedColumn = 'right';
+      } else {
+        fixedColumn = prevColumn ? prevColumn.fixed : null;
+      }
+
       const expandColumn = {
         [INTERNAL_COL_DEFINE]: {
           className: `${prefixCls}-expand-icon-col`,
         },
         title: '',
-        fixed: prevColumn ? prevColumn.fixed : null,
+        fixed: fixedColumn,
         className: `${prefixCls}-row-expand-icon-cell`,
         width: columnWidth,
         render: (_, record, index) => {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 
 /**
  * ColumnType which applied in antd: https://ant.design/components/table-cn/#Column
@@ -89,7 +89,10 @@ export interface ColumnType<RecordType> extends ColumnSharedType<RecordType> {
   onCellClick?: (record: RecordType, e: React.MouseEvent<HTMLElement>) => void;
 }
 
-export type ColumnsType<RecordType = unknown> = readonly (ColumnGroupType<RecordType> | ColumnType<RecordType>)[];
+export type ColumnsType<RecordType = unknown> = readonly (
+  | ColumnGroupType<RecordType>
+  | ColumnType<RecordType>
+)[];
 
 export type GetRowKey<RecordType> = (record: RecordType, index?: number) => Key;
 
@@ -208,6 +211,7 @@ export interface ExpandableConfig<RecordType> {
   childrenColumnName?: string;
   rowExpandable?: (record: RecordType) => boolean;
   columnWidth?: number | string;
+  fixed?: FixedType;
 }
 
 // =================== Render ===================


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/29924

---
`expandable` 增加了 `fixed`
- 当设置 true 或 `left` 且 expandIconColumnIndex 没设置或为 0 时，即在最左边，开启 expandable icon fixed left
- 当设置 true 或 `right` 且 expandIconColumnIndex 设置 最大列数时，即在最右边，开启 expandable icon fixed right