### PR TITLE
change style 'maxHeight' to 'height'

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -402,7 +402,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
   if (fixHeader) {
     scrollYStyle = {
       overflowY: 'scroll',
-      maxHeight: scroll.y,
+      height: scroll.y,
     };
   }
 


### PR DESCRIPTION
```ts
if (fixHeader) {
    scrollYStyle = {
      overflowY: 'scroll',
      maxHeight: scroll.y,
    };
  }
```
if set `maxHeight`，when height of content is smaller than 'scroll.y'，`pagination` will placed at the bottom of table，but i think most of user want to  place `pagination` into bottom of container which we set by 'scroll.y'
