### PR TITLE
enhance: Rm duplicated re-render of expanded row

### DIFF
--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import Cell from '../Cell';
 import { responseImmutable } from '../context/TableContext';
 import devRenderTimes from '../hooks/useRenderTimes';
+import useRowInfo from '../hooks/useRowInfo';
 import type { ColumnType, CustomizeComponent, GetRowKey } from '../interface';
 import ExpandedRow from './ExpandedRow';
-import useRowInfo from '../hooks/useRowInfo';
 
 export interface BodyRowProps<RecordType> {
   record: RecordType;
@@ -116,17 +116,13 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
     rowSupportExpand,
   } = rowInfo;
 
-  const [expandRended, setExpandRended] = React.useState(false);
+  // Force render expand row if expanded before
+  const expandedRef = React.useRef(false);
+  expandedRef.current ||= expanded;
 
   if (process.env.NODE_ENV !== 'production') {
     devRenderTimes(props);
   }
-
-  React.useEffect(() => {
-    if (expanded) {
-      setExpandRended(true);
-    }
-  }, [expanded]);
 
   // ======================== Base tr row ========================
   const baseRowNode = (
@@ -181,7 +177,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
 
   // ======================== Expand Row =========================
   let expandRowNode: React.ReactElement;
-  if (rowSupportExpand && (expandRended || expanded)) {
+  if (rowSupportExpand && (expandedRef.current || expanded)) {
     const expandContent = expandedRowRender(record, index, indent + 1, expanded);
     const computedExpandedRowClassName =
       expandedRowClassName && expandedRowClassName(record, index, indent);

--- a/tests/ExpandRow.spec.jsx
+++ b/tests/ExpandRow.spec.jsx
@@ -1,3 +1,4 @@
+import { render } from '@testing-library/react';
 import { mount } from 'enzyme';
 import { spyElementPrototype } from 'rc-util/lib/test/domHook';
 import { resetWarned } from 'rc-util/lib/warning';
@@ -635,5 +636,19 @@ describe('Table.Expand', () => {
       'Warning: `expandedRowRender` should not use with nested Table',
     );
     errorSpy.mockRestore();
+  });
+
+  it('should only trigger once', () => {
+    const expandedRowRender = vi.fn(() => <p>extra data</p>);
+    render(
+      createTable({
+        expandable: {
+          expandedRowRender,
+          expandedRowKeys: [0],
+        },
+      }),
+    );
+
+    expect(expandedRowRender).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
更标准的解法应该是 `useState` 在关闭时一起做 state 更新，但是这样会让渲染逻辑变得过于复杂。只为了少一次渲染会变得缺少性价比。

close https://github.com/ant-design/ant-design/issues/44890