### PR TITLE
fix: update col width when using cutomized body

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -63,7 +63,7 @@ import useColumns from './hooks/useColumns';
 import { useLayoutState, useTimeoutLock } from './hooks/useFrame';
 import { getPathValue, mergeObject, validateValue, getColumnsKey } from './utils/valueUtil';
 import ResizeContext from './context/ResizeContext';
-import useStickyOffsets from './hooks/useStickyOffsets';
+import useStickyOffsets, { stickyOffsetCalculator } from './hooks/useStickyOffsets';
 import ColGroup from './ColGroup';
 import { getExpandableProps } from './utils/legacyUtil';
 import Panel from './Panel';
@@ -641,6 +641,11 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
 
         return 0;
       }) as number[];
+      headerProps.stickyOffsets = stickyOffsetCalculator(
+        headerProps.colWidths,
+        flattenColumns.length,
+        direction,
+      );
     } else {
       bodyContent = (
         <div

--- a/src/hooks/useStickyOffsets.ts
+++ b/src/hooks/useStickyOffsets.ts
@@ -1,43 +1,52 @@
 import { useMemo } from 'react';
 import type { StickyOffsets } from '../interface';
 
+export const stickyOffsetCalculator = (
+  colWidths: number[],
+  columnCount: number,
+  direction: 'ltr' | 'rtl',
+) => {
+  const leftOffsets: number[] = [];
+  const rightOffsets: number[] = [];
+  let left = 0;
+  let right = 0;
+
+  for (let start = 0; start < columnCount; start += 1) {
+    if (direction === 'rtl') {
+      // Left offset
+      rightOffsets[start] = right;
+      right += colWidths[start] || 0;
+
+      // Right offset
+      const end = columnCount - start - 1;
+      leftOffsets[end] = left;
+      left += colWidths[end] || 0;
+    } else {
+      // Left offset
+      leftOffsets[start] = left;
+      left += colWidths[start] || 0;
+
+      // Right offset
+      const end = columnCount - start - 1;
+      rightOffsets[end] = right;
+      right += colWidths[end] || 0;
+    }
+  }
+
+  return {
+    left: leftOffsets,
+    right: rightOffsets,
+  };
+};
+
 /**
  * Get sticky column offset width
  */
 function useStickyOffsets(colWidths: number[], columnCount: number, direction: 'ltr' | 'rtl') {
-  const stickyOffsets: StickyOffsets = useMemo(() => {
-    const leftOffsets: number[] = [];
-    const rightOffsets: number[] = [];
-    let left = 0;
-    let right = 0;
-
-    for (let start = 0; start < columnCount; start += 1) {
-      if (direction === 'rtl') {
-        // Left offset
-        rightOffsets[start] = right;
-        right += colWidths[start] || 0;
-
-        // Right offset
-        const end = columnCount - start - 1;
-        leftOffsets[end] = left;
-        left += colWidths[end] || 0;
-      } else {
-        // Left offset
-        leftOffsets[start] = left;
-        left += colWidths[start] || 0;
-
-        // Right offset
-        const end = columnCount - start - 1;
-        rightOffsets[end] = right;
-        right += colWidths[end] || 0;
-      }
-    }
-
-    return {
-      left: leftOffsets,
-      right: rightOffsets,
-    };
-  }, [colWidths, columnCount, direction]);
+  const stickyOffsets: StickyOffsets = useMemo(
+    () => stickyOffsetCalculator(colWidths, columnCount, direction),
+    [colWidths, columnCount, direction],
+  );
 
   return stickyOffsets;
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] Bug fix

### 🔗 Related issue link

https://github.com/ant-design/ant-design/issues/35562

### 💡 Background and solution

1. extracted the logic of calculating sticky columns' width to a pure function for sharing
2. imported this function in `Table` component to update the `stickyOffsets` value

### 📝 Changelog



| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the table header issue when multiple columns are fixed in virtual rendering. |
| 🇨🇳 Chinese |  修复了虚拟渲染时多列固定的情况下表头错位的问题。 |
