### PR TITLE
docs: better rowKey type

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ React.render(<Table columns={columns} data={data} />, mountNode);
 | expandable.onExpand | Function(expanded, record) |  | function to call when click expand icon |
 | expandable.onExpandedRowsChange | Function(expandedRows) |  | function to call when the expanded rows change |
 | expandable.fixed | String \| Boolean | - | this expand icon will be fixed when table scroll horizontally: true or `left` or `right` and `expandIconColumnIndex` need to stay first or last |
-| rowKey | string or Function(record):string | 'key' | If rowKey is string, `record[rowKey]` will be used as key. If rowKey is function, the return value of `rowKey(record)` will be use as key. |
+| rowKey | string or Function(record, index):string | 'key' | If rowKey is string, `record[rowKey]` will be used as key. If rowKey is function, the return value of `rowKey(record, index)` will be use as key. |
 | rowClassName | string or Function(record, index, indent):string |  | get row's className |
 | rowRef | Function(record, index, indent):string |  | get row's ref key |
 | data | Object[] |  | data record array to be rendered |


### PR DESCRIPTION
When we pass `rowKey` with a function, it will actually invoked as `rowKey(record, index)`,  where the second parameter is the index of dataSource. We may find evidence in the following code:

```ts
// src/Body/index.tsx:68
let rows: React.ReactNode;
if (data.length) {
  rows = flattenData.map((item, idx) => {
    const { record, indent, index: renderIndex } = item;

    const key = getRowKey(record, idx);
    // ...
  }
}
```

This is also confirmed in the type definition:

```ts
// src/interface.ts:97
export type GetRowKey<RecordType> = (record: RecordType, index?: number) => Key;
```

However, the information about the second parameter is not explicitly mentioned in README.md. In addition, there is no information provided about second parameter in the document of `Table` component of Ant Design, which depends on `rc-table` behind scene.

I hope a better rowKey type could be provided in the document, because the second parameter of rowkey may be very useful in some scenarios. For example, there may not be a unique index in the list data returned by the backend. In this case, we needs to manually add keys to the each items of list data at frontend to ensure that the table component can work normally. If the user does not know the detail of type definition of rowkey, he/she may write this:

```tsx
<Table
  dataSource={list.map((item, index)=> ({ ...item, key: `${item.userId}-${index}` }))}
  columns={columns}
/>
```

The above code can be quite confusing and cause bug sometimes, and with `rowKey` we can do better:

```tsx
 <Table
  dataSource={list}
  rowKey={(record, index) => `${record.userId}-${index}`}
  columns={columns}
/>
```
