### PR TITLE
fix: when using scrollTo the outer layer also scrolls at the same time

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -328,7 +328,16 @@ function Table<RecordType extends DefaultRecordType>(
             });
           } else {
             const mergedKey = key ?? getRowKey(mergedData[index]);
-            scrollBodyRef.current.querySelector(`[data-row-key="${mergedKey}"]`)?.scrollIntoView();
+            const { offsetTop } =
+              (scrollBodyRef.current.querySelector(
+                `[data-row-key="${mergedKey}"]`,
+              ) as HTMLElement) || {};
+
+            if (offsetTop !== undefined) {
+              scrollBodyRef.current?.scrollTo({
+                top: offsetTop,
+              });
+            }
           }
         } else if ((scrollBodyRef.current as any)?.scrollTo) {
           // Pass to proxy

--- a/tests/refs.spec.tsx
+++ b/tests/refs.spec.tsx
@@ -5,16 +5,11 @@ import Table, { type Reference } from '../src';
 
 describe('Table.Ref', () => {
   let scrollParam: any = null;
-  let scrollIntoViewElement: HTMLElement = null;
 
   beforeAll(() => {
     spyElementPrototypes(HTMLElement, {
       scrollTo: (_: any, param: any) => {
         scrollParam = param;
-      },
-      scrollIntoView() {
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
-        scrollIntoViewElement = this;
       },
     });
   });
@@ -49,17 +44,5 @@ describe('Table.Ref', () => {
     });
 
     expect(scrollParam.top).toEqual(903);
-
-    // Scroll index
-    ref.current.scrollTo({
-      index: 0,
-    });
-    expect(scrollIntoViewElement.textContent).toEqual('light');
-
-    // Scroll key
-    ref.current.scrollTo({
-      key: 'bamboo',
-    });
-    expect(scrollIntoViewElement.textContent).toEqual('bamboo');
   });
 });

--- a/tests/refs.spec.tsx
+++ b/tests/refs.spec.tsx
@@ -44,5 +44,17 @@ describe('Table.Ref', () => {
     });
 
     expect(scrollParam.top).toEqual(903);
+
+    // Scroll index
+    ref.current.scrollTo({
+      index: 0,
+    });
+    expect(scrollParam.top).toEqual(0);
+
+    // Scroll key
+    ref.current.scrollTo({
+      key: 'bamboo',
+    });
+    expect(scrollParam.top).toEqual(0);
   });
 });


### PR DESCRIPTION
使用 scrollTo 替换 scrollIntoView，避免出现嵌套滚动 div 的时候，使内部 div 滚动同时导致外部的 div 也一起滚动。

https://github.com/ant-design/ant-design/issues/46467