### PR TITLE
fix: rm useless `min-width`

### DIFF
--- a/src/ColGroup.tsx
+++ b/src/ColGroup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ColumnType } from './interface';
+import type { ColumnType } from './interface';
 import { INTERNAL_COL_DEFINE } from './utils/legacyUtil';
 
 export interface ColGroupProps<RecordType> {
@@ -21,7 +21,7 @@ function ColGroup<RecordType>({ colWidths, columns, columCount }: ColGroupProps<
     const additionalProps = column && column[INTERNAL_COL_DEFINE];
 
     if (width || additionalProps || mustInsert) {
-      cols.unshift(<col key={i} style={{ width, minWidth: width }} {...additionalProps} />);
+      cols.unshift(<col key={i} style={{ width }} {...additionalProps} />);
       mustInsert = true;
     }
   }

--- a/tests/__snapshots__/FixedColumn.spec.js.snap
+++ b/tests/__snapshots__/FixedColumn.spec.js.snap
@@ -16,10 +16,10 @@ exports[`Table.FixedColumn fixed column renders correctly RTL 1`] = `
       >
         <colgroup>
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
           <col />
           <col />
@@ -31,7 +31,7 @@ exports[`Table.FixedColumn fixed column renders correctly RTL 1`] = `
           <col />
           <col />
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
         </colgroup>
         <thead
@@ -698,10 +698,10 @@ exports[`Table.FixedColumn fixed column renders correctly RTL 1`] = `
 exports[`Table.FixedColumn renders correctly all column has width should use it 1`] = `
 <colgroup>
   <col
-    style="width: 100px; min-width: 100px;"
+    style="width: 100px;"
   />
   <col
-    style="width: 100px; min-width: 100px;"
+    style="width: 100px;"
   />
 </colgroup>
 `;
@@ -722,10 +722,10 @@ exports[`Table.FixedColumn renders correctly scrollX - with data 1`] = `
       >
         <colgroup>
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
           <col />
           <col />
@@ -737,7 +737,7 @@ exports[`Table.FixedColumn renders correctly scrollX - with data 1`] = `
           <col />
           <col />
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
         </colgroup>
         <thead
@@ -1417,10 +1417,10 @@ exports[`Table.FixedColumn renders correctly scrollX - without data 1`] = `
       >
         <colgroup>
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
           <col />
           <col />
@@ -1432,7 +1432,7 @@ exports[`Table.FixedColumn renders correctly scrollX - without data 1`] = `
           <col />
           <col />
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
         </colgroup>
         <thead
@@ -1659,43 +1659,43 @@ exports[`Table.FixedColumn renders correctly scrollXY - with data 1`] = `
       >
         <colgroup>
           <col
-            style="width: 93px; min-width: 93px;"
+            style="width: 93px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 15px; min-width: 15px;"
+            style="width: 15px;"
           />
         </colgroup>
         <thead
@@ -1782,10 +1782,10 @@ exports[`Table.FixedColumn renders correctly scrollXY - with data 1`] = `
       >
         <colgroup>
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
           <col />
           <col />
@@ -1797,7 +1797,7 @@ exports[`Table.FixedColumn renders correctly scrollXY - with data 1`] = `
           <col />
           <col />
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
         </colgroup>
         <tbody
@@ -2408,43 +2408,43 @@ exports[`Table.FixedColumn renders correctly scrollXY - without data 1`] = `
       >
         <colgroup>
           <col
-            style="width: 93px; min-width: 93px;"
+            style="width: 93px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 15px; min-width: 15px;"
+            style="width: 15px;"
           />
         </colgroup>
         <thead
@@ -2531,10 +2531,10 @@ exports[`Table.FixedColumn renders correctly scrollXY - without data 1`] = `
       >
         <colgroup>
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
           <col />
           <col />
@@ -2546,7 +2546,7 @@ exports[`Table.FixedColumn renders correctly scrollXY - without data 1`] = `
           <col />
           <col />
           <col
-            style="width: 100px; min-width: 100px;"
+            style="width: 100px;"
           />
         </colgroup>
         <tbody

--- a/tests/__snapshots__/Table.spec.js.snap
+++ b/tests/__snapshots__/Table.spec.js.snap
@@ -211,13 +211,13 @@ exports[`Table.Basic custom components scroll content with scroll 1`] = `
       >
         <colgroup>
           <col
-            style="width: 0px; min-width: 0;"
+            style="width: 0px;"
           />
           <col
-            style="width: 888px; min-width: 888px;"
+            style="width: 888px;"
           />
           <col
-            style="width: 15px; min-width: 15px;"
+            style="width: 15px;"
           />
         </colgroup>
         <thead


### PR DESCRIPTION
Seems `min-width` never work as expect. Just remove it.

ref https://github.com/react-component/table/blame/35f7831f5d9f9e5569f509483493d88bc044f450/src/ColGroup.js#L33

resolve https://github.com/ant-design/ant-design/issues/30755

