### PR TITLE
fix: rowExpandable在树形表格下不生效

### DIFF
--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -88,10 +88,10 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
       setExpandRended(true);
     }
   }, [expanded]);
-
-  const rowSupportExpand = expandableType === 'row' && (!rowExpandable || rowExpandable(record));
-  // Only when row is not expandable and `children` exist in record
-  const nestExpandable = expandableType === 'nest';
+  const notExpandable = !rowExpandable || rowExpandable(record)
+  const rowSupportExpand = expandableType === 'row' && notExpandable;
+  //  when `children` exist in record
+  const nestExpandable = expandableType === 'nest' && notExpandable;
   const hasNestChildren = childrenColumnName && record && record[childrenColumnName];
   const mergedExpandable = rowSupportExpand || nestExpandable;
 

--- a/tests/ExpandRow.spec.js
+++ b/tests/ExpandRow.spec.js
@@ -636,4 +636,31 @@ describe('Table.Expand', () => {
     );
     errorSpy.mockRestore();
   });
+
+  it('nest with `rowExpandable`', () => {
+    const data = [
+      {
+        key: 0,
+        children: [
+          {
+            key: 1,
+            children: [],
+          },
+        ],
+      },
+      {
+        key: 2,
+        children: [],
+      },
+    ];
+    const wrapper = mount(
+      createTable({
+        data, expandable: {
+          rowExpandable: ({ children }) => !!children.length,
+          defaultExpandAllRows: true
+        }
+      }),
+    );
+    expect(wrapper.find('tbody tr')).toHaveLength(3);
+  })
 });


### PR DESCRIPTION
fix: [ant-design/ant-design#37208](https://github.com/ant-design/ant-design/issues/37208)