### PR TITLE
fix: no scrollbar size issue

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -384,7 +384,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
   const fullTableRef = React.useRef<HTMLDivElement>();
   const scrollHeaderRef = React.useRef<HTMLDivElement>();
   const scrollBodyRef = React.useRef<HTMLDivElement>();
-  const scrollBodyConainerRef = React.useRef<HTMLDivElement>();
+  const scrollBodyContainerRef = React.useRef<HTMLDivElement>();
   const scrollSummaryRef = React.useRef<HTMLDivElement>();
   const [pingedLeft, setPingedLeft] = React.useState(false);
   const [pingedRight, setPingedRight] = React.useState(false);
@@ -538,7 +538,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     if (scrollBodyRef.current instanceof Element) {
       setScrollbarSize(getTargetScrollBarSize(scrollBodyRef.current).width);
     } else {
-      setScrollbarSize(getTargetScrollBarSize(scrollBodyConainerRef.current).width);
+      setScrollbarSize(getTargetScrollBarSize(scrollBodyContainerRef.current).width);
     }
     setSupportSticky(isStyleSupport('position', 'sticky'));
   }, []);
@@ -786,7 +786,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
         props={{ ...props, stickyOffsets, mergedExpandedKeys }}
       >
         {title && <Panel className={`${prefixCls}-title`}>{title(mergedData)}</Panel>}
-        <div ref={scrollBodyConainerRef} className={`${prefixCls}-container`}>
+        <div ref={scrollBodyContainerRef} className={`${prefixCls}-container`}>
           {groupTableNode}
         </div>
         {footer && <Panel className={`${prefixCls}-footer`}>{footer(mergedData)}</Panel>}

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -384,6 +384,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
   const fullTableRef = React.useRef<HTMLDivElement>();
   const scrollHeaderRef = React.useRef<HTMLDivElement>();
   const scrollBodyRef = React.useRef<HTMLDivElement>();
+  const scrollBodyConainerRef = React.useRef<HTMLDivElement>();
   const scrollSummaryRef = React.useRef<HTMLDivElement>();
   const [pingedLeft, setPingedLeft] = React.useState(false);
   const [pingedRight, setPingedRight] = React.useState(false);
@@ -534,7 +535,11 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
   const [supportSticky, setSupportSticky] = React.useState(true); // Only IE not support, we mark as support first
 
   React.useEffect(() => {
-    setScrollbarSize(getTargetScrollBarSize(scrollBodyRef.current).width);
+    if (scrollBodyRef.current instanceof Element) {
+      setScrollbarSize(getTargetScrollBarSize(scrollBodyRef.current).width);
+    } else {
+      setScrollbarSize(getTargetScrollBarSize(scrollBodyConainerRef.current).width);
+    }
     setSupportSticky(isStyleSupport('position', 'sticky'));
   }, []);
 
@@ -781,7 +786,9 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
         props={{ ...props, stickyOffsets, mergedExpandedKeys }}
       >
         {title && <Panel className={`${prefixCls}-title`}>{title(mergedData)}</Panel>}
-        <div className={`${prefixCls}-container`}>{groupTableNode}</div>
+        <div ref={scrollBodyConainerRef} className={`${prefixCls}-container`}>
+          {groupTableNode}
+        </div>
         {footer && <Panel className={`${prefixCls}-footer`}>{footer(mergedData)}</Panel>}
       </MemoTableContent>
     </div>

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -1020,4 +1020,22 @@ describe('Table.Basic', () => {
       expect(wrapper.find('td.rc-table-cell-row-hover')).toHaveLength(1);
     });
   });
+  it('should get scrollbar size', () => {
+    const tData = [
+      { key: 'key0', name: 'Lucy' },
+      { key: 'key1', name: 'Jack' },
+    ];
+    const tColumns = [{ title: 'Name', dataIndex: 'name', key: 'name', width: 100 }];
+    const wrapper = mount(
+      createTable({
+        columns: tColumns,
+        scroll: { y: 100 },
+        components: {
+          body: () => <React.Fragment />,
+        },
+      }),
+    );
+    expect(wrapper.render()).toMatchSnapshot();
+    expect(wrapper.find('col')).toHaveLength(tColumns.length + 1);
+  });
 });

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -1021,10 +1021,6 @@ describe('Table.Basic', () => {
     });
   });
   it('should get scrollbar size', () => {
-    const tData = [
-      { key: 'key0', name: 'Lucy' },
-      { key: 'key1', name: 'Jack' },
-    ];
     const tColumns = [{ title: 'Name', dataIndex: 'name', key: 'name', width: 100 }];
     const wrapper = mount(
       createTable({

--- a/tests/__mocks__/rc-util/lib/getScrollBarSize.ts
+++ b/tests/__mocks__/rc-util/lib/getScrollBarSize.ts
@@ -1,3 +1,8 @@
 export default () => 15;
 
-export const getTargetScrollBarSize = () => ({ width: 15, height: 15 });
+export const getTargetScrollBarSize = (target: HTMLElement) => {
+  if (!target || !(target instanceof Element)) {
+    return { width: 0, height: 0 };
+  }
+  return { width: 15, height: 15 };
+};

--- a/tests/__snapshots__/Table.spec.js.snap
+++ b/tests/__snapshots__/Table.spec.js.snap
@@ -735,6 +735,48 @@ exports[`Table.Basic renders rowSpan correctly 1`] = `
 </div>
 `;
 
+exports[`Table.Basic should get scrollbar size 1`] = `
+<div
+  class="rc-table rc-table-fixed-header"
+>
+  <div
+    class="rc-table-container"
+  >
+    <div
+      class="rc-table-header"
+      style="overflow: hidden;"
+    >
+      <table
+        style="table-layout: fixed;"
+      >
+        <colgroup>
+          <col
+            style="width: 85px;"
+          />
+          <col
+            style="width: 15px;"
+          />
+        </colgroup>
+        <thead
+          class="rc-table-thead"
+        >
+          <tr>
+            <th
+              class="rc-table-cell"
+            >
+              Name
+            </th>
+            <th
+              class="rc-table-cell rc-table-cell-scrollbar"
+            />
+          </tr>
+        </thead>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Table.Basic syntactic sugar 1`] = `
 <div
   class="rc-table"


### PR DESCRIPTION
ref: https://github.com/ant-design/ant-design/issues/35665
在不一定能保证用户传入的`components`为`Element Type`的情况下
退而求其次，获取其容器组件的scrollBarSize