### PR TITLE
Adds ability to define a scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ React.render(<Table columns={columns} data={data} />, mountNode);
 | fixed | String \| Boolean |  | this column will be fixed when table scroll horizontally: true or 'left' or 'right' |
 | align | String |  | specify how cell content is aligned |
 | ellipsis | Boolean |  | specify whether cell content be ellipsized |
+| scope | 'col' \| 'colgroup' |  | 	Set scope attribute. |
 | onCell | Function(record, index) |  | Set custom props per each cell. |
 | onHeaderCell | Function(record) |  | Set custom props per each header cell. |
 | render | Function(value, row, index) |  | The render function of cell, has three params: the text of this cell, the record of this row, the index of this row, it's return an object:{ children: value, props: { colSpan: 1, rowSpan:1 } } ==> 'children' is the text of this cell, props is some setting of this cell, eg: 'colspan' set td colspan, 'rowspan' set td rowspan |

--- a/docs/demo/scope.md
+++ b/docs/demo/scope.md
@@ -1,0 +1,3 @@
+## scope
+
+<code src="../examples/scope.tsx">

--- a/docs/examples/scope.tsx
+++ b/docs/examples/scope.tsx
@@ -1,0 +1,82 @@
+import type { ColumnsType } from '@/interface';
+import Table from 'rc-table';
+import '../../assets/index.less';
+
+interface FirstTableRecordType {
+  lastName?: string;
+  firstName?: string;
+  city?: string;
+  key?: string;
+}
+
+const firstTableColumns: ColumnsType<FirstTableRecordType> = [
+  { title: 'Last Name', dataIndex: 'lastName', key: 'lastName', scope: 'col' },
+  { title: 'First Name', dataIndex: 'firstName', key: 'firstName', scope: 'col' },
+  { title: 'City', dataIndex: 'city', key: 'city', scope: 'col' },
+];
+
+const firstTableData: FirstTableRecordType[] = [
+  { lastName: 'Phoenix', firstName: 'Imary', city: 'Henry', key: '1' },
+  { lastName: 'Zeki', firstName: 'Rome', city: 'Min', key: '2' },
+  { lastName: 'Apirka', firstName: 'Kelly', city: 'Brynn', key: '3' },
+];
+
+interface SecondTableRecordType {
+  producedMars?: string;
+  soldMars?: string;
+  producedVenus?: string;
+  soldVenus?: string;
+  key?: string;
+}
+
+const secondTableColumns: ColumnsType<SecondTableRecordType> = [
+  {
+    title: 'Mars',
+    dataIndex: 'mars',
+    key: 'mars',
+    scope: 'colgroup',
+    children: [
+      { title: 'Produced', dataIndex: 'producedMars', key: 'producedMars', scope: 'col' },
+      { title: 'Sold', dataIndex: 'soldMars', key: 'soldMars', scope: 'col' },
+    ],
+  },
+  {
+    title: 'Venus',
+    dataIndex: 'venus',
+    key: 'venus',
+    scope: 'colgroup',
+    children: [
+      { title: 'Produced', dataIndex: 'producedVenus', key: 'producedVenus', scope: 'col' },
+      { title: 'Sold', dataIndex: 'soldVenus', key: 'soldVenus', scope: 'col' },
+    ],
+  },
+];
+
+const secondTableData: SecondTableRecordType[] = [
+  {
+    producedMars: '50,000',
+    soldMars: '30,000',
+    producedVenus: '100,000',
+    soldVenus: '80,000',
+    key: '1',
+  },
+  {
+    producedMars: '10,000',
+    soldMars: '5,000',
+    producedVenus: '12,000',
+    soldVenus: '9,000',
+    key: '2',
+  },
+];
+
+const Demo = () => (
+  <div>
+    <h2>Scope col</h2>
+    <Table<FirstTableRecordType> columns={firstTableColumns} data={firstTableData} />
+    <br/>
+    <h2>Scope colgroup</h2>
+    <Table<SecondTableRecordType> columns={secondTableColumns} data={secondTableData} />
+  </div>
+);
+
+export default Demo;

--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -1,25 +1,26 @@
-import * as React from 'react';
 import classNames from 'classnames';
-import shallowEqual from 'shallowequal';
 import { supportRef } from 'rc-util/lib/ref';
-import type {
-  DataIndex,
-  ColumnType,
-  RenderedCell,
-  CustomizeComponent,
-  CellType,
-  DefaultRecordType,
-  AlignType,
-  CellEllipsisType,
-} from '../interface';
-import { getPathValue, validateValue } from '../utils/valueUtil';
-import StickyContext from '../context/StickyContext';
-import HoverContext from '../context/HoverContext';
+import warning from 'rc-util/lib/warning';
+import * as React from 'react';
+import shallowEqual from 'shallowequal';
 import BodyContext from '../context/BodyContext';
 import type { HoverContextProps } from '../context/HoverContext';
-import warning from 'rc-util/lib/warning';
+import HoverContext from '../context/HoverContext';
 import PerfContext from '../context/PerfContext';
+import StickyContext from '../context/StickyContext';
 import { useContextSelector } from '../ContextSelector';
+import type {
+  AlignType,
+  CellEllipsisType,
+  CellType,
+  ColumnType,
+  CustomizeComponent,
+  DataIndex,
+  DefaultRecordType,
+  RenderedCell,
+  ScopeType,
+} from '../interface';
+import { getPathValue, validateValue } from '../utils/valueUtil';
 
 /** Check if cell is in hover range */
 function inHoverRange(cellStartRow: number, cellRowSpan: number, startRow: number, endRow: number) {
@@ -56,6 +57,7 @@ interface InternalCellProps<RecordType extends DefaultRecordType>
   children?: React.ReactNode;
   colSpan?: number;
   rowSpan?: number;
+  scope?: ScopeType;
   ellipsis?: CellEllipsisType;
   align?: AlignType;
 
@@ -119,6 +121,7 @@ function Cell<RecordType extends DefaultRecordType>(
     component: Component = 'td',
     colSpan,
     rowSpan, // This is already merged on WrapperCell
+    scope,
     fixLeft,
     fixRight,
     firstFixLeft,
@@ -276,6 +279,7 @@ function Cell<RecordType extends DefaultRecordType>(
     ...additionalProps,
     colSpan: mergedColSpan !== 1 ? mergedColSpan : null,
     rowSpan: mergedRowSpan !== 1 ? mergedRowSpan : null,
+    scope,
     className: classNames(
       cellPrefixCls,
       className,

--- a/src/Header/HeaderRow.tsx
+++ b/src/Header/HeaderRow.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import Cell from '../Cell';
+import TableContext from '../context/TableContext';
 import type {
   CellType,
-  StickyOffsets,
   ColumnType,
   CustomizeComponent,
   GetComponentProps,
+  StickyOffsets,
 } from '../interface';
-import TableContext from '../context/TableContext';
 import { getCellFixedInfo } from '../utils/fixUtil';
 import { getColumnsKey } from '../utils/valueUtil';
 
@@ -62,6 +62,7 @@ function HeaderRow<RecordType>({
         return (
           <Cell
             {...cell}
+            scope={column.scope}
             ellipsis={column.ellipsis}
             align={column.align}
             component={CellComponent}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -57,6 +57,8 @@ export type DataIndex = string | number | readonly (string | number)[];
 
 export type CellEllipsisType = { showTitle?: boolean } | boolean;
 
+export type ScopeType = 'col' | 'colgroup';
+
 interface ColumnSharedType<RecordType> {
   title?: React.ReactNode;
   key?: Key;
@@ -65,6 +67,7 @@ interface ColumnSharedType<RecordType> {
   onHeaderCell?: GetComponentProps<ColumnsType<RecordType>[number]>;
   ellipsis?: CellEllipsisType;
   align?: AlignType;
+  scope?: ScopeType;
 }
 
 export interface ColumnGroupType<RecordType> extends ColumnSharedType<RecordType> {

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -1,6 +1,6 @@
-import React from 'react';
 import { mount } from 'enzyme';
 import { resetWarned } from 'rc-util/lib/warning';
+import React from 'react';
 import Table, { INTERNAL_COL_DEFINE } from '../src';
 import { INTERNAL_HOOKS } from '../src/Table';
 
@@ -216,6 +216,38 @@ describe('Table.Basic', () => {
     wrapper.find('.rc-table-tbody td').forEach(td => {
       expect(td.getDOMNode().attributes.getNamedItem('title')).toBeFalsy();
     });
+  });
+
+  it('renders scope', () => {
+    const wrapper = mount(
+      createTable({
+        columns: [
+          {
+            title: 'Name',
+            scope: 'col',
+          },
+          {
+            title: 'Contact',
+            scope: 'colgroup',
+            children: [
+              {
+                title: 'Email',
+                scope: 'col',
+              },
+              {
+                title: 'Phone Number',
+                scope: 'col',
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(wrapper.find('thead th').at(0).prop('scope')).toEqual('col');
+    expect(wrapper.find('thead th').at(1).prop('scope')).toEqual('colgroup');
+    expect(wrapper.find('thead th').at(2).prop('scope')).toEqual('col');
+    expect(wrapper.find('thead th').at(3).prop('scope')).toEqual('col');
   });
 
   it('renders column correctly', () => {


### PR DESCRIPTION
In this PR I added an optional ```scope``` prop to the table columns.

By adding this prop, we give developers an ability to improve accessibility in cases where the browser incorrectly determines the header cell type. And it can help users with a screen reader to better understand and navigate through tables.
Examples that describe this in more detail: [Simple table](https://www.w3.org/WAI/tutorials/tables/one-header/#table-with-ambiguous-data
), [Table with two-level header](https://www.w3.org/WAI/tutorials/tables/irregular/)
Without this attribute, tables that use rc-table may not meet the WCAG 1.3.1 success criteria.
Ref: https://www.w3.org/TR/WCAG20-TECHS/F91.html

Note: Because rc-table only uses column headers but not row headers, in the ```ScopeType``` interface I allowed only ​​```'col'``` and ```'colgroup'``` values