### PR TITLE
fix: Missing caption styling

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -284,6 +284,13 @@
     border-bottom: 0;
   }
 
+  // ================= Caption ==================
+  &-caption {
+    padding: @cell-padding;
+    border-right: @border;
+    border-bottom: @border;
+  }
+
   // ================= Footer =================
   &-footer {
     padding: @cell-padding;


### PR DESCRIPTION
Missing styling added for caption. 

closed  [#999]

<img width="749" alt="Screenshot 2023-06-30 at 11 39 56 pm" src="https://github.com/react-component/table/assets/29937197/ece12f97-9c88-4988-822e-79d1577a57b9">
