### PR TITLE
fix: when columns is empty, don't warning

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -570,10 +570,12 @@ function Table<RecordType extends DefaultRecordType>(tableProps: TableProps<Reco
         if (typeof colWidth === 'number' && !Number.isNaN(colWidth)) {
           return colWidth;
         }
-        warning(
-          false,
-          'When use `components.body` with render props. Each column should have a fixed `width` value.',
-        );
+        if ((props?.columns || []).length !== 0) {
+          warning(
+            false,
+            'When use `components.body` with render props. Each column should have a fixed `width` value.',
+          ); 
+        }
 
         return 0;
       }) as number[];

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -570,12 +570,10 @@ function Table<RecordType extends DefaultRecordType>(tableProps: TableProps<Reco
         if (typeof colWidth === 'number' && !Number.isNaN(colWidth)) {
           return colWidth;
         }
-        if ((props?.columns || []).length !== 0) {
           warning(
-            false,
+            (props?.columns || []).length === 0,
             'When use `components.body` with render props. Each column should have a fixed `width` value.',
           ); 
-        }
 
         return 0;
       }) as number[];


### PR DESCRIPTION
## 当自定义 table.body && column?.length == 0 会报错 
## 期望传空数组时候 别报错
<img width="1057" alt="224067680-224a6880-13dc-4bb7-9877-b3652718c471" src="https://user-images.githubusercontent.com/63464198/224085047-cb80af0c-ef82-4ec9-ac98-b34414d276bd.png">
