### PR TITLE
fix: table emptynode fixed display

### DIFF
--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -196,6 +196,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
         component={RowComponent}
         cellComponent={cellComponent}
         colSpan={flattenColumns.length}
+        isEmpty={false}
       >
         {expandContent}
       </ExpandedRow>

--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -12,6 +12,7 @@ export interface ExpandedRowProps {
   expanded: boolean;
   children: React.ReactNode;
   colSpan: number;
+  isEmpty: boolean;
 }
 
 function ExpandedRow({
@@ -22,15 +23,17 @@ function ExpandedRow({
   className,
   expanded,
   colSpan,
+  isEmpty,
 }: ExpandedRowProps) {
   const { scrollbarSize } = React.useContext(TableContext);
-  const { fixHeader, fixColumn, componentWidth } = React.useContext(ExpandedRowContext);
+  const { fixHeader, fixColumn, componentWidth, horizonScroll } =
+    React.useContext(ExpandedRowContext);
 
   // Cache render node
   return React.useMemo(() => {
     let contentNode = children;
 
-    if (fixColumn) {
+    if (isEmpty ? horizonScroll : fixColumn) {
       contentNode = (
         <div
           style={{
@@ -64,10 +67,12 @@ function ExpandedRow({
     className,
     expanded,
     colSpan,
+    isEmpty,
     scrollbarSize,
     componentWidth,
     fixColumn,
     fixHeader,
+    horizonScroll,
   ]);
 }
 

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -92,6 +92,7 @@ function Body<RecordType>({
           component={trComponent}
           cellComponent={tdComponent}
           colSpan={flattenColumns.length}
+          isEmpty
         >
           {emptyNode}
         </ExpandedRow>

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -844,8 +844,9 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       componentWidth,
       fixHeader,
       fixColumn,
+      horizonScroll
     }),
-    [componentWidth, fixHeader, fixColumn],
+    [componentWidth, fixHeader, fixColumn, horizonScroll],
   );
 
   const ResizeContextValue = React.useMemo(() => ({ onColumnResize }), [onColumnResize]);

--- a/src/context/ExpandedRowContext.tsx
+++ b/src/context/ExpandedRowContext.tsx
@@ -4,6 +4,7 @@ export interface ExpandedRowProps {
   componentWidth: number;
   fixHeader: boolean;
   fixColumn: boolean;
+  horizonScroll: boolean;
 }
 
 const ExpandedRowContext = React.createContext<ExpandedRowProps>(null);


### PR DESCRIPTION
修复表格空状态时 emptynode 未固定显示的问题

7.20.2之前，这里的传值是模糊的
![image](https://user-images.githubusercontent.com/49073282/148317252-ea75a4d8-899e-40fe-9d64-fc064679e7b4.png)

7.20.2之后，在 https://github.com/react-component/table/blob/b973d405b9e2552e41c3fccc992da1362b8622d4/src/Body/ExpandedRow.tsx#L33 改成了始终使用 `ExpandedRowContext` 中的 `fixColumn`，空状态时 `fixColumn` 为 `false`，就造成了显示上的问题