### PR TITLE
fix: table crashes if expandable set without scroll

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -432,7 +432,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       scrollYStyle = { overflowY: 'hidden' };
     }
     scrollTableStyle = {
-      width: scroll ? (scroll.x === true ? 'auto' : scroll.x) : undefined,
+      width: scroll?.x === true ? 'auto' : scroll?.x,
       minWidth: '100%',
     };
   }

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -432,7 +432,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       scrollYStyle = { overflowY: 'hidden' };
     }
     scrollTableStyle = {
-      width: scroll.x === true ? 'auto' : scroll.x,
+      width: scroll ? (scroll.x === true ? 'auto' : scroll.x) : undefined,
       minWidth: '100%',
     };
   }
@@ -553,7 +553,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     // When scroll.x is max-content, no need to fix table layout
     // it's width should stretch out to fit content
     if (fixColumn) {
-      return scroll.x === 'max-content' ? 'auto' : 'fixed';
+      return scroll && scroll.x === 'max-content' ? 'auto' : 'fixed';
     }
     if (fixHeader || isSticky || flattenColumns.some(({ ellipsis }) => ellipsis)) {
       return 'fixed';
@@ -844,7 +844,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       componentWidth,
       fixHeader,
       fixColumn,
-      horizonScroll
+      horizonScroll,
     }),
     [componentWidth, fixHeader, fixColumn, horizonScroll],
   );

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -553,7 +553,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     // When scroll.x is max-content, no need to fix table layout
     // it's width should stretch out to fit content
     if (fixColumn) {
-      return scroll && scroll.x === 'max-content' ? 'auto' : 'fixed';
+      return scroll?.x === 'max-content' ? 'auto' : 'fixed';
     }
     if (fixHeader || isSticky || flattenColumns.some(({ ellipsis }) => ellipsis)) {
       return 'fixed';

--- a/tests/ExpandRow.spec.js
+++ b/tests/ExpandRow.spec.js
@@ -170,6 +170,35 @@ describe('Table.Expand', () => {
     expect(wrapper2.render()).toMatchSnapshot();
   });
 
+  it('does not crash if scroll is not set', () => {
+    const columns = [
+      { title: 'Name', dataIndex: 'name', key: 'name' },
+      { title: 'Age', dataIndex: 'age', key: 'age' },
+      { title: 'Gender', dataIndex: 'gender', key: 'gender' },
+    ];
+    const data = [
+      { key: 0, name: 'Lucy', age: 27, gender: 'F' },
+      { key: 1, name: 'Jack', age: 28, gender: 'M' },
+    ];
+    const wrapper = mount(
+      createTable({
+        columns,
+        data,
+        scroll: {},
+        expandable: { expandedRowRender, fixed: true },
+      }),
+    );
+    const wrapper2 = mount(
+      createTable({
+        columns,
+        data,
+        expandable: { expandedRowRender, fixed: true },
+      }),
+    );
+    expect(wrapper.render()).toMatchSnapshot();
+    expect(wrapper2.render()).toMatchSnapshot();
+  });
+
   it('expandable fix not when expandIconColumnIndex', () => {
     const columns = [
       { title: 'Name', dataIndex: 'name', key: 'name' },

--- a/tests/__snapshots__/ExpandRow.spec.js.snap
+++ b/tests/__snapshots__/ExpandRow.spec.js.snap
@@ -103,6 +103,310 @@ exports[`Table.Expand childrenColumnName 1`] = `
 </div>
 `;
 
+exports[`Table.Expand does not crash if scroll is not set 1`] = `
+<div
+  class="rc-table rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left"
+>
+  <div
+    class="rc-table-container"
+  >
+    <div
+      class="rc-table-content"
+      style="overflow-x: auto; overflow-y: hidden;"
+    >
+      <table
+        style="min-width: 100%; table-layout: fixed;"
+      >
+        <colgroup>
+          <col
+            class="rc-table-expand-icon-col"
+          />
+        </colgroup>
+        <thead
+          class="rc-table-thead"
+        >
+          <tr>
+            <th
+              class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
+              style="position: sticky; left: 0px;"
+            />
+            <th
+              class="rc-table-cell"
+            >
+              Name
+            </th>
+            <th
+              class="rc-table-cell"
+            >
+              Age
+            </th>
+            <th
+              class="rc-table-cell"
+            >
+              Gender
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="rc-table-tbody"
+        >
+          <tr
+            aria-hidden="true"
+            class="rc-table-measure-row"
+            style="height: 0px; font-size: 0;"
+          >
+            <td
+              style="padding: 0px; border: 0px; height: 0px;"
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
+            <td
+              style="padding: 0px; border: 0px; height: 0px;"
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
+            <td
+              style="padding: 0px; border: 0px; height: 0px;"
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
+            <td
+              style="padding: 0px; border: 0px; height: 0px;"
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="rc-table-row rc-table-row-level-0"
+            data-row-key="0"
+          >
+            <td
+              class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
+              style="position: sticky; left: 0px;"
+            >
+              <span
+                class="rc-table-row-expand-icon rc-table-row-collapsed"
+              />
+            </td>
+            <td
+              class="rc-table-cell"
+            >
+              Lucy
+            </td>
+            <td
+              class="rc-table-cell"
+            >
+              27
+            </td>
+            <td
+              class="rc-table-cell"
+            >
+              F
+            </td>
+          </tr>
+          <tr
+            class="rc-table-row rc-table-row-level-0"
+            data-row-key="1"
+          >
+            <td
+              class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
+              style="position: sticky; left: 0px;"
+            >
+              <span
+                class="rc-table-row-expand-icon rc-table-row-collapsed"
+              />
+            </td>
+            <td
+              class="rc-table-cell"
+            >
+              Jack
+            </td>
+            <td
+              class="rc-table-cell"
+            >
+              28
+            </td>
+            <td
+              class="rc-table-cell"
+            >
+              M
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Table.Expand does not crash if scroll is not set 2`] = `
+<div
+  class="rc-table rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left"
+>
+  <div
+    class="rc-table-container"
+  >
+    <div
+      class="rc-table-content"
+      style="overflow-x: auto; overflow-y: hidden;"
+    >
+      <table
+        style="min-width: 100%; table-layout: fixed;"
+      >
+        <colgroup>
+          <col
+            class="rc-table-expand-icon-col"
+          />
+        </colgroup>
+        <thead
+          class="rc-table-thead"
+        >
+          <tr>
+            <th
+              class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
+              style="position: sticky; left: 0px;"
+            />
+            <th
+              class="rc-table-cell"
+            >
+              Name
+            </th>
+            <th
+              class="rc-table-cell"
+            >
+              Age
+            </th>
+            <th
+              class="rc-table-cell"
+            >
+              Gender
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="rc-table-tbody"
+        >
+          <tr
+            aria-hidden="true"
+            class="rc-table-measure-row"
+            style="height: 0px; font-size: 0;"
+          >
+            <td
+              style="padding: 0px; border: 0px; height: 0px;"
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
+            <td
+              style="padding: 0px; border: 0px; height: 0px;"
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
+            <td
+              style="padding: 0px; border: 0px; height: 0px;"
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
+            <td
+              style="padding: 0px; border: 0px; height: 0px;"
+            >
+              <div
+                style="height: 0px; overflow: hidden;"
+              >
+                 
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="rc-table-row rc-table-row-level-0"
+            data-row-key="0"
+          >
+            <td
+              class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
+              style="position: sticky; left: 0px;"
+            >
+              <span
+                class="rc-table-row-expand-icon rc-table-row-collapsed"
+              />
+            </td>
+            <td
+              class="rc-table-cell"
+            >
+              Lucy
+            </td>
+            <td
+              class="rc-table-cell"
+            >
+              27
+            </td>
+            <td
+              class="rc-table-cell"
+            >
+              F
+            </td>
+          </tr>
+          <tr
+            class="rc-table-row rc-table-row-level-0"
+            data-row-key="1"
+          >
+            <td
+              class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
+              style="position: sticky; left: 0px;"
+            >
+              <span
+                class="rc-table-row-expand-icon rc-table-row-collapsed"
+              />
+            </td>
+            <td
+              class="rc-table-cell"
+            >
+              Jack
+            </td>
+            <td
+              class="rc-table-cell"
+            >
+              28
+            </td>
+            <td
+              class="rc-table-cell"
+            >
+              M
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Table.Expand not use nest when children is invalidate 1`] = `
 <div
   class="rc-table"


### PR DESCRIPTION
采用了Junlin-Tommy在[原PR](https://github.com/react-component/table/pull/764)提出的[修改方案](https://github.com/react-component/table/pull/764#discussion_r828693506)，减少对代码逻辑的改动。补充了测试用例。

修复了[issue#755](https://github.com/react-component/table/issues/755)第一点提及的问题。

antd的官方文档中并未提及expandable.fixed 和 scroll 两属性需要同时设置，因此将scroll属性置空不应导致整个table crash。采用了默认的auto方式设置水平方向的scroll。