### PR TITLE
Only trigger full table resize if width changes.

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -482,8 +482,10 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
   };
 
   const onFullTableResize = ({ width }) => {
-    triggerOnScroll();
-    setComponentWidth(fullTableRef.current ? fullTableRef.current.offsetWidth : width);
+    if (width !== componentWidth) {
+      triggerOnScroll();
+      setComponentWidth(fullTableRef.current ? fullTableRef.current.offsetWidth : width);
+    }
   };
 
   // Sync scroll bar when init or `horizonScroll` changed


### PR DESCRIPTION
Performance optimization: when only height is changed, don't trigger re-render.