### PR TITLE
Fix shadows still shown after resize to fullscreen

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -488,6 +488,8 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       const { scrollWidth, clientWidth } = currentTarget;
       // There is no space to scroll
       if (scrollWidth === clientWidth) {
+        setPingedLeft(false);
+        setPingedRight(false);
         return;
       }
       if (isRTL) {

--- a/tests/FixedColumn.spec.js
+++ b/tests/FixedColumn.spec.js
@@ -1,10 +1,9 @@
-import React from 'react';
 import { mount } from 'enzyme';
-import { act } from 'react-dom/test-utils';
-import { resetWarned } from 'rc-util/lib/warning';
-import { spyElementPrototype } from 'rc-util/lib/test/domHook';
-import Table from '../src';
 import RcResizeObserver from 'rc-resize-observer';
+import { spyElementPrototype } from 'rc-util/lib/test/domHook';
+import { resetWarned } from 'rc-util/lib/warning';
+import { act } from 'react-dom/test-utils';
+import Table from '../src';
 
 describe('Table.FixedColumn', () => {
   let domSpy;
@@ -159,6 +158,23 @@ describe('Table.FixedColumn', () => {
     });
     wrapper.update();
     expect(wrapper.find('.rc-table').hasClass('rc-table-ping-left')).toBeTruthy();
+    expect(wrapper.find('.rc-table').hasClass('rc-table-ping-right')).toBeFalsy();
+
+    // Fullscreen
+    act(() => {
+      wrapper
+        .find('.rc-table-content')
+        .props()
+        .onScroll({
+          currentTarget: {
+            scrollLeft: 0,
+            scrollWidth: 100,
+            clientWidth: 100,
+          },
+        });
+    });
+    wrapper.update();
+    expect(wrapper.find('.rc-table').hasClass('rc-table-ping-left')).toBeFalsy();
     expect(wrapper.find('.rc-table').hasClass('rc-table-ping-right')).toBeFalsy();
   });
 


### PR DESCRIPTION
When you:
- have rendered a table that fits on your screen
- you resize the view so that the scrollbar appears and the shadows on the table
- you go back to the original size of the screen

**What happens**
The shadows are still there

**What should happen**
The shadows are gone since there's no longer a scrollbar, nor a need to scroll

This is because the code is jumping out of the function when the scrollwidth and clientwidth are the same, but it doesn't reset the pingedLeft and pingedRight values.

close https://github.com/react-component/table/pull/837
close https://github.com/react-component/table/pull/834
close https://github.com/ant-design/ant-design/issues/35817