### PR TITLE
perf: observe columns with one ResizeObserver instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,13 +55,15 @@
   "dependencies": {
     "@babel/runtime": "^7.10.1",
     "classnames": "^2.2.5",
-    "rc-resize-observer": "^1.0.0",
+    "lodash": "^4.17.21",
+    "rc-resize-observer": "^1.1.0",
     "rc-util": "^5.14.0",
     "shallowequal": "^1.1.0"
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.5",
     "@types/jest": "^26.0.3",
+    "@types/lodash": "^4.14.177",
     "@types/react": "^17.0.35",
     "@types/react-dom": "^17.0.10",
     "@umijs/fabric": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "dependencies": {
     "@babel/runtime": "^7.10.1",
     "classnames": "^2.2.5",
-    "lodash": "^4.17.21",
     "rc-resize-observer": "^1.1.0",
     "rc-util": "^5.14.0",
     "shallowequal": "^1.1.0"
@@ -63,7 +62,6 @@
   "devDependencies": {
     "@types/enzyme": "^3.10.5",
     "@types/jest": "^26.0.3",
-    "@types/lodash": "^4.14.177",
     "@types/react": "^17.0.35",
     "@types/react-dom": "^17.0.10",
     "@umijs/fabric": "^2.0.0",

--- a/src/Body/MeasureCell.tsx
+++ b/src/Body/MeasureCell.tsx
@@ -7,7 +7,7 @@ export interface MeasureCellProps {
 }
 
 export default function MeasureCell({ columnKey, onColumnResize }: MeasureCellProps) {
-  const cellRef = React.useRef<HTMLTableDataCellElement>();
+  const cellRef = React.useRef<HTMLTableCellElement>();
 
   React.useEffect(() => {
     if (cellRef.current) {
@@ -16,11 +16,7 @@ export default function MeasureCell({ columnKey, onColumnResize }: MeasureCellPr
   }, []);
 
   return (
-    <ResizeObserver
-      onResize={({ offsetWidth }) => {
-        onColumnResize(columnKey, offsetWidth);
-      }}
-    >
+    <ResizeObserver data={columnKey}>
       <td ref={cellRef} style={{ padding: 0, border: 0, height: 0 }}>
         <div style={{ height: 0, overflow: 'hidden' }}>&nbsp;</div>
       </td>

--- a/src/Body/MeasureRow.tsx
+++ b/src/Body/MeasureRow.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import ResizeObserver from 'rc-resize-observer';
+import { debounce } from 'lodash';
+import MeasureCell from './MeasureCell';
+
+export interface MeasureCellProps {
+  prefixCls: string;
+  onColumnResize: (key: React.Key, width: number) => void;
+  columnsKey: React.Key[];
+}
+
+export default function MeasureRow({ prefixCls, columnsKey, onColumnResize }: MeasureCellProps) {
+  // debounce the continuous resize, e.g. window resize
+  const resizedColumnsRef = React.useRef(new Map());
+  const onColumnResizeRef = React.useRef(onColumnResize);
+  onColumnResizeRef.current = onColumnResize;
+  const debounceColumnResize = React.useMemo(
+    () =>
+      debounce(
+        () => {
+          resizedColumnsRef.current.forEach((width, columnKey) => {
+            onColumnResizeRef.current(columnKey, width);
+          });
+          resizedColumnsRef.current.clear();
+        },
+        1200,
+        {
+          leading: true,
+          trailing: true,
+        },
+      ),
+    [],
+  );
+  React.useEffect(() => {
+    return () => {
+      debounceColumnResize.cancel();
+    };
+  }, []);
+  return (
+    <tr
+      aria-hidden="true"
+      className={`${prefixCls}-measure-row`}
+      style={{ height: 0, fontSize: 0 }}
+    >
+      <ResizeObserver.Collection
+        onBatchResize={infoList => {
+          infoList.forEach(({ data: columnKey, size }) => {
+            resizedColumnsRef.current.set(columnKey, size.offsetWidth);
+          });
+          debounceColumnResize();
+        }}
+      >
+        {columnsKey.map(columnKey => (
+          <MeasureCell key={columnKey} columnKey={columnKey} onColumnResize={onColumnResize} />
+        ))}
+      </ResizeObserver.Collection>
+    </tr>
+  );
+}

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -5,10 +5,10 @@ import ExpandedRow from './ExpandedRow';
 import BodyContext from '../context/BodyContext';
 import { getColumnsKey } from '../utils/valueUtil';
 import ResizeContext from '../context/ResizeContext';
-import MeasureCell from './MeasureCell';
 import BodyRow from './BodyRow';
 import useFlattenRecords from '../hooks/useFlattenRecords';
 import HoverContext from '../context/HoverContext';
+import MeasureRow from './MeasureRow';
 
 export interface BodyProps<RecordType> {
   data: readonly RecordType[];
@@ -102,19 +102,11 @@ function Body<RecordType>({
         <WrapperComponent className={`${prefixCls}-tbody`}>
           {/* Measure body column width with additional hidden col */}
           {measureColumnWidth && (
-            <tr
-              aria-hidden="true"
-              className={`${prefixCls}-measure-row`}
-              style={{ height: 0, fontSize: 0 }}
-            >
-              {columnsKey.map(columnKey => (
-                <MeasureCell
-                  key={columnKey}
-                  columnKey={columnKey}
-                  onColumnResize={onColumnResize}
-                />
-              ))}
-            </tr>
+            <MeasureRow
+              prefixCls={prefixCls}
+              columnsKey={columnsKey}
+              onColumnResize={onColumnResize}
+            />
           )}
 
           {rows}

--- a/tests/FixedColumn-IE.spec.js
+++ b/tests/FixedColumn-IE.spec.js
@@ -60,7 +60,7 @@ describe('Table.FixedColumn', () => {
     });
 
     await act(async () => {
-      jest.runOnlyPendingTimers();
+      jest.runAllTimers();
       await Promise.resolve();
       wrapper.update();
     });

--- a/tests/FixedColumn-IE.spec.js
+++ b/tests/FixedColumn-IE.spec.js
@@ -5,6 +5,7 @@ import { spyElementPrototype } from 'rc-util/lib/test/domHook';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { isStyleSupport } from 'rc-util/lib/Dom/styleChecker';
 import Table from '../src';
+import RcResizeObserver from 'rc-resize-observer';
 
 jest.mock('rc-util/lib/Dom/styleChecker', () => {
   return {
@@ -46,11 +47,20 @@ describe('Table.FixedColumn', () => {
     const wrapper = mount(<Table columns={columns} data={data} scroll={{ x: 1200 }} />);
 
     act(() => {
-      wrapper.find('table ResizeObserver').first().props().onResize({ width: 93, offsetWidth: 93 });
+      wrapper
+        .find(RcResizeObserver.Collection)
+        .first()
+        .props()
+        .onBatchResize([
+          {
+            data: wrapper.find('table ResizeObserver').first().props().data,
+            size: { width: 93, offsetWidth: 93 },
+          },
+        ]);
     });
 
     await act(async () => {
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
       await Promise.resolve();
       wrapper.update();
     });

--- a/tests/FixedColumn.spec.js
+++ b/tests/FixedColumn.spec.js
@@ -4,6 +4,7 @@ import { act } from 'react-dom/test-utils';
 import { resetWarned } from 'rc-util/lib/warning';
 import { spyElementPrototype } from 'rc-util/lib/test/domHook';
 import Table from '../src';
+import RcResizeObserver from 'rc-resize-observer';
 
 describe('Table.FixedColumn', () => {
   let domSpy;
@@ -59,13 +60,18 @@ describe('Table.FixedColumn', () => {
 
           act(() => {
             wrapper
-              .find('table ResizeObserver')
+              .find(RcResizeObserver.Collection)
               .first()
               .props()
-              .onResize({ width: 93, offsetWidth: 93 });
+              .onBatchResize([
+                {
+                  data: wrapper.find('table ResizeObserver').first().props().data,
+                  size: { width: 93, offsetWidth: 93 },
+                },
+              ]);
           });
           await act(async () => {
-            jest.runAllTimers();
+            jest.runOnlyPendingTimers();
             await Promise.resolve();
             wrapper.update();
           });

--- a/tests/FixedColumn.spec.js
+++ b/tests/FixedColumn.spec.js
@@ -71,7 +71,7 @@ describe('Table.FixedColumn', () => {
               ]);
           });
           await act(async () => {
-            jest.runOnlyPendingTimers();
+            jest.runAllTimers();
             await Promise.resolve();
             wrapper.update();
           });

--- a/tests/FixedHeader.spec.js
+++ b/tests/FixedHeader.spec.js
@@ -24,6 +24,7 @@ describe('Table.FixedHeader', () => {
   });
 
   it('should work', async () => {
+    jest.useFakeTimers();
     const col1 = { dataIndex: 'light', width: 100 };
     const col2 = { dataIndex: 'bamboo', width: 200 };
     const col3 = { dataIndex: 'empty', width: 0 };
@@ -55,7 +56,7 @@ describe('Table.FixedHeader', () => {
       ]);
 
     await act(async () => {
-      jest.runOnlyPendingTimers();
+      jest.runAllTimers();
       await Promise.resolve();
       wrapper.update();
     });
@@ -173,7 +174,7 @@ describe('Table.FixedHeader', () => {
         },
       ]);
     await act(async () => {
-      jest.runOnlyPendingTimers();
+      jest.runAllTimers();
       await Promise.resolve();
       wrapper.update();
     });
@@ -197,7 +198,7 @@ describe('Table.FixedHeader', () => {
       ]);
 
     act(() => {
-      jest.runOnlyPendingTimers();
+      jest.runAllTimers();
       wrapper.update();
     });
 

--- a/tests/FixedHeader.spec.js
+++ b/tests/FixedHeader.spec.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import { spyElementPrototype } from 'rc-util/lib/test/domHook';
 import Table, { INTERNAL_COL_DEFINE } from '../src';
+import RcResizeObserver from 'rc-resize-observer';
 
 describe('Table.FixedHeader', () => {
   let domSpy;
@@ -23,7 +24,6 @@ describe('Table.FixedHeader', () => {
   });
 
   it('should work', async () => {
-    jest.useFakeTimers();
     const col1 = { dataIndex: 'light', width: 100 };
     const col2 = { dataIndex: 'bamboo', width: 200 };
     const col3 = { dataIndex: 'empty', width: 0 };
@@ -35,12 +35,27 @@ describe('Table.FixedHeader', () => {
       />,
     );
 
-    wrapper.find('ResizeObserver').at(0).props().onResize({ width: 100, offsetWidth: 100 });
-    wrapper.find('ResizeObserver').at(1).props().onResize({ width: 200, offsetWidth: 200 });
-    wrapper.find('ResizeObserver').at(2).props().onResize({ width: 0, offsetWidth: 0 });
+    wrapper
+      .find(RcResizeObserver.Collection)
+      .first()
+      .props()
+      .onBatchResize([
+        {
+          data: wrapper.find('ResizeObserver').at(0).props().data,
+          size: { width: 100, offsetWidth: 100 },
+        },
+        {
+          data: wrapper.find('ResizeObserver').at(1).props().data,
+          size: { width: 200, offsetWidth: 200 },
+        },
+        {
+          data: wrapper.find('ResizeObserver').at(2).props().data,
+          size: { width: 0, offsetWidth: 0 },
+        },
+      ]);
 
     await act(async () => {
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
       await Promise.resolve();
       wrapper.update();
     });
@@ -147,9 +162,18 @@ describe('Table.FixedHeader', () => {
       />,
     );
 
-    wrapper.find('ResizeObserver').at(0).props().onResize({ width: 93, offsetWidth: 93 });
+    wrapper
+      .find(RcResizeObserver.Collection)
+      .first()
+      .props()
+      .onBatchResize([
+        {
+          data: wrapper.find('ResizeObserver').at(0).props().data,
+          size: { width: 93, offsetWidth: 93 },
+        },
+      ]);
     await act(async () => {
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
       await Promise.resolve();
       wrapper.update();
     });
@@ -161,9 +185,19 @@ describe('Table.FixedHeader', () => {
     // Hide Table should not modify column width
     visible = false;
 
-    wrapper.find('ResizeObserver').at(0).props().onResize({ width: 0, offsetWidth: 0 });
+    wrapper
+      .find(RcResizeObserver.Collection)
+      .first()
+      .props()
+      .onBatchResize([
+        {
+          data: wrapper.find('ResizeObserver').at(0).props().data,
+          size: { width: 0, offsetWidth: 0 },
+        },
+      ]);
+
     act(() => {
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
       wrapper.update();
     });
 


### PR DESCRIPTION
**问题描述**：设置 scroll.x，resize 或者切换侧边栏时，卡顿明显。Ref: ant-design/ant-design#27775
**解决方式**：单个 `ResizeObserver` 实例 `observe` 所有列，支持在一个 Task 周期批量处理 Resize 引发的 Update
**优化结果**：固定栏平铺-折叠切换，所需用时 **6646.2ms ➜ 1080.8 ms**
**具体分析**：https://github.com/react-component/table/pull/701#discussion_r752994243