### PR TITLE
修复了设置direction为rtl时表格右边框消失 和 改变窗口大小时class rc-table-ping-left/right未及时清除的bug

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -15,6 +15,7 @@
 .tableBorder() {
   border: @border;
   border-right: 0;
+  border-left: 0;
   border-bottom: 0;
 }
 
@@ -45,10 +46,14 @@
     word-break: break-word;
     border: @border;
     border-top: 0;
-    border-left: 0;
+    &:not(:first-child) {
+      border-left: 0;
+    }
     transition: box-shadow 0.3s;
     .@{tablePrefixCls}-rtl& {
-      border-right: 0;
+      &:not(:first-child) {
+        border-right: 0;
+      }
       border-left: @border;
     }
   }

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -488,6 +488,8 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       const { scrollWidth, clientWidth } = currentTarget;
       // There is no space to scroll
       if (scrollWidth === clientWidth) {
+        setPingedLeft(false);
+        setPingedRight(false);
         return;
       }
       if (isRTL) {


### PR DESCRIPTION
设置列宽和scroll.x，并且设置direction为rtl，表格右边框消失了
代码：
<img width="282" alt="image" src="https://user-images.githubusercontent.com/46315787/175019526-461bd992-c5a1-4c08-af84-ca018fa06b9c.png">
bug如图：
![image](https://user-images.githubusercontent.com/46315787/175019597-d5d1c4b8-b510-45b3-ae61-30c367b79a1f.png)
————————————分割线—————————————
窗口缩小后 table-content会添加class [rc-table-ping-left，但是窗口变大后这class会一直残留（[antd-table有个issue应该就是同一个原因](https://github.com/ant-design/ant-design/issues/35817#issue-1253216117))
![image](https://user-images.githubusercontent.com/46315787/175020577-c63c9cfe-79c2-4dbe-b0d3-4c5df349fef4.png)

