### PR TITLE
feat(type): improve autocompletion for `rowKey`

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -92,7 +92,7 @@ export interface TableProps<RecordType = unknown>
   children?: React.ReactNode;
   data?: readonly RecordType[];
   columns?: ColumnsType<RecordType>;
-  rowKey?: string | GetRowKey<RecordType>;
+  rowKey?: (string & {}) | keyof RecordType | GetRowKey<RecordType>;
   tableLayout?: TableLayout;
 
   // Fixed Columns
@@ -107,7 +107,7 @@ export interface TableProps<RecordType = unknown>
   // Additional Part
   footer?: PanelRender<RecordType>;
   summary?: (data: readonly RecordType[]) => React.ReactNode;
-  caption?: string | React.ReactNode;
+  caption?: React.ReactNode;
 
   // Customize
   id?: string;


### PR DESCRIPTION
did two things:
- improve auto completion, by using the same technique that ant-design is using: [LiteralUnion](https://github.com/ant-design/ant-design/blob/f53618ddaa753c2614f777a7883d1b342bf3bdd8/components/_util/type.ts#L2)
- remove redundant type annotation: the union type `React.ReactNode` already has `string`

![image](https://user-images.githubusercontent.com/30516060/229170300-4bfeb015-5771-4620-8288-4e43d4d06f32.png)
