### PR TITLE
fix: when set scrollY, overflow-y will be "auto"

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -416,7 +416,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
 
   if (fixHeader) {
     scrollYStyle = {
-      overflowY: 'scroll',
+      overflowY: 'auto',
       maxHeight: scroll.y,
     };
   }

--- a/tests/Scroll.spec.js
+++ b/tests/Scroll.spec.js
@@ -5,7 +5,10 @@ import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
 import Table from '../src';
 
 describe('Table.Scroll', () => {
-  const data = [{ key: 'key0', name: 'Lucy' }, { key: 'key1', name: 'Jack' }];
+  const data = [
+    { key: 'key0', name: 'Lucy' },
+    { key: 'key1', name: 'Jack' },
+  ];
   const createTable = props => {
     const columns = [{ title: 'Name', dataIndex: 'name', key: 'name' }];
 
@@ -32,7 +35,7 @@ describe('Table.Scroll', () => {
   it('renders scroll.x and scroll.y are both true', () => {
     const wrapper = mount(createTable({ scroll: { x: true, y: 200 } }));
     expect(wrapper.find('.rc-table-body').props().style.overflowX).toEqual('auto');
-    expect(wrapper.find('.rc-table-body').props().style.overflowY).toEqual('scroll');
+    expect(wrapper.find('.rc-table-body').props().style.overflowY).toEqual('auto');
   });
 
   it('fire scroll event', () => {

--- a/tests/__snapshots__/FixedColumn.spec.js.snap
+++ b/tests/__snapshots__/FixedColumn.spec.js.snap
@@ -1909,7 +1909,7 @@ exports[`Table.FixedColumn renders correctly scrollXY - with data 1`] = `
     </div>
     <div
       class="rc-table-body"
-      style="overflow-x: auto; overflow-y: scroll; max-height: 100px;"
+      style="overflow-x: auto; overflow-y: auto; max-height: 100px;"
     >
       <table
         style="width: 1200px; min-width: 100%; table-layout: fixed;"
@@ -2740,7 +2740,7 @@ exports[`Table.FixedColumn renders correctly scrollXY - without data 1`] = `
     </div>
     <div
       class="rc-table-body"
-      style="overflow-x: auto; overflow-y: scroll; max-height: 100px;"
+      style="overflow-x: auto; overflow-y: auto; max-height: 100px;"
     >
       <table
         style="width: 1200px; min-width: 100%; table-layout: fixed;"

--- a/tests/__snapshots__/Table.spec.js.snap
+++ b/tests/__snapshots__/Table.spec.js.snap
@@ -118,7 +118,7 @@ exports[`Table.Basic custom components renders fixed column and header correctly
     </div>
     <div
       class="rc-table-body"
-      style="overflow-x: auto; overflow-y: scroll; max-height: 100px;"
+      style="overflow-x: auto; overflow-y: auto; max-height: 100px;"
     >
       <table
         name="my-table"


### PR DESCRIPTION
When `Table` add property` scroll={{ y: 355 }}`，and internal height is less than 355，a scroll bar will appear

https://codesandbox.io/s/ji-ben-yong-fa-antd-4-22-8-forked-hww656

![image](https://user-images.githubusercontent.com/44605072/187118309-19cc4c56-19ca-46fc-a027-8de43f44013d.png)

But when changed `ant-table-body` style `overflow-y` from `scroll`  to `auto` , it looks good 

![image](https://user-images.githubusercontent.com/44605072/187118795-732a36d8-bd12-4432-a154-7daca6b42230.png)
