### PR TITLE
fix: emptyNode should not shaked when horizontal scroll

### DIFF
--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -61,6 +61,8 @@ function ExpandedRow(props: ExpandedRowProps) {
       className={className}
       style={{
         display: expanded ? null : 'none',
+        // fix https://github.com/ant-design/ant-design/issues/49279
+        visibility: isEmpty && horizonScroll && !componentWidth ? 'hidden' : null,
       }}
     >
       <Cell component={cellComponent} prefixCls={prefixCls} colSpan={colSpan}>

--- a/tests/__snapshots__/FixedColumn.spec.tsx.snap
+++ b/tests/__snapshots__/FixedColumn.spec.tsx.snap
@@ -1819,6 +1819,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - without data 1`] = `
           </tr>
           <tr
             class="rc-table-placeholder"
+            style=""
           >
             <td
               class="rc-table-cell"
@@ -2975,6 +2976,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
           </tr>
           <tr
             class="rc-table-placeholder"
+            style=""
           >
             <td
               class="rc-table-cell"


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/49279

虽然不会有位置上的变动，但是这样会展示一下白屏再展示 Empty，体验会好一些。

问题的本质是因为第一次 render 时无法获取到 componentWidth 并展示。componentWidth 是 ResizeObserver 监听后还通过 getContainerWidth 然后 setComponentWidth 上去的。这个 pr 还无法完美解决

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复了在行为空、启用横向滚动且组件宽度为零或未定义时，展开行可能显示异常的问题。现在在这些情况下内容将被正确隐藏，提升了界面显示的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->