### PR TITLE
fix: do not render collapsed row

### DIFF
--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -56,13 +56,12 @@ function ExpandedRow(props: ExpandedRowProps) {
     );
   }
 
+  if (!expanded) {
+    return null;
+  }
+
   return (
-    <Component
-      className={className}
-      style={{
-        display: expanded ? null : 'none',
-      }}
-    >
+    <Component className={className}>
       <Cell component={cellComponent} prefixCls={prefixCls} colSpan={colSpan}>
         {contentNode}
       </Cell>


### PR DESCRIPTION
This fixes the case where you expand a table row which adds an element to the DOM, but previously would not be removed from the DOM when collapsing the row again. 

This fix is useful for implementing zebra striping on a table with expandable rows, as without this fix, expanding a row and then collapsing it adds an invisible row which messes up striping.