### PR TITLE
Column width supports this type of writing, such as '100' and '100px'

### DIFF
--- a/src/hooks/useColumns/useWidthColumns.tsx
+++ b/src/hooks/useColumns/useWidthColumns.tsx
@@ -9,6 +9,18 @@ function parseColWidth(totalWidth: number, width: string | number = '') {
   if (width.endsWith('%')) {
     return (totalWidth * parseFloat(width)) / 100;
   }
+
+  /**
+   * Column width supports this type of writing, such as '100' and '100px'
+   */
+  if (isNaN(Number(width))) {
+    if (width.endsWith('px')) {
+      return Number(width.replace(/px/, ''));
+    }
+  } else {
+    return Number(width);
+  }
+
   return null;
 }
 


### PR DESCRIPTION
说明文档介绍，Column的width，支持数值和字符串，但是不支持"100px"和"100"这两写法。本次pull request，扩展了代码，让Column的width支持"100px"和"100"这两写法。