### PR TITLE
fix: BodyGrid ref not exist clientWidth & scrollWidth，case *-ping-left、*-ping-right className loss 

### DIFF
--- a/src/VirtualTable/BodyGrid.tsx
+++ b/src/VirtualTable/BodyGrid.tsx
@@ -15,8 +15,10 @@ export interface GridProps<RecordType = any> {
 }
 
 export interface GridRef {
+  clientWidth: number;
+  scrollWidth: number;
   scrollLeft: number;
-  scrollTo?: (scrollConfig: ScrollConfig) => void;
+  scrollTo: (scrollConfig: ScrollConfig) => void;
 }
 
 const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
@@ -81,6 +83,8 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
       scrollTo: (config: ScrollConfig) => {
         listRef.current?.scrollTo(config);
       },
+      clientWidth: listRef.current?.clientWidth || 0,
+      scrollWidth: scrollX as number,
     } as unknown as GridRef;
 
     Object.defineProperty(obj, 'scrollLeft', {


### PR DESCRIPTION
最小可复现 demo：https://stackblitz.com/edit/vitejs-vite-pfczal?file=src%2FApp.tsx

触发 input 输入前，*-ping-right 正常
![image](https://github.com/react-component/table/assets/44686955/6bae82c8-18ac-4290-906b-ac18422b8d87)

触发 input 输入后，*-ping-right 丢失
![image](https://github.com/react-component/table/assets/44686955/b1957741-3d28-4052-afc5-ebefea7ea6e8)

该 PR 依赖 rc-virtual-list PR：https://github.com/react-component/virtual-list/pull/268