### PR TITLE
Use more specific type to ColumnType['dataIndex']

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -84,7 +84,7 @@ export type AlignType = 'left' | 'center' | 'right';
 
 export interface ColumnType<RecordType> extends ColumnSharedType<RecordType> {
   colSpan?: number;
-  dataIndex?: DataIndex;
+  dataIndex?: keyof RecordType;
   render?: (
     value: any,
     record: RecordType,


### PR DESCRIPTION
How about setting `ColumnType['dataIndex']` to the key of `RecordType`?