### PR TITLE
perf: improve performance when table resized

### DIFF
--- a/docs/demo/fixedColumns-resize.md
+++ b/docs/demo/fixedColumns-resize.md
@@ -1,0 +1,3 @@
+## fixedColumns-resize
+
+<code src="../examples/fixedColumns-resize.tsx">

--- a/docs/examples/fixedColumns-resize.tsx
+++ b/docs/examples/fixedColumns-resize.tsx
@@ -1,0 +1,95 @@
+import React, { useState, useCallback } from 'react';
+import Table from 'rc-table';
+import '../../assets/index.less';
+import type { ColumnType } from '@/interface';
+
+interface RecordType {
+  a: string;
+  b?: string;
+  c?: string;
+  d: number;
+  key: string;
+}
+
+const columns: ColumnType<RecordType>[] = [
+  { title: 'title1', dataIndex: 'a', key: 'a', width: 100, fixed: 'left' },
+  { title: 'title2', dataIndex: 'b', key: 'b', width: 100, fixed: 'left', ellipsis: true },
+  { title: 'title3', dataIndex: 'c', key: 'c' },
+  { title: 'title4', dataIndex: 'b', key: 'd' },
+  { title: 'title5', dataIndex: 'b', key: 'e' },
+  { title: 'title6', dataIndex: 'b', key: 'f' },
+  { title: 'title8', dataIndex: 'b', key: 'h' },
+  { title: 'title9', dataIndex: 'b', key: 'i' },
+  { title: 'title11', dataIndex: 'b', key: 'j' },
+  { title: 'title12', dataIndex: 'b', key: 'j1' },
+  { title: 'title13', dataIndex: 'b', key: 'j2' },
+  { title: 'title14', dataIndex: 'b', key: 'j3' },
+  { title: 'title15', dataIndex: 'b', key: 'j4' },
+  { title: 'title16', dataIndex: 'b', key: 'j5' },
+  { title: 'title17', dataIndex: 'b', key: 'j6' },
+  { title: 'title18', dataIndex: 'b', key: 'j7' },
+  { title: 'title19', dataIndex: 'b', key: 'k', width: 50, fixed: 'right' },
+  { title: 'title20', dataIndex: 'b', key: 'l', width: 100, fixed: 'right' },
+];
+
+const data: RecordType[] = Array.from(new Array(200).fill(1), (v, index) => {
+  return {
+    a: '123',
+    b: 'xxxxx',
+    d: 3,
+    key: index + '',
+  };
+});
+
+const Demo = () => {
+  const [isShown, setIsShown] = useState(false);
+  const [renderTime, setRenderTime] = useState(0);
+  const [isFixed, setIsFixed] = useState(true);
+  const onToggleSideBar = useCallback(() => {
+    const s = window.performance.now();
+    setIsShown(v => !v);
+
+    setTimeout(() => {
+      setRenderTime(+(window.performance.now() - s).toFixed(2));
+    });
+  }, []);
+
+  const onToggleFixed = useCallback(() => {
+    setIsFixed(v => !v);
+  }, []);
+
+  const expandedRowRender = useCallback(({ b, c }) => b || c, []);
+
+  return (
+    <div>
+      <div>
+        <button onClick={onToggleSideBar}>切换侧边栏展开状态</button>
+        <button onClick={onToggleFixed}>切换固定列</button>
+        <p>更新用时：{renderTime} ms</p>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          width: '800px',
+          resize: 'both',
+          padding: '12px',
+          border: '1px solid #333',
+          height: '80vh',
+          overflow: 'auto',
+        }}
+      >
+        <div style={{ flex: `0 0 ${isShown ? '10px' : '80px'}` }} />
+        <div style={{ flex: 1, overflow: 'hidden' }}>
+          <Table
+            columns={columns}
+            scroll={isFixed ? { x: 1200 } : null}
+            data={data}
+            expandedRowRender={expandedRowRender}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Demo;

--- a/docs/examples/fixedColumns-resize.tsx
+++ b/docs/examples/fixedColumns-resize.tsx
@@ -11,7 +11,7 @@ interface RecordType {
   key: string;
 }
 
-const columns: ColumnType<RecordType>[] = [
+const defaultColumns: ColumnType<RecordType>[] = [
   { title: 'title1', dataIndex: 'a', key: 'a', width: 100, fixed: 'left' },
   { title: 'title2', dataIndex: 'b', key: 'b', width: 100, fixed: 'left', ellipsis: true },
   { title: 'title3', dataIndex: 'c', key: 'c' },
@@ -45,17 +45,43 @@ const Demo = () => {
   const [isShown, setIsShown] = useState(false);
   const [renderTime, setRenderTime] = useState(0);
   const [isFixed, setIsFixed] = useState(true);
+  const [columns, setColumns] = useState(defaultColumns);
   const onToggleSideBar = useCallback(() => {
     const s = window.performance.now();
     setIsShown(v => !v);
 
     setTimeout(() => {
-      setRenderTime(+(window.performance.now() - s).toFixed(2));
+      setTimeout(() => {
+        setRenderTime(+(window.performance.now() - s).toFixed(2));
+      });
     });
   }, []);
 
   const onToggleFixed = useCallback(() => {
     setIsFixed(v => !v);
+  }, []);
+
+  const onRemoveColumn = useCallback(() => {
+    setColumns(state => {
+      const newState = [...state];
+      newState.splice(
+        state.findIndex(({ fixed }) => !fixed),
+        1,
+      );
+      return newState;
+    });
+  }, []);
+
+  const onAddColumn = useCallback(() => {
+    setColumns(state => {
+      const newState = [...state];
+      newState.splice(
+        state.findIndex(({ fixed }) => !fixed),
+        0,
+        { title: 'new title', dataIndex: 'b', key: Math.random().toString(16).slice(2) },
+      );
+      return newState;
+    });
   }, []);
 
   const expandedRowRender = useCallback(({ b, c }) => b || c, []);
@@ -65,6 +91,8 @@ const Demo = () => {
       <div>
         <button onClick={onToggleSideBar}>切换侧边栏展开状态</button>
         <button onClick={onToggleFixed}>切换固定列</button>
+        <button onClick={onRemoveColumn}>删除列</button>
+        <button onClick={onAddColumn}>增加列</button>
         <p>更新用时：{renderTime} ms</p>
       </div>
       <div
@@ -82,7 +110,7 @@ const Demo = () => {
         <div style={{ flex: 1, overflow: 'hidden' }}>
           <Table
             columns={columns}
-            scroll={isFixed ? { x: 1200 } : null}
+            scroll={isFixed ? { x: 800 } : null}
             data={data}
             expandedRowRender={expandedRowRender}
           />

--- a/docs/examples/fixedColumns-resize.tsx
+++ b/docs/examples/fixedColumns-resize.tsx
@@ -51,9 +51,7 @@ const Demo = () => {
     setIsShown(v => !v);
 
     setTimeout(() => {
-      setTimeout(() => {
-        setRenderTime(+(window.performance.now() - s).toFixed(2));
-      });
+      setRenderTime(+(window.performance.now() - s).toFixed(2));
     });
   }, []);
 
@@ -110,7 +108,7 @@ const Demo = () => {
         <div style={{ flex: 1, overflow: 'hidden' }}>
           <Table
             columns={columns}
-            scroll={isFixed ? { x: 800 } : null}
+            scroll={isFixed ? { x: 1200 } : null}
             data={data}
             expandedRowRender={expandedRowRender}
           />

--- a/package.json
+++ b/package.json
@@ -55,8 +55,10 @@
   "dependencies": {
     "@babel/runtime": "^7.10.1",
     "classnames": "^2.2.5",
+    "lodash.debounce": "^4.0.8",
     "rc-resize-observer": "^1.0.0",
     "rc-util": "^5.14.0",
+    "resize-observer-polyfill": "^1.5.1",
     "shallowequal": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -55,10 +55,9 @@
   "dependencies": {
     "@babel/runtime": "^7.10.1",
     "classnames": "^2.2.5",
-    "lodash.debounce": "^4.0.8",
+    "lodash": "^4.17.21",
     "rc-resize-observer": "^1.0.0",
     "rc-util": "^5.14.0",
-    "resize-observer-polyfill": "^1.5.1",
     "shallowequal": "^1.1.0"
   },
   "devDependencies": {

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -49,10 +49,6 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
   } = props;
   const { prefixCls, fixedInfoList } = React.useContext(TableContext);
   const {
-    fixHeader,
-    fixColumn,
-    horizonScroll,
-    componentWidth,
     flattenColumns,
     expandableType,
     expandRowByClick,
@@ -197,11 +193,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
           computedExpandedRowClassName,
         )}
         prefixCls={prefixCls}
-        fixHeader={fixHeader}
-        fixColumn={fixColumn}
-        horizonScroll={horizonScroll}
         component={RowComponent}
-        componentWidth={componentWidth}
         cellComponent={cellComponent}
         colSpan={flattenColumns.length}
       >

--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import type { CustomizeComponent } from '../interface';
 import Cell from '../Cell';
 import TableContext from '../context/TableContext';
-import ExpandedRowContext from '@/context/ExpandedRowContext';
+import ExpandedRowContext from '../context/ExpandedRowContext';
 
 export interface ExpandedRowProps {
   prefixCls: string;

--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -1,16 +1,13 @@
 import * as React from 'react';
-import { CustomizeComponent } from '../interface';
+import type { CustomizeComponent } from '../interface';
 import Cell from '../Cell';
 import TableContext from '../context/TableContext';
+import ExpandedRowContext from '@/context/ExpandedRowContext';
 
 export interface ExpandedRowProps {
   prefixCls: string;
   component: CustomizeComponent;
   cellComponent: CustomizeComponent;
-  fixHeader: boolean;
-  fixColumn: boolean;
-  horizonScroll: boolean;
-  componentWidth: number;
   className: string;
   expanded: boolean;
   children: React.ReactNode;
@@ -22,15 +19,12 @@ function ExpandedRow({
   children,
   component: Component,
   cellComponent,
-  fixHeader,
-  fixColumn,
-  horizonScroll,
   className,
   expanded,
-  componentWidth,
   colSpan,
 }: ExpandedRowProps) {
   const { scrollbarSize } = React.useContext(TableContext);
+  const { fixHeader, fixColumn, componentWidth } = React.useContext(ExpandedRowContext);
 
   // Cache render node
   return React.useMemo(() => {
@@ -67,13 +61,15 @@ function ExpandedRow({
   }, [
     children,
     Component,
+    fixColumn,
     fixHeader,
-    horizonScroll,
     className,
     expanded,
     componentWidth,
     colSpan,
     scrollbarSize,
+    cellComponent,
+    prefixCls,
   ]);
 }
 

--- a/src/Body/MeasureCell.tsx
+++ b/src/Body/MeasureCell.tsx
@@ -1,39 +1,24 @@
+import type { IColumnResizeObserver } from '../hooks/useColumnResizeObserver';
+import { useObserveElement } from '../hooks/useColumnResizeObserver';
 import * as React from 'react';
 
 export interface MeasureCellProps {
   columnKey: React.Key;
-  columnResizeObserver;
+  columnResizeObserver: IColumnResizeObserver<React.Key>;
 }
 
 export default function MeasureCell({ columnKey, columnResizeObserver }: MeasureCellProps) {
-  const cellRef = React.useRef<HTMLTableDataCellElement>();
-  const lastCellRef = React.useRef<HTMLTableDataCellElement>();
+  const [cellRef] = useObserveElement(columnResizeObserver, columnKey);
 
   React.useEffect(() => {
-    if (lastCellRef.current !== cellRef.current) {
-      if (lastCellRef.current) {
-        columnResizeObserver.unobserve(lastCellRef.current);
-      }
-      if (cellRef.current) {
-        columnResizeObserver.observe(cellRef.current, {
-          columnKey,
-        });
-      }
-
-      lastCellRef.current = cellRef.current;
-    }
-  });
-
-  React.useEffect(() => {
-    return () => {
-      if (lastCellRef.current) {
-        columnResizeObserver.unobserve(lastCellRef.current);
-      }
-    };
+    columnResizeObserver.trigger({ offsetWidth: cellRef.current.offsetWidth }, columnKey);
   }, []);
 
   return (
-    <td ref={cellRef} style={{ padding: 0, border: 0, height: 0 }}>
+    <td
+      ref={cellRef as React.RefObject<HTMLTableDataCellElement>}
+      style={{ padding: 0, border: 0, height: 0 }}
+    >
       <div style={{ height: 0, overflow: 'hidden' }}>&nbsp;</div>
     </td>
   );

--- a/src/Body/MeasureCell.tsx
+++ b/src/Body/MeasureCell.tsx
@@ -1,29 +1,40 @@
 import * as React from 'react';
-import ResizeObserver from 'rc-resize-observer';
 
 export interface MeasureCellProps {
   columnKey: React.Key;
-  onColumnResize: (key: React.Key, width: number) => void;
+  columnResizeObserver;
 }
 
-export default function MeasureCell({ columnKey, onColumnResize }: MeasureCellProps) {
+export default function MeasureCell({ columnKey, columnResizeObserver }: MeasureCellProps) {
   const cellRef = React.useRef<HTMLTableDataCellElement>();
+  const lastCellRef = React.useRef<HTMLTableDataCellElement>();
 
   React.useEffect(() => {
-    if (cellRef.current) {
-      onColumnResize(columnKey, cellRef.current.offsetWidth);
+    if (lastCellRef.current !== cellRef.current) {
+      if (lastCellRef.current) {
+        columnResizeObserver.unobserve(lastCellRef.current);
+      }
+      if (cellRef.current) {
+        columnResizeObserver.observe(cellRef.current, {
+          columnKey,
+        });
+      }
+
+      lastCellRef.current = cellRef.current;
     }
+  });
+
+  React.useEffect(() => {
+    return () => {
+      if (lastCellRef.current) {
+        columnResizeObserver.unobserve(lastCellRef.current);
+      }
+    };
   }, []);
 
   return (
-    <ResizeObserver
-      onResize={({ offsetWidth }) => {
-        onColumnResize(columnKey, offsetWidth);
-      }}
-    >
-      <td ref={cellRef} style={{ padding: 0, border: 0, height: 0 }}>
-        <div style={{ height: 0, overflow: 'hidden' }}>&nbsp;</div>
-      </td>
-    </ResizeObserver>
+    <td ref={cellRef} style={{ padding: 0, border: 0, height: 0 }}>
+      <div style={{ height: 0, overflow: 'hidden' }}>&nbsp;</div>
+    </td>
   );
 }

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -35,8 +35,7 @@ function Body<RecordType>({
   const [endRow, setEndRow] = React.useState(-1);
   const { onColumnResize } = React.useContext(ResizeContext);
   const { prefixCls, getComponent } = React.useContext(TableContext);
-  const { fixHeader, horizonScroll, flattenColumns, componentWidth } =
-    React.useContext(BodyContext);
+  const { flattenColumns } = React.useContext(BodyContext);
 
   const flattenData: { record: RecordType; indent: number }[] = useFlattenRecords<RecordType>(
     data,
@@ -91,11 +90,7 @@ function Body<RecordType>({
           expanded
           className={`${prefixCls}-placeholder`}
           prefixCls={prefixCls}
-          fixHeader={fixHeader}
-          fixColumn={horizonScroll}
-          horizonScroll={horizonScroll}
           component={trComponent}
-          componentWidth={componentWidth}
           cellComponent={tdComponent}
           colSpan={flattenColumns.length}
         >
@@ -138,12 +133,9 @@ function Body<RecordType>({
     expandedKeys,
     getRowKey,
     getComponent,
-    componentWidth,
     emptyNode,
     flattenColumns,
     childrenColumnName,
-    fixHeader,
-    horizonScroll,
     onColumnResize,
     rowExpandable,
     flattenData,

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -33,7 +33,7 @@ function Body<RecordType>({
 }: BodyProps<RecordType>) {
   const [startRow, setStartRow] = React.useState(-1);
   const [endRow, setEndRow] = React.useState(-1);
-  const { onColumnResize } = React.useContext(ResizeContext);
+  const { columnResizeObserver } = React.useContext(ResizeContext);
   const { prefixCls, getComponent } = React.useContext(TableContext);
   const { flattenColumns } = React.useContext(BodyContext);
 
@@ -115,7 +115,7 @@ function Body<RecordType>({
                 <MeasureCell
                   key={columnKey}
                   columnKey={columnKey}
-                  onColumnResize={onColumnResize}
+                  columnResizeObserver={columnResizeObserver}
                 />
               ))}
             </tr>
@@ -136,7 +136,7 @@ function Body<RecordType>({
     emptyNode,
     flattenColumns,
     childrenColumnName,
-    onColumnResize,
+    columnResizeObserver,
     rowExpandable,
     flattenData,
     hoverContext,

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -436,8 +436,8 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     };
   }
 
-  const onColumnResize = React.useCallback(({ offsetWidth }, { columnKey }) => {
-    if (isVisible(fullTableRef.current)) {
+  const onColumnResize = React.useCallback(({ offsetWidth }, { columnKey } = {}) => {
+    if (isVisible(fullTableRef.current) && columnKey) {
       updateColsWidths(widths => {
         if (widths.get(columnKey) !== offsetWidth) {
           const newWidths = new Map(widths);

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -436,7 +436,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     };
   }
 
-  const onColumnResize = React.useCallback(({ offsetWidth }, { columnKey } = {}) => {
+  const onColumnResize = React.useCallback(({ offsetWidth }, columnKey) => {
     if (isVisible(fullTableRef.current) && columnKey) {
       updateColsWidths(widths => {
         if (widths.get(columnKey) !== offsetWidth) {
@@ -448,9 +448,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       });
     }
   }, []);
-  const columnResizeObserver = useColumnResizeObserver<{
-    columnKey: React.Key;
-  }>(onColumnResize);
+  const columnResizeObserver = useColumnResizeObserver<React.Key>(onColumnResize);
 
   const [setScrollTarget, getScrollTarget] = useTimeoutLock(null);
 

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -60,7 +60,7 @@ import TableContext from './context/TableContext';
 import BodyContext from './context/BodyContext';
 import Body from './Body';
 import useColumns from './hooks/useColumns';
-import { useLayoutState, useTimeoutLock } from './hooks/useFrame';
+import { useDelayState, useTimeoutLock } from './hooks/useFrame';
 import { getPathValue, mergeObject, validateValue, getColumnsKey } from './utils/valueUtil';
 import ResizeContext from './context/ResizeContext';
 import useStickyOffsets from './hooks/useStickyOffsets';
@@ -76,6 +76,7 @@ import FixedHolder from './FixedHolder';
 import type { SummaryProps } from './Footer/Summary';
 import Summary from './Footer/Summary';
 import StickyContext from './context/StickyContext';
+import ExpandedRowContext from './context/ExpandedRowContext';
 
 // Used for conditions cache
 const EMPTY_DATA = [];
@@ -384,7 +385,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
   const scrollSummaryRef = React.useRef<HTMLDivElement>();
   const [pingedLeft, setPingedLeft] = React.useState(false);
   const [pingedRight, setPingedRight] = React.useState(false);
-  const [colsWidths, updateColsWidths] = useLayoutState(new Map<React.Key, number>());
+  const [colsWidths, updateColsWidths] = useDelayState(new Map<React.Key, number>());
 
   // Convert map to number width
   const colsKeys = getColumnsKey(flattenColumns);
@@ -805,10 +806,6 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       tableLayout: mergedTableLayout,
       rowClassName,
       expandedRowClassName,
-      componentWidth,
-      fixHeader,
-      fixColumn,
-      horizonScroll,
       expandIcon: mergedExpandIcon,
       expandableType,
       expandRowByClick,
@@ -822,10 +819,6 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       mergedTableLayout,
       rowClassName,
       expandedRowClassName,
-      componentWidth,
-      fixHeader,
-      fixColumn,
-      horizonScroll,
       mergedExpandIcon,
       expandableType,
       expandRowByClick,
@@ -836,13 +829,25 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     ],
   );
 
+  const ExpandedRowContextValue = React.useMemo(
+    () => ({
+      componentWidth,
+      fixHeader,
+      fixColumn,
+      horizonScroll,
+    }),
+    [componentWidth, fixHeader, fixColumn, horizonScroll],
+  );
+
   const ResizeContextValue = React.useMemo(() => ({ onColumnResize }), [onColumnResize]);
 
   return (
     <StickyContext.Provider value={supportSticky}>
       <TableContext.Provider value={TableContextValue}>
         <BodyContext.Provider value={BodyContextValue}>
-          <ResizeContext.Provider value={ResizeContextValue}>{fullTable}</ResizeContext.Provider>
+          <ExpandedRowContext.Provider value={ExpandedRowContextValue}>
+            <ResizeContext.Provider value={ResizeContextValue}>{fullTable}</ResizeContext.Provider>
+          </ExpandedRowContext.Provider>
         </BodyContext.Provider>
       </TableContext.Provider>
     </StickyContext.Provider>

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -834,9 +834,8 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       componentWidth,
       fixHeader,
       fixColumn,
-      horizonScroll,
     }),
-    [componentWidth, fixHeader, fixColumn, horizonScroll],
+    [componentWidth, fixHeader, fixColumn],
   );
 
   const ResizeContextValue = React.useMemo(() => ({ onColumnResize }), [onColumnResize]);

--- a/src/context/BodyContext.tsx
+++ b/src/context/BodyContext.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {
+import type {
   ColumnType,
   DefaultRecordType,
   ColumnsType,
@@ -18,11 +18,7 @@ export interface BodyContextProps<RecordType = DefaultRecordType> {
   columns: ColumnsType<RecordType>;
   flattenColumns: readonly ColumnType<RecordType>[];
 
-  componentWidth: number;
   tableLayout: TableLayout;
-  fixHeader: boolean;
-  fixColumn: boolean;
-  horizonScroll: boolean;
 
   indentSize: number;
   expandableType: ExpandableType;

--- a/src/context/ExpandedRowContext.tsx
+++ b/src/context/ExpandedRowContext.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export interface ExpandedRowProps {
+  componentWidth: number;
+  fixHeader: boolean;
+  fixColumn: boolean;
+}
+
+const ExpandedRowContext = React.createContext<ExpandedRowProps>(null);
+
+export default ExpandedRowContext;

--- a/src/context/ResizeContext.tsx
+++ b/src/context/ResizeContext.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import type useColumnResizeObserver from '../hooks/useColumnResizeObserver';
 
 interface ResizeContextProps {
-  onColumnResize: (columnKey: React.Key, width: number) => void;
+  columnResizeObserver: ReturnType<typeof useColumnResizeObserver>;
 }
 
 const ResizeContext = React.createContext<ResizeContextProps>(null);

--- a/src/context/ResizeContext.tsx
+++ b/src/context/ResizeContext.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import type useColumnResizeObserver from '../hooks/useColumnResizeObserver';
+import type { IColumnResizeObserver } from '../hooks/useColumnResizeObserver';
 
 interface ResizeContextProps {
-  columnResizeObserver: ReturnType<typeof useColumnResizeObserver>;
+  columnResizeObserver: IColumnResizeObserver<React.Key>;
 }
 
 const ResizeContext = React.createContext<ResizeContextProps>(null);

--- a/src/hooks/useColumnResizeObserver.ts
+++ b/src/hooks/useColumnResizeObserver.ts
@@ -1,0 +1,63 @@
+import React from 'react';
+
+interface ISize {
+  width: number;
+  height: number;
+  offsetWidth: number;
+  offsetHeight: number;
+}
+type ResizeCallback<T> = (size: ISize, info: T) => void;
+
+export default function useColumnResizeObserver<T>(onResize: ResizeCallback<T>): {
+  observe: (el: Element, info: T) => void;
+  unobserve: (el: Element) => void;
+} {
+  const resizeObserverRef = React.useRef<ResizeObserver>(null);
+  const targetInfoRef = React.useRef(new WeakMap<Element, T>());
+
+  if (!resizeObserverRef.current) {
+    resizeObserverRef.current = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const target = entry.target;
+        const { width, height } = target.getBoundingClientRect();
+        const { offsetWidth, offsetHeight } = target;
+
+        /**
+         * Resize observer trigger when content size changed.
+         * In most case we just care about element size,
+         * let's use `boundary` instead of `contentRect` here to avoid shaking.
+         */
+        const fixedWidth = Math.floor(width);
+        const fixedHeight = Math.floor(height);
+
+        const size = { width: fixedWidth, height: fixedHeight, offsetWidth, offsetHeight };
+        if (onResize) {
+          const mergedOffsetWidth = offsetWidth === Math.round(width) ? width : offsetWidth;
+          const mergedOffsetHeight = offsetHeight === Math.round(height) ? height : offsetHeight;
+          Promise.resolve().then(() => {
+            onResize(
+              {
+                ...size,
+                offsetWidth: mergedOffsetWidth,
+                offsetHeight: mergedOffsetHeight,
+              },
+              targetInfoRef.current.get(target),
+            );
+          });
+        }
+      }
+    });
+  }
+
+  const observe = (el: Element, info) => {
+    resizeObserverRef.current.observe(el);
+    targetInfoRef.current.set(el, info);
+  };
+
+  const unobserve = (el: Element) => {
+    resizeObserverRef.current.unobserve(el);
+    targetInfoRef.current.delete(el);
+  };
+
+  return React.useMemo(() => ({ observe, unobserve }), []);
+}

--- a/src/hooks/useColumnResizeObserver.ts
+++ b/src/hooks/useColumnResizeObserver.ts
@@ -1,4 +1,6 @@
 import React from 'react';
+import ResizeObserver from 'resize-observer-polyfill';
+import debounce from 'lodash.debounce';
 
 interface ISize {
   width: number;
@@ -6,103 +8,130 @@ interface ISize {
   offsetWidth: number;
   offsetHeight: number;
 }
-type ResizeCallback<T> = (size: ISize, info: T) => void;
 
-// leading one will execute at once, without delay to next task.
-function useDebounceCallback(callback, interval = 0) {
-  const lastCheckTimeRef = React.useRef(0);
-  const finalTimerRef = React.useRef<number>();
-
-  const debouncedCallback = React.useCallback(() => {
-    function control() {
-      const currentTime = window.performance?.now?.() ?? window.Date.now();
-      const isReachIntervalTime = currentTime - lastCheckTimeRef.current >= interval;
-
-      if (isReachIntervalTime) {
-        // reserve re-computed and re-render time, avoid continuous triggering。
-        lastCheckTimeRef.current = currentTime + 5000;
-        callback();
-        cleanUpTimer();
-      } else {
-        lastCheckTimeRef.current = currentTime;
-        cleanUpTimer();
-        finalTimerRef.current = window.setTimeout(() => {
-          control();
-        }, interval);
-      }
-    }
-
-    function cleanUpTimer() {
-      if (finalTimerRef.current) {
-        clearTimeout(finalTimerRef.current);
-        finalTimerRef.current = null;
-      }
-    }
-
-    control();
-  }, []);
-
-  return debouncedCallback;
-}
-
-export default function useColumnResizeObserver<T>(onResize: ResizeCallback<T>): {
+export interface IColumnResizeObserver<T> {
   observe: (el: HTMLElement, info: T) => void;
   unobserve: (el: HTMLElement) => void;
-} {
+  trigger: (size: Partial<ISize>, info: T) => void;
+}
+
+function getDebounceWithCache(callback, ...debounceParams) {
+  const cache = new Set();
+
+  const debounced = debounce(function () {
+    callback(cache);
+    cache.clear();
+  }, ...debounceParams);
+
+  return items => {
+    items.forEach(item => cache.add(item));
+    debounced();
+  };
+}
+
+type ResizeCallback<T> = (size: ISize, info: T) => void;
+export default function useColumnResizeObserver<T>(
+  onResize: ResizeCallback<T>,
+): IColumnResizeObserver<T> {
   const resizeObserverRef = React.useRef<ResizeObserver>(null);
   const targetInfoRef = React.useRef(new WeakMap<HTMLElement, T>());
-  const resizedTargetSetRef = React.useRef(new Set<HTMLElement>());
-
-  const resizeCallback = function () {
-    for (const target of resizedTargetSetRef.current) {
-      const { width, height } = target.getBoundingClientRect();
-      const { offsetWidth, offsetHeight } = target;
-
-      /**
-       * Resize observer trigger when content size changed.
-       * In most case we just care about HTMLElement size,
-       * let's use `boundary` instead of `contentRect` here to avoid shaking.
-       */
-      const fixedWidth = Math.floor(width);
-      const fixedHeight = Math.floor(height);
-
-      const size = { width: fixedWidth, height: fixedHeight, offsetWidth, offsetHeight };
-      if (onResize) {
-        const mergedOffsetWidth = offsetWidth === Math.round(width) ? width : offsetWidth;
-        const mergedOffsetHeight = offsetHeight === Math.round(height) ? height : offsetHeight;
-        Promise.resolve().then(() => {
-          onResize(
-            {
-              ...size,
-              offsetWidth: mergedOffsetWidth,
-              offsetHeight: mergedOffsetHeight,
-            },
-            targetInfoRef.current.get(target),
-          );
-        });
-      }
-    }
-    resizedTargetSetRef.current.clear();
-  };
-  const debouncedResizeCallback = useDebounceCallback(resizeCallback, 1200);
+  // for onResize update
+  const onResizeRef = React.useRef<ResizeCallback<T>>();
+  onResizeRef.current = onResize;
 
   if (!resizeObserverRef.current) {
+    const resizeCallback = function (targetSet) {
+      for (const target of targetSet) {
+        const { width, height } = target.getBoundingClientRect();
+        const { offsetWidth, offsetHeight } = target;
+
+        /**
+         * Resize observer trigger when content size changed.
+         * In most case we just care about HTMLElement size,
+         * let's use `boundary` instead of `contentRect` here to avoid shaking.
+         */
+        const fixedWidth = Math.floor(width);
+        const fixedHeight = Math.floor(height);
+
+        const size = { width: fixedWidth, height: fixedHeight, offsetWidth, offsetHeight };
+        if (onResizeRef.current) {
+          const mergedOffsetWidth = offsetWidth === Math.round(width) ? width : offsetWidth;
+          const mergedOffsetHeight = offsetHeight === Math.round(height) ? height : offsetHeight;
+          Promise.resolve().then(() => {
+            onResizeRef.current(
+              {
+                ...size,
+                offsetWidth: mergedOffsetWidth,
+                offsetHeight: mergedOffsetHeight,
+              },
+              targetInfoRef.current.get(target),
+            );
+          });
+        }
+      }
+    };
+    const debouncedCallback = getDebounceWithCache(resizeCallback, 1200, {
+      leading: true,
+      trailing: true,
+    });
+
     resizeObserverRef.current = new ResizeObserver(entries => {
-      entries.map(({ target }) => resizedTargetSetRef.current.add(target));
-      // handle continuous resizing,
-      debouncedResizeCallback();
+      debouncedCallback(entries.map(entry => entry.target));
     });
   }
 
-  const observe = (el: HTMLElement, info) => {
-    resizeObserverRef.current.observe(el);
-    targetInfoRef.current.set(el, info);
-  };
+  return React.useMemo(() => {
+    return {
+      observe: (el: HTMLElement, info) => {
+        resizeObserverRef.current.observe(el);
+        targetInfoRef.current.set(el, info);
+      },
+      unobserve: (el: HTMLElement) => {
+        resizeObserverRef.current.unobserve(el);
+        targetInfoRef.current.delete(el);
+      },
+      trigger: (size, info) => {
+        onResizeRef.current(
+          Object.assign(
+            {
+              width: 0,
+              height: 0,
+              offsetWidth: 0,
+              offsetHeight: 0,
+            },
+            size,
+          ),
+          info,
+        );
+      },
+    };
+  }, []);
+}
 
-  const unobserve = (el: HTMLElement) => {
-    resizeObserverRef.current.unobserve(el);
-    targetInfoRef.current.delete(el);
-  };
+export function useObserveElement<T>(columnResizeObserver: IColumnResizeObserver<T>, info: T) {
+  const lastCellRef = React.useRef<HTMLElement>(null);
+  const cellRef = React.useRef<HTMLElement>(null);
 
-  return React.useMemo(() => ({ observe, unobserve }), []);
+  React.useEffect(() => {
+    if (lastCellRef.current !== cellRef.current) {
+      if (lastCellRef.current) {
+        columnResizeObserver.unobserve(lastCellRef.current);
+      }
+      if (cellRef.current) {
+        columnResizeObserver.observe(cellRef.current, info);
+      }
+
+      lastCellRef.current = cellRef.current;
+    }
+  });
+
+  React.useEffect(() => {
+    return () => {
+      if (lastCellRef.current) {
+        columnResizeObserver.unobserve(lastCellRef.current);
+      }
+    };
+  }, []);
+
+  return [cellRef];
 }

--- a/src/hooks/useColumnResizeObserver.ts
+++ b/src/hooks/useColumnResizeObserver.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import ResizeObserver from 'resize-observer-polyfill';
-import debounce from 'lodash.debounce';
+import { debounce } from 'lodash';
 
 interface ISize {
   width: number;

--- a/src/hooks/useColumnResizeObserver.ts
+++ b/src/hooks/useColumnResizeObserver.ts
@@ -8,53 +8,98 @@ interface ISize {
 }
 type ResizeCallback<T> = (size: ISize, info: T) => void;
 
+// leading one will execute at once, without delay to next task.
+function useDebounceCallback(callback, interval = 0) {
+  const lastCheckTimeRef = React.useRef(0);
+  const finalTimerRef = React.useRef<number>();
+
+  const debouncedCallback = React.useCallback(() => {
+    function control() {
+      const currentTime = window.performance?.now?.() ?? window.Date.now();
+      const isReachIntervalTime = currentTime - lastCheckTimeRef.current >= interval;
+
+      if (isReachIntervalTime) {
+        // reserve re-computed and re-render time, avoid continuous triggering。
+        lastCheckTimeRef.current = currentTime + 5000;
+        callback();
+        cleanUpTimer();
+      } else {
+        lastCheckTimeRef.current = currentTime;
+        cleanUpTimer();
+        finalTimerRef.current = window.setTimeout(() => {
+          control();
+        }, interval);
+      }
+    }
+
+    function cleanUpTimer() {
+      if (finalTimerRef.current) {
+        clearTimeout(finalTimerRef.current);
+        finalTimerRef.current = null;
+      }
+    }
+
+    control();
+  }, []);
+
+  return debouncedCallback;
+}
+
 export default function useColumnResizeObserver<T>(onResize: ResizeCallback<T>): {
-  observe: (el: Element, info: T) => void;
-  unobserve: (el: Element) => void;
+  observe: (el: HTMLElement, info: T) => void;
+  unobserve: (el: HTMLElement) => void;
 } {
   const resizeObserverRef = React.useRef<ResizeObserver>(null);
-  const targetInfoRef = React.useRef(new WeakMap<Element, T>());
+  const targetInfoRef = React.useRef(new WeakMap<HTMLElement, T>());
+  const resizedTargetSetRef = React.useRef(new Set<HTMLElement>());
+
+  const resizeCallback = function () {
+    for (const target of resizedTargetSetRef.current) {
+      const { width, height } = target.getBoundingClientRect();
+      const { offsetWidth, offsetHeight } = target;
+
+      /**
+       * Resize observer trigger when content size changed.
+       * In most case we just care about HTMLElement size,
+       * let's use `boundary` instead of `contentRect` here to avoid shaking.
+       */
+      const fixedWidth = Math.floor(width);
+      const fixedHeight = Math.floor(height);
+
+      const size = { width: fixedWidth, height: fixedHeight, offsetWidth, offsetHeight };
+      if (onResize) {
+        const mergedOffsetWidth = offsetWidth === Math.round(width) ? width : offsetWidth;
+        const mergedOffsetHeight = offsetHeight === Math.round(height) ? height : offsetHeight;
+        Promise.resolve().then(() => {
+          onResize(
+            {
+              ...size,
+              offsetWidth: mergedOffsetWidth,
+              offsetHeight: mergedOffsetHeight,
+            },
+            targetInfoRef.current.get(target),
+          );
+        });
+      }
+    }
+    resizedTargetSetRef.current.clear();
+  };
+  const debouncedResizeCallback = useDebounceCallback(resizeCallback, 1200);
 
   if (!resizeObserverRef.current) {
     resizeObserverRef.current = new ResizeObserver(entries => {
-      for (const entry of entries) {
-        const target = entry.target;
-        const { width, height } = target.getBoundingClientRect();
-        const { offsetWidth, offsetHeight } = target;
-
-        /**
-         * Resize observer trigger when content size changed.
-         * In most case we just care about element size,
-         * let's use `boundary` instead of `contentRect` here to avoid shaking.
-         */
-        const fixedWidth = Math.floor(width);
-        const fixedHeight = Math.floor(height);
-
-        const size = { width: fixedWidth, height: fixedHeight, offsetWidth, offsetHeight };
-        if (onResize) {
-          const mergedOffsetWidth = offsetWidth === Math.round(width) ? width : offsetWidth;
-          const mergedOffsetHeight = offsetHeight === Math.round(height) ? height : offsetHeight;
-          Promise.resolve().then(() => {
-            onResize(
-              {
-                ...size,
-                offsetWidth: mergedOffsetWidth,
-                offsetHeight: mergedOffsetHeight,
-              },
-              targetInfoRef.current.get(target),
-            );
-          });
-        }
-      }
+      entries.map(({ target }) => resizedTargetSetRef.current.add(target));
+      // handle continuous resizing,
+      debouncedResizeCallback();
     });
   }
 
-  const observe = (el: Element, info) => {
+  const observe = (el: HTMLElement, info) => {
     resizeObserverRef.current.observe(el);
     targetInfoRef.current.set(el, info);
   };
 
-  const unobserve = (el: Element) => {
+  const unobserve = (el: HTMLElement) => {
     resizeObserverRef.current.unobserve(el);
     targetInfoRef.current.delete(el);
   };

--- a/src/hooks/useColumnResizeObserver.ts
+++ b/src/hooks/useColumnResizeObserver.ts
@@ -80,6 +80,14 @@ export default function useColumnResizeObserver<T>(
     });
   }
 
+  React.useEffect(() => {
+    return () => {
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+      }
+    };
+  }, []);
+
   return React.useMemo(() => {
     return {
       observe: (el: HTMLElement, info) => {

--- a/src/hooks/useFrame.ts
+++ b/src/hooks/useFrame.ts
@@ -49,47 +49,6 @@ export function useLayoutState<State>(
   return [stateRef.current, setFrameState];
 }
 
-// append state update to the tail of macro task queue
-export function useDelayState<State>(
-  defaultState: State,
-): [State, (updater: Updater<State>) => void] {
-  const stateRef = useRef(defaultState);
-  const [, forceUpdate] = useState({});
-
-  const timeoutRef = useRef<number>(null);
-  const updateBatchRef = useRef<Updater<State>[]>([]);
-
-  function cleanUp() {
-    window.clearTimeout(timeoutRef.current);
-    timeoutRef.current = null;
-  }
-
-  function setDelayState(updater: Updater<State>) {
-    if (timeoutRef.current) {
-      cleanUp();
-    }
-    updateBatchRef.current.push(updater);
-    timeoutRef.current = window.setTimeout(() => {
-      const prevBatch = updateBatchRef.current;
-      const prevState = stateRef.current;
-      updateBatchRef.current = [];
-
-      prevBatch.forEach(batchUpdater => {
-        stateRef.current = batchUpdater(stateRef.current);
-      });
-
-      cleanUp();
-      if (prevState !== stateRef.current) {
-        forceUpdate({});
-      }
-    });
-  }
-
-  useEffect(() => cleanUp(), []);
-
-  return [stateRef.current, setDelayState];
-}
-
 /** Lock frame, when frame pass reset the lock. */
 export function useTimeoutLock<State>(
   defaultState?: State,

--- a/tests/FixedColumn-IE.spec.js
+++ b/tests/FixedColumn-IE.spec.js
@@ -5,6 +5,7 @@ import { spyElementPrototype } from 'rc-util/lib/test/domHook';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { isStyleSupport } from 'rc-util/lib/Dom/styleChecker';
 import Table from '../src';
+import resizeColumn from './helpers/resizeColumn';
 
 jest.mock('rc-util/lib/Dom/styleChecker', () => {
   return {
@@ -46,7 +47,7 @@ describe('Table.FixedColumn', () => {
     const wrapper = mount(<Table columns={columns} data={data} scroll={{ x: 1200 }} />);
 
     act(() => {
-      wrapper.find('table ResizeObserver').first().props().onResize({ width: 93, offsetWidth: 93 });
+      resizeColumn(wrapper, 0, { width: 93, offsetWidth: 93 });
     });
 
     await act(async () => {

--- a/tests/FixedColumn.spec.js
+++ b/tests/FixedColumn.spec.js
@@ -4,6 +4,7 @@ import { act } from 'react-dom/test-utils';
 import { resetWarned } from 'rc-util/lib/warning';
 import { spyElementPrototype } from 'rc-util/lib/test/domHook';
 import Table from '../src';
+import resizeColumn from './helpers/resizeColumn';
 
 describe('Table.FixedColumn', () => {
   let domSpy;
@@ -58,15 +59,11 @@ describe('Table.FixedColumn', () => {
           const wrapper = mount(<Table columns={columns} data={testData} scroll={scroll} />);
 
           act(() => {
-            wrapper
-              .find('table ResizeObserver')
-              .first()
-              .props()
-              .onResize({ width: 93, offsetWidth: 93 });
+            resizeColumn(wrapper, 0, { width: 93, offsetWidth: 93 });
           });
           await act(async () => {
             jest.runAllTimers();
-            await Promise.resolve();
+            await Promise.resolve().then(Promise.resolve());
             wrapper.update();
           });
           expect(wrapper.render()).toMatchSnapshot();

--- a/tests/FixedHeader.spec.js
+++ b/tests/FixedHeader.spec.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { spyElementPrototype } from 'rc-util/lib/test/domHook';
 import Table, { INTERNAL_COL_DEFINE } from '../src';
+import resizeColumn from './helpers/resizeColumn';
 
 describe('Table.FixedHeader', () => {
   let domSpy;
@@ -35,9 +36,9 @@ describe('Table.FixedHeader', () => {
       />,
     );
 
-    wrapper.find('ResizeObserver').at(0).props().onResize({ width: 100, offsetWidth: 100 });
-    wrapper.find('ResizeObserver').at(1).props().onResize({ width: 200, offsetWidth: 200 });
-    wrapper.find('ResizeObserver').at(2).props().onResize({ width: 0, offsetWidth: 0 });
+    resizeColumn(wrapper, 0, { width: 100, offsetWidth: 100 });
+    resizeColumn(wrapper, 1, { width: 200, offsetWidth: 200 });
+    resizeColumn(wrapper, 2, { width: 0, offsetWidth: 0 });
 
     await act(async () => {
       jest.runAllTimers();
@@ -147,7 +148,7 @@ describe('Table.FixedHeader', () => {
       />,
     );
 
-    wrapper.find('ResizeObserver').at(0).props().onResize({ width: 93, offsetWidth: 93 });
+    resizeColumn(wrapper, 0, { width: 93, offsetWidth: 93 });
     await act(async () => {
       jest.runAllTimers();
       await Promise.resolve();
@@ -161,7 +162,7 @@ describe('Table.FixedHeader', () => {
     // Hide Table should not modify column width
     visible = false;
 
-    wrapper.find('ResizeObserver').at(0).props().onResize({ width: 0, offsetWidth: 0 });
+    resizeColumn(wrapper, 0, { width: 0, offsetWidth: 0 });
     act(() => {
       jest.runAllTimers();
       wrapper.update();

--- a/tests/helpers/resizeColumn.ts
+++ b/tests/helpers/resizeColumn.ts
@@ -1,0 +1,4 @@
+export default function (wrapper, index, resizeInfo) {
+  const { columnResizeObserver, columnKey } = wrapper.find('MeasureCell').at(index).props();
+  columnResizeObserver.trigger(resizeInfo, columnKey);
+}


### PR DESCRIPTION
# 现象描述

设置 `scroll.x`，resize 或者切换侧边栏时，卡顿明显。

Ref: https://github.com/ant-design/ant-design/issues/27775

# 问题定位

## 优化宽度变化时 Table 组件的更新性能
<img width="695" alt="Screen Shot 2021-11-17 at 5 56 45 PM" src="https://user-images.githubusercontent.com/76864176/142329719-a8ba330c-fffc-44a3-aa01-666a39f70c7c.png">

<img width="419" alt="Screen Shot 2021-11-17 at 5 59 55 PM" src="https://user-images.githubusercontent.com/76864176/142329762-f42a9d79-010a-458a-8c34-64ed5b61ab80.png">

`resize` 时 `onFullTableResize` 的消耗最多，其中大部分时间去处理 `setComponentWidth`。`componentWidth` 通过 Context 被 `BodyRow` 订阅，实际上只用在 `ExpandedRow` 中计算宽度。即使 `ExpanedRow` 没有挂载，`componentWidth` 更新也会触发 `BodyRow` 重渲染。

解决方法：将只在 `ExpandedRow` 中用到的 `fixColumn/fixHeader/componentWidth` 单独封装到一个 `Context` 中，供 `ExpanedRow` 订阅。考虑到 `ExpandedRow` 大量挂载的情况不普遍，没有将宽度计算和样式切换移动到 css 中，如需进一步优化可考虑自定义属性。

## 避免 `resize` 时多次触发状态更新

Table 组件通过 `sticky` 定位实现固定列，需要收集列宽进行定位。每一列宽度变化时都会触发 `onResize`，原项目中将状态更新放在微任务中执行。通过测试得出 `ResizeObserver` 的 `callback` 在浏览器中以宏任务被安排，即以 `Column1 onResize` -> `setState` -> `Column2 onResize` -> `setState` 的队列调度，导致频繁状态更新。

<img width="525" alt="Screen Shot 2021-11-17 at 10 47 38 PM" src="https://user-images.githubusercontent.com/76864176/142333149-be07f5f4-0803-43af-8d40-2ac88c3057b2.png">
<img width="505" alt="Screen Shot 2021-11-17 at 10 48 17 PM" src="https://user-images.githubusercontent.com/76864176/142333168-6dc94d43-9cff-4717-b21b-f0cf6e291202.png">



解决方法：尝试收集所有列的状态更新，在所有列 `onResize` 执行后再统一执行。具体实现为使用 `setTimeout` 将状态更新扔到任务队列尾部。

