### PR TITLE
fix: table warning message when columns=[]

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -570,11 +570,12 @@ function Table<RecordType extends DefaultRecordType>(tableProps: TableProps<Reco
         if (typeof colWidth === 'number' && !Number.isNaN(colWidth)) {
           return colWidth;
         }
-        warning(
-          false,
-          'When use `components.body` with render props. Each column should have a fixed `width` value.',
-        );
-
+        if (props.columns.length > 0) {
+          warning(
+            false,
+            'When use `components.body` with render props. Each column should have a fixed `width` value.',
+          );
+        }
         return 0;
       }) as number[];
     } else {
@@ -599,7 +600,11 @@ function Table<RecordType extends DefaultRecordType>(tableProps: TableProps<Reco
             {bodyColGroup}
             {bodyTable}
             {!fixFooter && summaryNode && (
-              <Footer stickyOffsets={stickyOffsets} flattenColumns={flattenColumns} columns={columns}>
+              <Footer
+                stickyOffsets={stickyOffsets}
+                flattenColumns={flattenColumns}
+                columns={columns}
+              >
                 {summaryNode}
               </Footer>
             )}

--- a/tests/Table.spec.js
+++ b/tests/Table.spec.js
@@ -701,6 +701,24 @@ describe('Table.Basic', () => {
       });
     });
 
+    it('without warning - columns is emplty', () => {
+      resetWarned();
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mount(
+        createTable({
+          columns: [],
+          components: {
+            body: () => <h1>Bamboo</h1>,
+          },
+          scroll: { x: 100, y: 100 },
+        }),
+      );
+      expect(errSpy).not.toHaveBeenCalledWith(
+        'Warning: When use `components.body` with render props. Each column should have a fixed `width` value.',
+      );
+      errSpy.mockRestore();
+    });
+
     it('not crash', () => {
       const Looper = React.forwardRef(() => <td />);
       Looper.looper = Looper;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

fix https://github.com/ant-design/ant-design/issues/41150

### 💡 Background and solution

Issue: Error message logged on the console when columns is empty []. This issue occurs in the custom body component: 
```
<Table
 {...props}
 components={{
          body: renderSomethinig,
        }}
/>
```

After looking into it, I find that there's no major issue when columns is empty []. So, I just added a conditional  check to only log an error if columns.length > 0.


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |   fix error message being logged in the custom body component when columns is empty []         |
| 🇨🇳 Chinese |  修复自定义 body component, columns[] 為空時 错误报错错误报
### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
