### PR TITLE
fix: rerender table trigger table-body collapses

### DIFF
--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -40,7 +40,7 @@ function ExpandedRow(props: ExpandedRowProps) {
   // Cache render node
   let contentNode = children;
 
-  if (isEmpty ? horizonScroll : fixColumn) {
+  if (isEmpty ? horizonScroll && componentWidth : fixColumn) {
     contentNode = (
       <div
         style={{
@@ -51,7 +51,7 @@ function ExpandedRow(props: ExpandedRowProps) {
         }}
         className={`${prefixCls}-expanded-row-fixed`}
       >
-        {componentWidth !== 0 && contentNode}
+        {contentNode}
       </div>
     );
   }


### PR DESCRIPTION
When a table has 'scrollX' prop is initialized , the height of the table body collapses to zero. This issue leads to shaking when two tables are switched. The root cause is the presence of empty text in ExpandedRow. To address this, introduce a conditional check for horizonScroll to prevent this unintended behavior.

issue: https://github.com/ant-design/ant-design/issues/44281