### PR TITLE
fix: SummaryCell triggering `onCell` warning

### DIFF
--- a/src/Footer/Cell.tsx
+++ b/src/Footer/Cell.tsx
@@ -44,10 +44,8 @@ export default function SummaryCell({
       record={null}
       dataIndex={null}
       align={align}
-      additionalProps={{
-        colSpan: mergedColSpan,
-        rowSpan
-      }}
+      colSpan={mergedColSpan}
+      rowSpan={rowSpan}
       render={() => children}
       {...fixedInfo}
     />

--- a/src/Footer/Cell.tsx
+++ b/src/Footer/Cell.tsx
@@ -44,13 +44,11 @@ export default function SummaryCell({
       record={null}
       dataIndex={null}
       align={align}
-      render={() => ({
-        children,
-        props: {
-          colSpan: mergedColSpan,
-          rowSpan,
-        },
-      })}
+      additionalProps={{
+        colSpan: mergedColSpan,
+        rowSpan
+      }}
+      render={() => children}
       {...fixedInfo}
     />
   );


### PR DESCRIPTION
Warning started appearing on `Table.Summary.Cell` on antd v4.18.0 due to 75ee0064e54a4b321569450

close https://github.com/react-component/table/issues/722
close #724
close ant-design/ant-design#33488

