### PR TITLE
feat: use css hover when no rowSpan

### DIFF
--- a/assets/index.less
+++ b/assets/index.less
@@ -214,6 +214,12 @@
         background: #fff;
       }
 
+      &:hover {
+        > td {
+          background: #fff4f4;
+        }
+      }
+
       th {
         background: @table-head-background-color;
       }

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -129,6 +129,15 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
   const computedExpandedRowClassName =
     expandedRowClassName && expandedRowClassName(record, index, indent);
 
+  const cellPropsArray = flattenColumns.map((column, colIndex) =>
+    getCellProps(rowInfo, column, colIndex, indent, index),
+  );
+  const useJsHover = flattenColumns.some((_, colIndex) => {
+    const { additionalCellProps } = cellPropsArray[colIndex];
+    const rowSpan = additionalCellProps.rowSpan ?? 1;
+    return rowSpan !== 1;
+  });
+
   // ======================== Base tr row ========================
   const baseRowNode = (
     <RowComponent
@@ -149,16 +158,11 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
       {flattenColumns.map((column: ColumnType<RecordType>, colIndex) => {
         const { render, dataIndex, className: columnClassName } = column;
 
-        const { key, fixedInfo, appendCellNode, additionalCellProps } = getCellProps(
-          rowInfo,
-          column,
-          colIndex,
-          indent,
-          index,
-        );
+        const { key, fixedInfo, appendCellNode, additionalCellProps } = cellPropsArray[colIndex];
 
         return (
           <Cell
+            useJsHover={useJsHover}
             className={columnClassName}
             ellipsis={column.ellipsis}
             align={column.align}
@@ -211,10 +215,6 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
       {expandRowNode}
     </>
   );
-}
-
-if (process.env.NODE_ENV !== 'production') {
-  BodyRow.displayName = 'BodyRow';
 }
 
 export default responseImmutable(BodyRow);

--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -33,6 +33,7 @@ export interface CellProps<RecordType extends DefaultRecordType> {
   scope?: ScopeType;
   ellipsis?: CellEllipsisType;
   align?: AlignType;
+  useJsHover?: boolean;
 
   shouldCellUpdate?: (record: RecordType, prevRecord: RecordType) => boolean;
 
@@ -87,6 +88,7 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     prefixCls,
     className,
     align,
+    useJsHover = true,
 
     // Value
     record,
@@ -244,8 +246,8 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
       title={title}
       scope={scope}
       // Hover
-      onMouseEnter={onMouseEnter}
-      onMouseLeave={onMouseLeave}
+      onMouseEnter={useJsHover ? onMouseEnter : undefined}
+      onMouseLeave={useJsHover ? onMouseLeave : undefined}
       //Span
       colSpan={mergedColSpan !== 1 ? mergedColSpan : null}
       rowSpan={mergedRowSpan !== 1 ? mergedRowSpan : null}


### PR DESCRIPTION
1、当前这行有某个 cell 的 rowSpan 不为 1 时，使用 js 的 hover。如果都为 1，使用 css hover。
2、legacyCellProps 里的 rowSpan 先不判断了，我看 virtual-table 代码里也没判断，没人用了吧，有问题再说？否则要在 row 每个再算一遍，或者传到 cell 里。

ref: https://github.com/ant-design/ant-design/issues/32979
ref: https://github.com/ant-design/ant-design/issues/46934