### PR TITLE
fix: change sticky scroll bar default state

### DIFF
--- a/src/stickyScrollBar.tsx
+++ b/src/stickyScrollBar.tsx
@@ -30,7 +30,7 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
     isHiddenScrollBar: boolean;
   }>({
     scrollLeft: 0,
-    isHiddenScrollBar: false,
+    isHiddenScrollBar: true,
   });
   const refState = React.useRef<{
     delta: number;
@@ -168,9 +168,11 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
   }, [scrollState.isHiddenScrollBar]);
 
   if (bodyScrollWidth <= bodyWidth || !scrollBarWidth || scrollState.isHiddenScrollBar) {
+    console.log('1');
     return null;
   }
 
+  console.log('2', bodyScrollWidth, bodyWidth, scrollBarWidth, scrollState.isHiddenScrollBar);
   return (
     <div
       style={{

--- a/src/stickyScrollBar.tsx
+++ b/src/stickyScrollBar.tsx
@@ -168,11 +168,9 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
   }, [scrollState.isHiddenScrollBar]);
 
   if (bodyScrollWidth <= bodyWidth || !scrollBarWidth || scrollState.isHiddenScrollBar) {
-    console.log('1');
     return null;
   }
 
-  console.log('2', bodyScrollWidth, bodyWidth, scrollBarWidth, scrollState.isHiddenScrollBar);
   return (
     <div
       style={{

--- a/tests/Sticky.spec.jsx
+++ b/tests/Sticky.spec.jsx
@@ -122,9 +122,10 @@ describe('Table.Sticky', () => {
     await act(async () => {
       vi.runAllTimers();
       await Promise.resolve();
+      wrapper.update();
     });
 
-    expect(wrapper.find('.rc-table-sticky-scroll').get(0)).toBeUndefined();
+    expect(wrapper.find('.rc-table-sticky-scroll').get(0)).not.toBeUndefined();
 
     const oldInnerHeight = global.innerHeight;
     const resizeEvent = new Event('resize');

--- a/tests/Sticky.spec.jsx
+++ b/tests/Sticky.spec.jsx
@@ -124,7 +124,7 @@ describe('Table.Sticky', () => {
       await Promise.resolve();
     });
 
-    expect(wrapper.find('.rc-table-sticky-scroll').get(0)).not.toBeUndefined();
+    expect(wrapper.find('.rc-table-sticky-scroll').get(0)).toBeUndefined();
 
     const oldInnerHeight = global.innerHeight;
     const resizeEvent = new Event('resize');
@@ -392,6 +392,7 @@ describe('Table.Sticky', () => {
     await act(async () => {
       vi.runAllTimers();
       await Promise.resolve();
+      wrapper.update();
     });
 
     expect(wrapper.find('.rc-table-sticky-scroll').get(0)).toBeTruthy();


### PR DESCRIPTION
一开始是不应该显示的，否则一开始可能会出现双滚动条，然后 check 后再消失，会闪动一下，应改成默认不展示，执行 check 后如果判断需要展示再展示出来。

（我自己的项目中出现了这种问题，手动修改 node_modules 中 rc-table 源码后可修复）