### PR TITLE
chore: make dumi types can be resolved

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "paths": {
       "@/*": ["src/*"],
-      "@@/*": ["src/.umi/*"],
+      "@@/*": [".dumi/tmp/*"],
       "rc-table": ["src/index.ts"]
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,6 @@
       "@@/*": [".dumi/tmp/*"],
       "rc-table": ["src/index.ts"]
     }
-  }
+  },
+  "include": [".dumi/**/*", ".dumirc.ts", "**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
修复 `.dumirc.ts` 里 `defineConfig` 类型缺失的问题