### PR TITLE
feat: add `levelIndex` param to `onRow` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ React.render(<Table columns={columns} data={data} />, mountNode);
 | rowClassName | string or Function(record, index, indent):string |  | get row's className |
 | rowRef | Function(record, index, indent):string |  | get row's ref key |
 | data | Object[] |  | data record array to be rendered |
-| onRow | Function(record, index) |  | Set custom props per each row. |
+| onRow | Function(record, index, levelIndex) |  | Set custom props per each row. |
 | onHeaderRow | Function(record, index) |  | Set custom props per each header row. |
 | showHeader | Boolean | true | whether table head is shown |
 | title | Function(currentData) |  | table title render function |

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -17,6 +17,7 @@ export interface BodyRowProps<RecordType> {
   record: RecordType;
   index: number;
   renderIndex: number;
+  levelIndex: number;
   className?: string;
   style?: React.CSSProperties;
   recordKey: Key;
@@ -40,6 +41,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
     record,
     index,
     renderIndex,
+    levelIndex,
     rowKey,
     rowExpandable,
     expandedKeys,
@@ -89,7 +91,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
   // =========================== onRow ===========================
   let additionalProps: React.HTMLAttributes<HTMLElement>;
   if (onRow) {
-    additionalProps = onRow(record, index);
+    additionalProps = onRow(record, index, levelIndex);
   }
 
   const onClick: React.MouseEventHandler<HTMLElement> = (event, ...args) => {

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -66,10 +66,16 @@ function Body<RecordType>({
     const tdComponent = getComponent(['body', 'cell'], 'td');
 
     let rows: React.ReactNode;
+    let lastIndent = -1;
+    let indexWithLevel = -1;
     if (data.length) {
       rows = flattenData.map((item, idx) => {
         const { record, indent, index: renderIndex } = item;
-
+        if (lastIndent !== indent) {
+          lastIndent = indent;
+          indexWithLevel = 0;
+        }
+        const levelIndex = indexWithLevel++;
         const key = getRowKey(record, idx);
 
         return (
@@ -80,6 +86,7 @@ function Body<RecordType>({
             recordKey={key}
             index={idx}
             renderIndex={renderIndex}
+            levelIndex={levelIndex}
             rowComponent={trComponent}
             cellComponent={tdComponent}
             expandedKeys={expandedKeys}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -107,6 +107,7 @@ export interface StickyOffsets {
 export type GetComponentProps<DataType> = (
   data: DataType,
   index?: number,
+  levelIndex?: number,
 ) => React.HTMLAttributes<any> | React.TdHTMLAttributes<any>;
 
 type Component<P> =


### PR DESCRIPTION
特性说明：

目的：在拖拽排序，并且数据是树形结构（带有 children）时，拿到**某行对应到该层级的索引**，简化拖拽后的数组元素移动操作