### PR TITLE
fix: header column resize delay

### DIFF
--- a/docs/examples/column-resize.tsx
+++ b/docs/examples/column-resize.tsx
@@ -31,6 +31,7 @@ interface DemoState {
   columns: ColumnType<RecordType>[];
 }
 
+
 class Demo extends React.Component<{}, DemoState> {
   state: DemoState = {
     columns: [

--- a/src/Body/MeasureRow.tsx
+++ b/src/Body/MeasureRow.tsx
@@ -9,16 +9,6 @@ export interface MeasureCellProps {
 }
 
 export default function MeasureRow({ prefixCls, columnsKey, onColumnResize }: MeasureCellProps) {
-  // delay state update while resize continuously, e.g. window resize
-  const resizedColumnsRef = React.useRef(new Map());
-
-  const batchOnColumnResize = () => {
-    resizedColumnsRef.current.forEach((width, columnKey) => {
-      onColumnResize(columnKey, width);
-    });
-    resizedColumnsRef.current.clear();
-  };
-
   return (
     <tr
       aria-hidden="true"
@@ -28,9 +18,8 @@ export default function MeasureRow({ prefixCls, columnsKey, onColumnResize }: Me
       <ResizeObserver.Collection
         onBatchResize={infoList => {
           infoList.forEach(({ data: columnKey, size }) => {
-            resizedColumnsRef.current.set(columnKey, size.offsetWidth);
+            onColumnResize(columnKey, size.offsetWidth);
           });
-          batchOnColumnResize();
         }}
       >
         {columnsKey.map(columnKey => (


### PR DESCRIPTION
## 问题描述
由于延迟更新column宽度，导致表头表body宽度更新不同步

## 相关issuse
https://github.com/ant-design/ant-design/issues/33545

## 解决方案
移除2帧的延迟