### PR TITLE
Resolve the issue of table header width collapsing and flashing

### DIFF
--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -149,7 +149,7 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<unknown>>(
       <table
         style={{
           tableLayout: 'fixed',
-          visibility: noData || mergedColumnWidth ? null : 'hidden',
+          visibility: mergedColumnWidth ? null : 'hidden',
         }}
       >
         {(!noData || !maxContentScroll || allFlattenColumnsWithWidth) && (


### PR DESCRIPTION
Resolve the issue of table header width collapsing and flashing during the initial rendering when setting sticky=true for a table with a large number of columns.
![image](https://github.com/user-attachments/assets/29bb03ae-934d-4ecc-9188-d6a6be9d4d54)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
  - 修改了`FixedHolder`组件中表格元素的可见性逻辑，现在表格仅在`mergedColumnWidth`为假时隐藏，提升了可用性。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->