### PR TITLE
🐞 FIX: swap columns for rtl direction

### DIFF
--- a/src/utils/fixUtil.ts
+++ b/src/utils/fixUtil.ts
@@ -1,4 +1,10 @@
-import type { StickyOffsets, FixedType, Direction, ColumnType, ColumnGroupType } from '../interface';
+import type {
+  ColumnGroupType,
+  ColumnType,
+  Direction,
+  FixedType,
+  StickyOffsets,
+} from '../interface';
 
 export interface FixedInfo {
   fixLeft: number | false;
@@ -19,7 +25,7 @@ export function getCellFixedInfo<RecordType = any>(
   columns: readonly { fixed?: FixedType }[],
   stickyOffsets: StickyOffsets,
   direction: Direction,
-  curColumns?: ColumnType<RecordType> | ColumnGroupType<RecordType>
+  curColumns?: ColumnType<RecordType> | ColumnGroupType<RecordType>,
 ): FixedInfo {
   const startColumn = columns[colStart] || {};
   const endColumn = columns[colEnd] || {};
@@ -28,9 +34,9 @@ export function getCellFixedInfo<RecordType = any>(
   let fixRight: number;
 
   if (startColumn.fixed === 'left') {
-    fixLeft = stickyOffsets.left[colStart];
+    fixLeft = stickyOffsets.left[direction === 'rtl' ? colEnd : colStart];
   } else if (endColumn.fixed === 'right') {
-    fixRight = stickyOffsets.right[colEnd];
+    fixRight = stickyOffsets.right[direction === 'rtl' ? colStart : colEnd];
   }
 
   let lastFixLeft: boolean = false;


### PR DESCRIPTION
Closes https://github.com/ant-design/ant-design/issues/41070

There is a problem in ant design's Table component in **rtl** direction when using fixed summary.

![image](https://user-images.githubusercontent.com/33312687/222891083-6433d625-3d83-468f-ba38-aa9869abe2f3.png)

I tested the changes in **sticky-header-and-summary** example and it was okay.

![image](https://user-images.githubusercontent.com/33312687/222891155-4a609327-f0e0-48a7-80cd-e3b9ce0f713b.png)
