### PR TITLE
Corrects the element that aria- props are applied to

### DIFF
--- a/docs/demo/aria.md
+++ b/docs/demo/aria.md
@@ -1,0 +1,3 @@
+## aria-label
+
+<code src="../examples/aria.tsx">

--- a/docs/examples/aria.tsx
+++ b/docs/examples/aria.tsx
@@ -28,8 +28,10 @@ const data = [
 
 const Demo = () => (
   <div>
-    <Table columns={columns} data={data} aria-label="Users" />
+    <h2>Table with aria-label</h2>
+    <Table columns={columns} data={data} aria-label="Users" data-testid="blah" />
     <br />
+    <h2>Table with aria-labelledby</h2>
     <label id="lblPeopleTable">People</label>
     <Table columns={columns} data={data} aria-labelledby="lblPeopleTable" />
   </div>

--- a/docs/examples/aria.tsx
+++ b/docs/examples/aria.tsx
@@ -28,7 +28,7 @@ const data = [
 
 const Demo = () => (
   <div>
-    <Table columns={columns} data={data} aria-label="Users" data-testid="blah" />
+    <Table columns={columns} data={data} aria-label="Users" />
     <br />
     <label id="lblPeopleTable">People</label>
     <Table columns={columns} data={data} aria-labelledby="lblPeopleTable" />

--- a/docs/examples/aria.tsx
+++ b/docs/examples/aria.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Table from 'rc-table';
+import '../../assets/index.less';
+
+const columns = [
+  {
+    title: 'Name',
+    dataIndex: 'name',
+    key: 'name',
+  },
+  {
+    title: 'Age',
+    dataIndex: 'age',
+    key: 'age',
+  },
+  {
+    title: 'Address',
+    dataIndex: 'address',
+    key: 'address',
+  },
+];
+
+const data = [
+  { name: 'John', age: '25', address: '1 A Street' },
+  { name: 'Fred', age: '38', address: '2 B Street' },
+  { name: 'Anne', age: '47', address: '3 C Street' },
+];
+
+const Demo = () => (
+  <div>
+    <Table columns={columns} data={data} aria-label="Users" data-testid="blah" />
+    <br />
+    <label id="lblPeopleTable">People</label>
+    <Table columns={columns} data={data} aria-labelledby="lblPeopleTable" />
+  </div>
+);
+
+export default Demo;

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -620,6 +620,9 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     warning(false, '`components.body` with render props is only work on `scroll.y`.');
   }
 
+  const dataProps = pickAttrs(props, { data: true });
+  const ariaProps = pickAttrs(props, { aria: true });
+
   if (fixHeader || isSticky) {
     // >>>>>> Fixed Header
     let bodyContent: React.ReactNode;
@@ -659,6 +662,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
               ...scrollTableStyle,
               tableLayout: mergedTableLayout,
             }}
+            {...ariaProps}
           >
             {bodyColGroup}
             {bodyTable}
@@ -740,7 +744,10 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
         onScroll={onScroll}
         ref={scrollBodyRef}
       >
-        <TableComponent style={{ ...scrollTableStyle, tableLayout: mergedTableLayout }}>
+        <TableComponent
+          style={{ ...scrollTableStyle, tableLayout: mergedTableLayout }}
+          {...ariaProps}
+        >
           {bodyColGroup}
           {showHeader !== false && <Header {...headerProps} {...columnContext} />}
           {bodyTable}
@@ -753,8 +760,6 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       </div>
     );
   }
-
-  const ariaProps = pickAttrs(props, { aria: true, data: true });
 
   let fullTable = (
     <div
@@ -775,7 +780,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       style={style}
       id={id}
       ref={fullTableRef}
-      {...ariaProps}
+      {...dataProps}
     >
       <MemoTableContent
         pingLeft={pingedLeft}

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -135,10 +135,17 @@ describe('Table.Basic', () => {
     expect(wrapper.find(`div#${testId}`).length).toBeTruthy();
   });
 
-  it('renders data- &  aria- attributes', () => {
-    const miscProps = { 'data-test': 'names-table', 'aria-label': 'names-table-aria' };
+  it('renders data- attributes', () => {
+    const miscProps = { 'data-test': 'names-table' };
     const wrapper = mount(createTable(miscProps));
     const props = wrapper.find('div.rc-table').props();
+    expect(props).toEqual(expect.objectContaining(miscProps));
+  });
+
+  it('renders aria- attributes', () => {
+    const miscProps = { 'aria-label': 'names-table-aria' };
+    const wrapper = mount(createTable(miscProps));
+    const props = wrapper.find('table').props();
     expect(props).toEqual(expect.objectContaining(miscProps));
   });
 


### PR DESCRIPTION
aria- attributes should be applied to the `<table>` element.  Instead, they are applied to the great grandparent of the `<table>` element where they serve no purpose. eg:

![image](https://user-images.githubusercontent.com/39313898/181355467-3bf907ec-4b5e-4e41-a0b7-6a8c9e64e7d2.png)

This PR moves them to the correct element. As a result, screen readers will correctly announce the table.

This PR does NOT change where the data- props are added (still on the great grandparent of the `<table>` element).

ref: UIEN-973