### PR TITLE
fix: dynamic sticky

### DIFF
--- a/src/hooks/useSticky.ts
+++ b/src/hooks/useSticky.ts
@@ -26,8 +26,9 @@ export default function useSticky(
 
   const container = getContainer() || defaultContainer;
 
+  const isSticky = !!sticky;
+
   return React.useMemo(() => {
-    const isSticky = !!sticky;
     return {
       isSticky,
       stickyClassName: isSticky ? `${prefixCls}-sticky-holder` : '',
@@ -36,5 +37,5 @@ export default function useSticky(
       offsetScroll,
       container,
     };
-  }, [offsetScroll, offsetHeader, offsetSummary, prefixCls, container]);
+  }, [isSticky, prefixCls, offsetHeader, offsetSummary, offsetScroll, container]);
 }

--- a/src/hooks/useSticky.ts
+++ b/src/hooks/useSticky.ts
@@ -37,5 +37,5 @@ export default function useSticky(
       offsetScroll,
       container,
     };
-  }, [isSticky, prefixCls, offsetHeader, offsetSummary, offsetScroll, container]);
+  }, [isSticky, offsetScroll, offsetHeader, offsetSummary, prefixCls, container]);
 }


### PR DESCRIPTION
sticky 可以动态，这个合并后。

在自己的应用中先设置 sticky 为 false，渲染后再设置为 true，虽然比较 hack，但可以暂时在应用层中解决 Header 闪烁的问题（https://github.com/ant-design/ant-design/issues/50496）。（因为目前没有很好的方式解决，因为 rc-table 中有 scroll.y 或 sticky 时，表头的宽度收集是用的 ResizeObserver，会慢一拍）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **性能提升**
	- 优化了 `useSticky` 钩子的实现，减少不必要的重新计算，提高了性能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->