### PR TITLE
chore: event passive false

### DIFF
--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -89,7 +89,7 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
         e.preventDefault();
       }
     }
-    scrollRef.current?.addEventListener('wheel', onWheel);
+    scrollRef.current?.addEventListener('wheel', onWheel, { passive: false });
 
     return () => {
       scrollRef.current?.removeEventListener('wheel', onWheel);


### PR DESCRIPTION
Calling `preventDefault` in onWheel is possibility. `passive` cannot be set to true. Set it to false to suppress warnings.

close #996