### PR TITLE
fix: cannot render docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ React.render(<Table columns={columns} data={data} />, mountNode);
 | key | String |  | key of this summary |
 | className | String | - | className of this summary row |
 | style | React.CSSProperties | - | style of this summary row |
-| onClick | (e?: React.MouseEvent<HTMLElement>) => void | - | The `onClick` attribute in `Table.Summary.Row` component can be used to set a click event handler for the summary row. |
+| onClick | (e?: React.MouseEvent\<HTMLElement>) => void | - | The `onClick` attribute in `Table.Summary.Row` component can be used to set a click event handler for the summary row. |
 
 ## License
 


### PR DESCRIPTION
Currently, the docs page at https://table.react-component.now.sh cannot be shown and throwing this error:

![Screenshot 2566-05-23 at 17 10 39](https://github.com/react-component/table/assets/9304909/6e2ada78-2010-402a-986d-e2f8e77d872f)

This is due to the `<HTMLElement>` that was added in the `README.md` at commit https://github.com/react-component/table/pull/985/commits/c43523efb86d3911b915ebdcec916934561401be has no escape character (`/`), therefore being unintentionally compiled as a real HTML element.

This PR fixes #992 by adding an escape character so that https://table.react-component.now.sh is back online again.