### PR TITLE
fix: Summary Context Circular Dependency

### DIFF
--- a/src/Footer/Cell.tsx
+++ b/src/Footer/Cell.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { SummaryContext } from './Summary';
+import SummaryContext from './SummaryContext';
 import Cell from '../Cell';
 import TableContext from '../context/TableContext';
 import type { AlignType } from '../interface';

--- a/src/Footer/Summary.tsx
+++ b/src/Footer/Summary.tsx
@@ -1,3 +1,4 @@
+import type * as React from 'react';
 import Cell from './Cell';
 import Row from './Row';
 

--- a/src/Footer/Summary.tsx
+++ b/src/Footer/Summary.tsx
@@ -1,15 +1,5 @@
-import * as React from 'react';
 import Cell from './Cell';
 import Row from './Row';
-import type { ColumnType, StickyOffsets } from '../interface';
-
-type FlattenColumns<RecordType> = readonly (ColumnType<RecordType> & { scrollbar?: boolean })[];
-
-export const SummaryContext = React.createContext<{
-  stickyOffsets?: StickyOffsets;
-  scrollColumnIndex?: number;
-  flattenColumns?: FlattenColumns<any>;
-}>({});
 
 export interface SummaryProps {
   fixed?: boolean | 'top' | 'bottom';

--- a/src/Footer/SummaryContext.tsx
+++ b/src/Footer/SummaryContext.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import type { ColumnType, StickyOffsets } from '../interface';
+
+type FlattenColumns<RecordType> = readonly (ColumnType<RecordType> & { scrollbar?: boolean })[];
+
+const SummaryContext = React.createContext<{
+  stickyOffsets?: StickyOffsets;
+  scrollColumnIndex?: number;
+  flattenColumns?: FlattenColumns<any>;
+}>({});
+
+export default SummaryContext;

--- a/src/Footer/index.tsx
+++ b/src/Footer/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import TableContext from '../context/TableContext';
-import Summary, { SummaryContext } from './Summary';
+import Summary from './Summary';
+import SummaryContext from './SummaryContext';
 import type { ColumnType, StickyOffsets } from '../interface';
 
 type FlattenColumns<RecordType> = readonly (ColumnType<RecordType> & { scrollbar?: boolean })[];


### PR DESCRIPTION
The last circular dependency fix merely changed where the circular dependency occurred, as Footer/Summar.tsx imports from Footer/Cell.tsx and vice versa. So I Isolated the `SummaryContext` constant and the type it uses to its own file to break that circular import. 

Verified the fix using madge https://www.npmjs.com/package/madge