### PR TITLE
Bump outdated rc-util dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@babel/runtime": "^7.10.1",
     "classnames": "^2.2.5",
     "rc-resize-observer": "^1.1.0",
-    "rc-util": "^5.14.0",
+    "rc-util": "^5.22.5",
     "shallowequal": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Dear RC-team

It seems that commit https://github.com/react-component/table/commit/4e64b556259948fa01bd1c1329a3a32c4dcbfb0d introduced a dependency to rc-util's `useEvent` hook, which has been introduced with `rc-util@5.22.0`. On the other hand, this package still lists `rc-util: ^5.14.0` in its package dependencies. This leads to bundling errors such as:

```
ERROR in ../../node_modules/rc-table/es/ContextSelector/index.js 4:0-49
Module not found: Error: Can't resolve 'rc-util/es/hooks/useEvent' in '/<project-dir>/node_modules/rc-table/es/ContextSelector'
```

I therefore bump the rc-util dependency to the current version `5.22.5`.