### PR TITLE
fix: should check sticky scroll bar visible when table height changed

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -357,8 +357,6 @@ function Table<RecordType extends DefaultRecordType>(
   const stickyRef = React.useRef<{ setScrollLeft: (left: number) => void }>();
   const { isSticky, offsetHeader, offsetSummary, offsetScroll, stickyClassName, container } =
     useSticky(sticky, prefixCls);
-  const showStickyScrollbar =
-    isSticky && scrollBodyRef.current && scrollBodyRef.current instanceof Element;
 
   // Footer (Fix footer must fixed header)
   const summaryNode = React.useMemo(() => summary?.(mergedData), [summary, mergedData]);
@@ -701,7 +699,7 @@ function Table<RecordType extends DefaultRecordType>(
           </FixedHolder>
         )}
 
-        {showStickyScrollbar && (
+        {isSticky && scrollBodyRef.current && scrollBodyRef.current instanceof Element && (
           <StickyScrollBar
             ref={stickyRef}
             offsetScroll={offsetScroll}

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -354,10 +354,7 @@ function Table<RecordType extends DefaultRecordType>(
   const fixColumn = horizonScroll && flattenColumns.some(({ fixed }) => fixed);
 
   // Sticky
-  const stickyRef = React.useRef<{
-    setScrollLeft: (left: number) => void;
-    checkScrollBarVisible: () => void;
-  }>();
+  const stickyRef = React.useRef<{ setScrollLeft: (left: number) => void }>();
   const { isSticky, offsetHeader, offsetSummary, offsetScroll, stickyClassName, container } =
     useSticky(sticky, prefixCls);
   const showStickyScrollbar =
@@ -631,41 +628,36 @@ function Table<RecordType extends DefaultRecordType>(
       }) as number[];
     } else {
       bodyContent = (
-        <ResizeObserver
-          disabled={!showStickyScrollbar}
-          onResize={() => stickyRef.current?.checkScrollBarVisible()}
+        <div
+          style={{
+            ...scrollXStyle,
+            ...scrollYStyle,
+          }}
+          onScroll={onScroll}
+          ref={scrollBodyRef}
+          className={classNames(`${prefixCls}-body`)}
         >
-          <div
+          <TableComponent
             style={{
-              ...scrollXStyle,
-              ...scrollYStyle,
+              ...scrollTableStyle,
+              tableLayout: mergedTableLayout,
             }}
-            onScroll={onScroll}
-            ref={scrollBodyRef}
-            className={classNames(`${prefixCls}-body`)}
+            {...ariaProps}
           >
-            <TableComponent
-              style={{
-                ...scrollTableStyle,
-                tableLayout: mergedTableLayout,
-              }}
-              {...ariaProps}
-            >
-              {captionElement}
-              {bodyColGroup}
-              {bodyTable}
-              {!fixFooter && summaryNode && (
-                <Footer
-                  stickyOffsets={stickyOffsets}
-                  flattenColumns={flattenColumns}
-                  columns={columns}
-                >
-                  {summaryNode}
-                </Footer>
-              )}
-            </TableComponent>
-          </div>
-        </ResizeObserver>
+            {captionElement}
+            {bodyColGroup}
+            {bodyTable}
+            {!fixFooter && summaryNode && (
+              <Footer
+                stickyOffsets={stickyOffsets}
+                flattenColumns={flattenColumns}
+                columns={columns}
+              >
+                {summaryNode}
+              </Footer>
+            )}
+          </TableComponent>
+        </div>
       );
     }
 
@@ -716,6 +708,7 @@ function Table<RecordType extends DefaultRecordType>(
             scrollBodyRef={scrollBodyRef}
             onScroll={onScroll}
             container={container}
+            data={data}
           />
         )}
       </>

--- a/src/stickyScrollBar.tsx
+++ b/src/stickyScrollBar.tsx
@@ -118,6 +118,7 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
 
   React.useImperativeHandle(ref, () => ({
     setScrollLeft,
+    checkScrollBarVisible,
   }));
 
   React.useEffect(() => {
@@ -139,20 +140,6 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
       onResizeListener.remove();
     };
   }, [container]);
-
-  React.useEffect(() => {
-    if (!scrollBodyRef.current) {
-      return;
-    }
-    const observer = new ResizeObserver(() => {
-      checkScrollBarVisible();
-    });
-    observer.observe(scrollBodyRef.current);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, []);
 
   React.useEffect(() => {
     if (!scrollState.isHiddenScrollBar) {

--- a/src/stickyScrollBar.tsx
+++ b/src/stickyScrollBar.tsx
@@ -80,7 +80,7 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
     refState.current.x = event.pageX;
   };
 
-  const onContainerScroll = () => {
+  const checkScrollBarVisible = () => {
     if (!scrollBodyRef.current) {
       return;
     }
@@ -123,7 +123,7 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
   React.useEffect(() => {
     const onMouseUpListener = addEventListener(document.body, 'mouseup', onMouseUp, false);
     const onMouseMoveListener = addEventListener(document.body, 'mousemove', onMouseMove, false);
-    onContainerScroll();
+    checkScrollBarVisible();
     return () => {
       onMouseUpListener.remove();
       onMouseMoveListener.remove();
@@ -131,14 +131,28 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
   }, [scrollBarWidth, isActive]);
 
   React.useEffect(() => {
-    const onScrollListener = addEventListener(container, 'scroll', onContainerScroll, false);
-    const onResizeListener = addEventListener(window, 'resize', onContainerScroll, false);
+    const onScrollListener = addEventListener(container, 'scroll', checkScrollBarVisible, false);
+    const onResizeListener = addEventListener(window, 'resize', checkScrollBarVisible, false);
 
     return () => {
       onScrollListener.remove();
       onResizeListener.remove();
     };
   }, [container]);
+
+  React.useEffect(() => {
+    if (!scrollBodyRef.current) {
+      return;
+    }
+    const observer = new ResizeObserver(() => {
+      checkScrollBarVisible();
+    });
+    observer.observe(scrollBodyRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
 
   React.useEffect(() => {
     if (!scrollState.isHiddenScrollBar) {

--- a/src/stickyScrollBar.tsx
+++ b/src/stickyScrollBar.tsx
@@ -12,10 +12,11 @@ interface StickyScrollBarProps {
   onScroll: (params: { scrollLeft?: number }) => void;
   offsetScroll: number;
   container: HTMLElement | Window;
+  data?: readonly any[];
 }
 
 const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarProps> = (
-  { scrollBodyRef, onScroll, offsetScroll, container },
+  { scrollBodyRef, onScroll, offsetScroll, container, data },
   ref,
 ) => {
   const prefixCls = useContext(TableContext, 'prefixCls');
@@ -118,7 +119,6 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
 
   React.useImperativeHandle(ref, () => ({
     setScrollLeft,
-    checkScrollBarVisible,
   }));
 
   React.useEffect(() => {
@@ -155,6 +155,11 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
       });
     }
   }, [scrollState.isHiddenScrollBar]);
+
+  // The best way is to use ResizeObserver to detect the body height, but this way is enough
+  React.useEffect(() => {
+    checkScrollBarVisible();
+  }, [data]);
 
   if (bodyScrollWidth <= bodyWidth || !scrollBarWidth || scrollState.isHiddenScrollBar) {
     return null;


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/47331
fix https://github.com/ant-design/ant-design/issues/33762

结论：最好的方式是用 ResizeObserver 监听 table body 高度（会耗一些性能），但是基本场景监听 data 变化去检测也够用了，有人提问题的话之后再把 useEffect 的依赖项去掉

https://github.com/react-component/table/assets/47104575/edb54c74-49ad-4837-b46a-7dffb1041164

