### PR TITLE
fix: 🐛 forceScroll error

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/jest": "^28.1.2",
     "@types/react": "^17.0.35",
     "@types/react-dom": "^18.0.5",
+    "@types/responselike": "^1.0.0",
     "@types/shallowequal": "^1.1.1",
     "@umijs/fabric": "^3.0.0",
     "cross-env": "^7.0.0",

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -24,60 +24,60 @@
  *  - All expanded props, move into expandable
  */
 
-import * as React from 'react';
-import isVisible from 'rc-util/lib/Dom/isVisible';
-import pickAttrs from 'rc-util/lib/pickAttrs';
-import { isStyleSupport } from 'rc-util/lib/Dom/styleChecker';
 import classNames from 'classnames';
-import shallowEqual from 'shallowequal';
-import warning from 'rc-util/lib/warning';
 import ResizeObserver from 'rc-resize-observer';
+import isVisible from 'rc-util/lib/Dom/isVisible';
+import { isStyleSupport } from 'rc-util/lib/Dom/styleChecker';
 import { getTargetScrollBarSize } from 'rc-util/lib/getScrollBarSize';
-import ColumnGroup from './sugar/ColumnGroup';
-import Column from './sugar/Column';
-import Header from './Header/Header';
-import type {
-  GetRowKey,
-  ColumnsType,
-  TableComponents,
-  Key,
-  DefaultRecordType,
-  TriggerEventHandler,
-  GetComponentProps,
-  ExpandableConfig,
-  LegacyExpandableProps,
-  GetComponent,
-  PanelRender,
-  TableLayout,
-  ExpandableType,
-  RowClassName,
-  CustomizeComponent,
-  ColumnType,
-  CustomizeScrollBody,
-  TableSticky,
-} from './interface';
-import TableContext from './context/TableContext';
-import BodyContext from './context/BodyContext';
+import pickAttrs from 'rc-util/lib/pickAttrs';
+import warning from 'rc-util/lib/warning';
+import * as React from 'react';
+import shallowEqual from 'shallowequal';
 import Body from './Body';
-import useColumns from './hooks/useColumns';
-import { useLayoutState, useTimeoutLock } from './hooks/useFrame';
-import { getPathValue, validateValue, getColumnsKey } from './utils/valueUtil';
-import ResizeContext from './context/ResizeContext';
-import useStickyOffsets from './hooks/useStickyOffsets';
 import ColGroup from './ColGroup';
-import { getExpandableProps } from './utils/legacyUtil';
-import Panel from './Panel';
-import Footer, { FooterComponents } from './Footer';
-import { findAllChildrenKeys, renderExpandIcon } from './utils/expandUtil';
-import { getCellFixedInfo } from './utils/fixUtil';
-import StickyScrollBar from './stickyScrollBar';
-import useSticky from './hooks/useSticky';
+import { EXPAND_COLUMN } from './constant';
+import BodyContext from './context/BodyContext';
+import ExpandedRowContext from './context/ExpandedRowContext';
+import ResizeContext from './context/ResizeContext';
+import StickyContext from './context/StickyContext';
+import TableContext from './context/TableContext';
 import FixedHolder from './FixedHolder';
+import Footer, { FooterComponents } from './Footer';
 import type { SummaryProps } from './Footer/Summary';
 import Summary from './Footer/Summary';
-import StickyContext from './context/StickyContext';
-import ExpandedRowContext from './context/ExpandedRowContext';
-import { EXPAND_COLUMN } from './constant';
+import Header from './Header/Header';
+import useColumns from './hooks/useColumns';
+import { useLayoutState, useTimeoutLock } from './hooks/useFrame';
+import useSticky from './hooks/useSticky';
+import useStickyOffsets from './hooks/useStickyOffsets';
+import type {
+  ColumnsType,
+  ColumnType,
+  CustomizeComponent,
+  CustomizeScrollBody,
+  DefaultRecordType,
+  ExpandableConfig,
+  ExpandableType,
+  GetComponent,
+  GetComponentProps,
+  GetRowKey,
+  Key,
+  LegacyExpandableProps,
+  PanelRender,
+  RowClassName,
+  TableComponents,
+  TableLayout,
+  TableSticky,
+  TriggerEventHandler,
+} from './interface';
+import Panel from './Panel';
+import StickyScrollBar from './stickyScrollBar';
+import Column from './sugar/Column';
+import ColumnGroup from './sugar/ColumnGroup';
+import { findAllChildrenKeys, renderExpandIcon } from './utils/expandUtil';
+import { getCellFixedInfo } from './utils/fixUtil';
+import { getExpandableProps } from './utils/legacyUtil';
+import { getColumnsKey, getPathValue, validateValue } from './utils/valueUtil';
 
 // Used for conditions cache
 const EMPTY_DATA = [];
@@ -458,10 +458,15 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
     if (typeof target === 'function') {
       target(scrollLeft);
     } else if (target.scrollLeft !== scrollLeft) {
-      // eslint-disable-next-line no-param-reassign
-      setTimeout(() => {
-        target.scrollLeft = scrollLeft;
-      }, 0);
+      target.scrollLeft = scrollLeft;
+
+      // Delay to force scroll position if not sync
+      // ref: https://github.com/ant-design/ant-design/issues/37179
+      if (target.scrollLeft !== scrollLeft) {
+        setTimeout(() => {
+          target.scrollLeft = scrollLeft;
+        }, 0);
+      }
     }
   }
 
@@ -615,7 +620,9 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
   );
 
   const captionElement =
-    caption !== null && caption !== undefined ? <caption className={`${prefixCls}-caption`}>{caption}</caption> : undefined;
+    caption !== null && caption !== undefined ? (
+      <caption className={`${prefixCls}-caption`}>{caption}</caption>
+    ) : undefined;
 
   const customizeScrollBody = getComponent(['body']) as CustomizeScrollBody<RecordType>;
 

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -459,7 +459,9 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
       target(scrollLeft);
     } else if (target.scrollLeft !== scrollLeft) {
       // eslint-disable-next-line no-param-reassign
-      target.scrollLeft = scrollLeft;
+      setTimeout(() => {
+        target.scrollLeft = scrollLeft;
+      }, 0);
     }
   }
 

--- a/tests/Scroll.spec.js
+++ b/tests/Scroll.spec.js
@@ -114,6 +114,7 @@ describe('Table.Scroll', () => {
           },
         });
     });
+    jest.runAllTimers();
     expect(setScrollLeft).toHaveBeenCalledWith(undefined, 33);
     setScrollLeft.mockReset();
 


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/37179

当动态新增 `columns` 时，调用 `forceScroll` 方法，设置 `scrollLeft`，并不起作用，发现此时的 `scrollLeft` 为 0，

[MDN文档](https://developer.mozilla.org/zh-CN/docs/Web/API/Element/scrollLeft)
> 如果元素不能滚动（比如：元素没有溢出），那么 `scrollLeft` 的值是 0。
如果给 `scrollLeft` 设置的值小于 0，那么 `scrollLeft` 的值将变为 0。
如果给 `scrollLeft` 设置的值大于元素内容最大宽度，那么 `scrollLeft` 的值将被设为元素最大宽度。

此时我打印了 `scrollWidth`，发现 `scrollWidth` 与预期不同，正常 `scrollWidth` 应该为 1800(此值为上方bug链接中的案例)， 此时为 358， 与`offsetWidth`，猜测符合MDN中说的第一条规则，**如果元素不能滚动（比如：元素没有溢出），那么scrollLeft 的值是 0**。

解决办法：
  我能想到的就是将 `scrollLeft` 设置推迟到 dom 更新后执行，不知道有没有更好的办法😮‍💨