### PR TITLE
chore: rm title deprecated mark

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -184,7 +184,6 @@ export interface LegacyExpandableProps<RecordType> {
   expandedRowClassName?: RowClassName<RecordType>;
   /** @deprecated Use `expandable.childrenColumnName` instead */
   childrenColumnName?: string;
-  /** @deprecated Use `caption` instead */
   title?: PanelRender<RecordType>;
 }
 


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/43036
close https://github.com/ant-design/ant-design/pull/43172

`caption` 是 table 内嵌元素，和 `title` 是不等价的。这个不能直接 deprecated：

![Kapture 2023-08-11 at 17 56 24](https://github.com/react-component/table/assets/5378891/9c914500-0b6d-4e4a-9fd4-43512dfc88d6)

