### PR TITLE
fix: read property getBoundingClientRect of null when unmount

### DIFF
--- a/src/stickyScrollBar.tsx
+++ b/src/stickyScrollBar.tsx
@@ -80,6 +80,9 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
   };
 
   const onContainerScroll = () => {
+    if (!scrollBodyRef.current) {
+      return;
+    }
     const tableOffsetTop = getOffset(scrollBodyRef.current).top;
     const tableBottomOffset = tableOffsetTop + scrollBodyRef.current.offsetHeight;
     const currentClientOffset =


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18572962/130894444-2c081262-00c2-418f-86c6-5f48fedd7b18.png)

经调查，出现在离开页面，组件卸载且页面出现滚动重置时，getOffset 参数会为 null