### PR TITLE
fix: throw error when clicking row with no set onClick in onRow

### DIFF
--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -99,7 +99,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
       onInternalTriggerExpand(record, event);
     }
 
-    additionalProps?.onClick(event, ...args);
+    additionalProps?.onClick?.(event, ...args);
   };
 
   // ======================== Base tr row ========================

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -446,6 +446,7 @@ describe('Table.Basic', () => {
       expect(wrapper.find('tbody tr').length).toBeTruthy();
       wrapper.find('tbody tr').forEach((tr, index) => {
         expect(tr.props().id).toEqual(`row-${data[index].key}`);
+        expect(tr.simulate.bind(tr, 'click')).not.toThrowError();
       });
     });
 


### PR DESCRIPTION
fix ant-design/ant-design#32892