### PR TITLE
fix(example/virtual-list-grid): 完善virtual-list-grid的demo

### DIFF
--- a/docs/examples/virtual-list-grid.tsx
+++ b/docs/examples/virtual-list-grid.tsx
@@ -27,7 +27,12 @@ const Demo = () => {
   const [connectObject] = React.useState<any>(() => {
     const obj = {};
     Object.defineProperty(obj, 'scrollLeft', {
-      get: () => null,
+      get: () => {
+        if (gridRef.current) {
+          return gridRef.current?.state?.scrollLeft;
+        }
+        return null;
+      },
       set: (scrollLeft: number) => {
         if (gridRef.current) {
           gridRef.current.scrollTo({ scrollLeft });


### PR DESCRIPTION
当修改table的dataSource时，拿不到正确的scrollBodyRef.scrollLeft而导致的header的scrollLeft不正确