### PR TITLE
fix: virtual table should be able to scroll when empty

### DIFF
--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -32,13 +32,14 @@ function ExpandedRow(props: ExpandedRowProps) {
     isEmpty,
   } = props;
 
-  const { fixHeader, scrollbarSize, fixColumn, componentWidth, horizonScroll } = useContext(
+  const { scrollbarSize, fixHeader, fixColumn, componentWidth, horizonScroll } = useContext(
     TableContext,
     ['scrollbarSize', 'fixHeader', 'fixColumn', 'componentWidth', 'horizonScroll'],
   );
 
   // Cache render node
   let contentNode = children;
+
   if (isEmpty ? horizonScroll && componentWidth : fixColumn) {
     contentNode = (
       <div

--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -32,22 +32,18 @@ function ExpandedRow(props: ExpandedRowProps) {
     isEmpty,
   } = props;
 
-  const { fixColumn, componentWidth, horizonScroll } = useContext(TableContext, [
-    'scrollbarSize',
-    'fixHeader',
-    'fixColumn',
-    'componentWidth',
-    'horizonScroll',
-  ]);
+  const { fixHeader, scrollbarSize, fixColumn, componentWidth, horizonScroll } = useContext(
+    TableContext,
+    ['scrollbarSize', 'fixHeader', 'fixColumn', 'componentWidth', 'horizonScroll'],
+  );
 
   // Cache render node
   let contentNode = children;
-
   if (isEmpty ? horizonScroll && componentWidth : fixColumn) {
     contentNode = (
       <div
         style={{
-          width: componentWidth,
+          width: componentWidth - (fixHeader && !isEmpty ? scrollbarSize : 0),
           position: 'sticky',
           left: 0,
           overflow: 'hidden',

--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -32,10 +32,13 @@ function ExpandedRow(props: ExpandedRowProps) {
     isEmpty,
   } = props;
 
-  const { scrollbarSize, fixHeader, fixColumn, componentWidth, horizonScroll } = useContext(
-    TableContext,
-    ['scrollbarSize', 'fixHeader', 'fixColumn', 'componentWidth', 'horizonScroll'],
-  );
+  const { fixColumn, componentWidth, horizonScroll } = useContext(TableContext, [
+    'scrollbarSize',
+    'fixHeader',
+    'fixColumn',
+    'componentWidth',
+    'horizonScroll',
+  ]);
 
   // Cache render node
   let contentNode = children;
@@ -44,7 +47,7 @@ function ExpandedRow(props: ExpandedRowProps) {
     contentNode = (
       <div
         style={{
-          width: componentWidth - (fixHeader ? scrollbarSize : 0),
+          width: componentWidth,
           position: 'sticky',
           left: 0,
           overflow: 'hidden',

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -385,7 +385,7 @@ function Table<RecordType extends DefaultRecordType>(
 
   if (fixHeader) {
     scrollYStyle = {
-      overflowY: 'scroll',
+      overflowY: hasData ? 'scroll' : 'auto',
       maxHeight: scroll.y,
     };
   }
@@ -521,8 +521,10 @@ function Table<RecordType extends DefaultRecordType>(
   React.useEffect(() => {
     if (!tailor || !useInternalHooks) {
       if (scrollBodyRef.current instanceof Element) {
+        console.log(getTargetScrollBarSize(scrollBodyRef.current).width);
         setScrollbarSize(getTargetScrollBarSize(scrollBodyRef.current).width);
       } else {
+        console.log(getTargetScrollBarSize(scrollBodyRef.current).width);
         setScrollbarSize(getTargetScrollBarSize(scrollBodyContainerRef.current).width);
       }
     }

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -521,10 +521,8 @@ function Table<RecordType extends DefaultRecordType>(
   React.useEffect(() => {
     if (!tailor || !useInternalHooks) {
       if (scrollBodyRef.current instanceof Element) {
-        console.log(getTargetScrollBarSize(scrollBodyRef.current).width);
         setScrollbarSize(getTargetScrollBarSize(scrollBodyRef.current).width);
       } else {
-        console.log(getTargetScrollBarSize(scrollBodyRef.current).width);
         setScrollbarSize(getTargetScrollBarSize(scrollBodyContainerRef.current).width);
       }
     }

--- a/src/VirtualTable/BodyGrid.tsx
+++ b/src/VirtualTable/BodyGrid.tsx
@@ -1,8 +1,6 @@
 import { useContext } from '@rc-component/context';
-import classNames from 'classnames';
 import VirtualList, { type ListProps, type ListRef } from 'rc-virtual-list';
 import * as React from 'react';
-import Cell from '../Cell';
 import TableContext, { responseImmutable } from '../context/TableContext';
 import useFlattenRecords, { type FlattenData } from '../hooks/useFlattenRecords';
 import type { ColumnType, OnCustomizeScroll, ScrollConfig } from '../interface';
@@ -29,7 +27,6 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
     expandedKeys,
     prefixCls,
     childrenColumnName,
-    emptyNode,
     scrollX,
   } = useContext(TableContext, [
     'flattenColumns',
@@ -38,7 +35,6 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
     'prefixCls',
     'expandedKeys',
     'childrenColumnName',
-    'emptyNode',
     'scrollX',
   ]);
   const {
@@ -206,8 +202,6 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
 
   // default 'div' in rc-virtual-list
   const wrapperComponent = getComponent(['body', 'wrapper']);
-  const RowComponent = getComponent(['body', 'row'], 'div');
-  const cellComponent = getComponent(['body', 'cell'], 'div');
 
   let bodyContent: React.ReactNode;
   if (flattenData.length) {
@@ -247,14 +241,6 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
           return <BodyLine data={item} rowKey={rowKey} index={index} {...itemProps} />;
         }}
       </VirtualList>
-    );
-  } else {
-    bodyContent = (
-      <RowComponent className={classNames(`${prefixCls}-placeholder`)}>
-        <Cell component={cellComponent} prefixCls={prefixCls}>
-          {emptyNode}
-        </Cell>
-      </RowComponent>
     );
   }
 

--- a/src/VirtualTable/BodyGrid.tsx
+++ b/src/VirtualTable/BodyGrid.tsx
@@ -203,19 +203,18 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
   // default 'div' in rc-virtual-list
   const wrapperComponent = getComponent(['body', 'wrapper']);
 
-  let bodyContent: React.ReactNode;
-  if (flattenData.length) {
-    // ========================== Sticky Scroll Bar ==========================
-    const horizontalScrollBarStyle: React.CSSProperties = {};
-    if (sticky) {
-      horizontalScrollBarStyle.position = 'sticky';
-      horizontalScrollBarStyle.bottom = 0;
-      if (typeof sticky === 'object' && sticky.offsetScroll) {
-        horizontalScrollBarStyle.bottom = sticky.offsetScroll;
-      }
+  // ========================== Sticky Scroll Bar ==========================
+  const horizontalScrollBarStyle: React.CSSProperties = {};
+  if (sticky) {
+    horizontalScrollBarStyle.position = 'sticky';
+    horizontalScrollBarStyle.bottom = 0;
+    if (typeof sticky === 'object' && sticky.offsetScroll) {
+      horizontalScrollBarStyle.bottom = sticky.offsetScroll;
     }
+  }
 
-    bodyContent = (
+  return (
+    <GridContext.Provider value={gridContext}>
       <VirtualList<FlattenData<any>>
         fullHeight={false}
         ref={listRef}
@@ -241,10 +240,8 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
           return <BodyLine data={item} rowKey={rowKey} index={index} {...itemProps} />;
         }}
       </VirtualList>
-    );
-  }
-
-  return <GridContext.Provider value={gridContext}>{bodyContent}</GridContext.Provider>;
+    </GridContext.Provider>
+  );
 });
 
 const ResponseGrid = responseImmutable(Grid);

--- a/src/VirtualTable/index.tsx
+++ b/src/VirtualTable/index.tsx
@@ -26,6 +26,7 @@ export interface VirtualTableProps<RecordType> extends Omit<TableProps<RecordTyp
 
 function VirtualTable<RecordType>(props: VirtualTableProps<RecordType>, ref: React.Ref<Reference>) {
   const {
+    data,
     columns,
     scroll,
     sticky,
@@ -81,7 +82,8 @@ function VirtualTable<RecordType>(props: VirtualTableProps<RecordType>, ref: Rea
         }}
         components={{
           ...components,
-          body: renderBody,
+          // fix https://github.com/ant-design/ant-design/issues/48991
+          body: data?.length ? renderBody : undefined,
         }}
         columns={columns}
         internalHooks={INTERNAL_HOOKS}

--- a/tests/Virtual.spec.tsx
+++ b/tests/Virtual.spec.tsx
@@ -443,4 +443,14 @@ describe('Table.Virtual', () => {
     fireEvent.scroll(container.querySelector('.rc-table-tbody-virtual-holder')!);
     expect(onScroll).toHaveBeenCalled();
   });
+
+  it('scrollable when empty', async () => {
+    const onScroll = vi.fn();
+    const { container } = getTable({ data: [], onScroll });
+
+    await waitFakeTimer();
+
+    fireEvent.scroll(container.querySelector('.rc-table-body'));
+    expect(onScroll).toHaveBeenCalled();
+  });
 });

--- a/tests/__snapshots__/FixedColumn.spec.tsx.snap
+++ b/tests/__snapshots__/FixedColumn.spec.tsx.snap
@@ -2951,7 +2951,7 @@ LoadedCheerio {
       </div>
       <div
         class="rc-table-body"
-        style="overflow-x: auto; overflow-y: scroll; max-height: 100px;"
+        style="overflow-x: auto; overflow-y: auto; max-height: 100px;"
       >
         <table
           style="width: 1200px; min-width: 100%; table-layout: fixed;"
@@ -3102,7 +3102,7 @@ LoadedCheerio {
               >
                 <div
                   class="rc-table-expanded-row-fixed"
-                  style="width: 985px; position: sticky; left: 0px; overflow: hidden;"
+                  style="width: 1000px; position: sticky; left: 0px; overflow: hidden;"
                 >
                   No Data
                 </div>


### PR DESCRIPTION
virtual table empty 时，body 使用正常表格渲染。
另外 empty 时，scrollY 应该为 auto，也更美观。

fix https://github.com/ant-design/ant-design/issues/48991