### PR TITLE
fix: the right border disappears when the table has no data

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -417,7 +417,7 @@ function Table<RecordType extends DefaultRecordType>(props: TableProps<RecordTyp
 
   if (fixHeader) {
     scrollYStyle = {
-      overflowY: 'scroll',
+      overflowY: hasData ? 'scroll' : 'hidden',
       maxHeight: scroll.y,
     };
   }


### PR DESCRIPTION
修复ant design 中 table 固定列，表格无数据时，右侧边框不显示的问题

fix: https://github.com/ant-design/ant-design/issues/39115