### PR TITLE
fix: The fixed attribute does not take effect

### DIFF
--- a/src/hooks/useColumns/index.tsx
+++ b/src/hooks/useColumns/index.tsx
@@ -176,8 +176,11 @@ function useColumns<RecordType>(
       // >>> Insert expand column if not exist
       if (!cloneColumns.includes(EXPAND_COLUMN)) {
         const expandColIndex = expandIconColumnIndex || 0;
-        if (expandColIndex >= 0) {
+        if ((expandColIndex && expandColIndex >= 0) || fixed === 'left' || !fixed) {
           cloneColumns.splice(expandColIndex, 0, EXPAND_COLUMN);
+        }
+        if (fixed === 'right') {
+          cloneColumns.splice(baseColumns.length, 0, EXPAND_COLUMN);
         }
       }
 
@@ -197,10 +200,8 @@ function useColumns<RecordType>(
       const prevColumn = baseColumns[expandColumnIndex];
 
       let fixedColumn: FixedType | null;
-      if ((fixed === 'left' || fixed) && !expandIconColumnIndex) {
-        fixedColumn = 'left';
-      } else if ((fixed === 'right' || fixed) && expandIconColumnIndex === baseColumns.length) {
-        fixedColumn = 'right';
+      if (fixed) {
+        fixedColumn = fixed;
       } else {
         fixedColumn = prevColumn ? prevColumn.fixed : null;
       }

--- a/src/hooks/useColumns/index.tsx
+++ b/src/hooks/useColumns/index.tsx
@@ -176,7 +176,6 @@ function useColumns<RecordType>(
       // >>> Insert expand column if not exist
       if (!cloneColumns.includes(EXPAND_COLUMN)) {
         const expandColIndex = expandIconColumnIndex || 0;
-        console.log(expandColIndex);
         if (expandColIndex >= 0 && (expandColIndex || fixed === 'left' || !fixed)) {
           cloneColumns.splice(expandColIndex, 0, EXPAND_COLUMN);
         }
@@ -245,6 +244,7 @@ function useColumns<RecordType>(
     }
 
     return baseColumns.filter(col => col !== EXPAND_COLUMN);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandable, baseColumns, getRowKey, expandedKeys, expandIcon, direction]);
 
   // ========================= Transform ========================
@@ -263,6 +263,7 @@ function useColumns<RecordType>(
       ];
     }
     return finalColumns;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [transformColumns, withExpandColumns, direction]);
 
   // ========================== Flatten =========================
@@ -271,6 +272,7 @@ function useColumns<RecordType>(
       return revertForRtl(flatColumns(mergedColumns));
     }
     return flatColumns(mergedColumns);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mergedColumns, direction, scrollWidth]);
 
   // ========================= Gap Fixed ========================

--- a/src/hooks/useColumns/index.tsx
+++ b/src/hooks/useColumns/index.tsx
@@ -176,7 +176,8 @@ function useColumns<RecordType>(
       // >>> Insert expand column if not exist
       if (!cloneColumns.includes(EXPAND_COLUMN)) {
         const expandColIndex = expandIconColumnIndex || 0;
-        if ((expandColIndex && expandColIndex >= 0) || fixed === 'left' || !fixed) {
+        console.log(expandColIndex);
+        if (expandColIndex >= 0 && (expandColIndex || fixed === 'left' || !fixed)) {
           cloneColumns.splice(expandColIndex, 0, EXPAND_COLUMN);
         }
         if (fixed === 'right') {

--- a/tests/ExpandRow.spec.jsx
+++ b/tests/ExpandRow.spec.jsx
@@ -230,6 +230,36 @@ describe('Table.Expand', () => {
     expect(wrapper2.find('.rc-table-has-fix-right').length).toBe(0);
   });
 
+  it('fixed in expandable Fixed in expandable', () => {
+    const columns = [
+      { title: 'Name', dataIndex: 'name', key: 'name' },
+      { title: 'Age', dataIndex: 'age', key: 'age' },
+      { title: 'Gender', dataIndex: 'gender', key: 'gender' },
+    ];
+    const data = [
+      { key: 0, name: 'Lucy', age: 27, gender: 'F' },
+      { key: 1, name: 'Jack', age: 28, gender: 'M' },
+    ];
+    const wrapper = mount(
+      createTable({
+        columns,
+        data,
+        scroll: { x: 903 },
+        expandable: { expandedRowRender, fixed: 'left' },
+      }),
+    );
+    const wrapper2 = mount(
+      createTable({
+        columns,
+        data,
+        scroll: { x: 903 },
+        expandable: { expandedRowRender, fixed: 'right' },
+      }),
+    );
+    expect(wrapper.find('.rc-table-has-fix-left').length).toBe(1);
+    expect(wrapper2.find('.rc-table-has-fix-right').length).toBe(1);
+  });
+
   describe('config expand column index', () => {
     it('not show EXPAND_COLUMN if expandable is false', () => {
       resetWarned();

--- a/tests/__snapshots__/ExpandRow.spec.jsx.snap
+++ b/tests/__snapshots__/ExpandRow.spec.jsx.snap
@@ -138,7 +138,7 @@ LoadedCheerio {
 exports[`Table.Expand > does not crash if scroll is not set 1`] = `
 LoadedCheerio {
   "0": <div
-    class="rc-table rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left"
+    class="rc-table rc-table-scroll-horizontal"
   >
     <div
       class="rc-table-container"
@@ -148,21 +148,13 @@ LoadedCheerio {
         style="overflow-x: auto; overflow-y: hidden;"
       >
         <table
-          style="min-width: 100%; table-layout: fixed;"
+          style="min-width: 100%; table-layout: auto;"
         >
-          <colgroup>
-            <col
-              class="rc-table-expand-icon-col"
-            />
-          </colgroup>
+          <colgroup />
           <thead
             class="rc-table-thead"
           >
             <tr>
-              <th
-                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
-                style="position: sticky; left: 0px;"
-              />
               <th
                 class="rc-table-cell"
                 scope="col"
@@ -218,28 +210,11 @@ LoadedCheerio {
                    
                 </div>
               </td>
-              <td
-                style="padding: 0px; border: 0px; height: 0px;"
-              >
-                <div
-                  style="height: 0px; overflow: hidden;"
-                >
-                   
-                </div>
-              </td>
             </tr>
             <tr
               class="rc-table-row rc-table-row-level-0"
               data-row-key="0"
             >
-              <td
-                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
-                style="position: sticky; left: 0px;"
-              >
-                <span
-                  class="rc-table-row-expand-icon rc-table-row-collapsed"
-                />
-              </td>
               <td
                 class="rc-table-cell"
               >
@@ -260,14 +235,6 @@ LoadedCheerio {
               class="rc-table-row rc-table-row-level-0"
               data-row-key="1"
             >
-              <td
-                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
-                style="position: sticky; left: 0px;"
-              >
-                <span
-                  class="rc-table-row-expand-icon rc-table-row-collapsed"
-                />
-              </td>
               <td
                 class="rc-table-cell"
               >
@@ -323,7 +290,7 @@ LoadedCheerio {
 exports[`Table.Expand > does not crash if scroll is not set 2`] = `
 LoadedCheerio {
   "0": <div
-    class="rc-table rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left"
+    class="rc-table rc-table-scroll-horizontal"
   >
     <div
       class="rc-table-container"
@@ -333,21 +300,13 @@ LoadedCheerio {
         style="overflow-x: auto; overflow-y: hidden;"
       >
         <table
-          style="min-width: 100%; table-layout: fixed;"
+          style="min-width: 100%; table-layout: auto;"
         >
-          <colgroup>
-            <col
-              class="rc-table-expand-icon-col"
-            />
-          </colgroup>
+          <colgroup />
           <thead
             class="rc-table-thead"
           >
             <tr>
-              <th
-                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
-                style="position: sticky; left: 0px;"
-              />
               <th
                 class="rc-table-cell"
                 scope="col"
@@ -403,28 +362,11 @@ LoadedCheerio {
                    
                 </div>
               </td>
-              <td
-                style="padding: 0px; border: 0px; height: 0px;"
-              >
-                <div
-                  style="height: 0px; overflow: hidden;"
-                >
-                   
-                </div>
-              </td>
             </tr>
             <tr
               class="rc-table-row rc-table-row-level-0"
               data-row-key="0"
             >
-              <td
-                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
-                style="position: sticky; left: 0px;"
-              >
-                <span
-                  class="rc-table-row-expand-icon rc-table-row-collapsed"
-                />
-              </td>
               <td
                 class="rc-table-cell"
               >
@@ -445,14 +387,6 @@ LoadedCheerio {
               class="rc-table-row rc-table-row-level-0"
               data-row-key="1"
             >
-              <td
-                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
-                style="position: sticky; left: 0px;"
-              >
-                <span
-                  class="rc-table-row-expand-icon rc-table-row-collapsed"
-                />
-              </td>
               <td
                 class="rc-table-cell"
               >
@@ -1183,7 +1117,7 @@ LoadedCheerio {
 exports[`Table.Expand > work in expandable fix 1`] = `
 LoadedCheerio {
   "0": <div
-    class="rc-table rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left"
+    class="rc-table rc-table-scroll-horizontal"
   >
     <div
       class="rc-table-container"
@@ -1193,21 +1127,13 @@ LoadedCheerio {
         style="overflow-x: auto; overflow-y: hidden;"
       >
         <table
-          style="width: 903px; min-width: 100%; table-layout: fixed;"
+          style="width: 903px; min-width: 100%; table-layout: auto;"
         >
-          <colgroup>
-            <col
-              class="rc-table-expand-icon-col"
-            />
-          </colgroup>
+          <colgroup />
           <thead
             class="rc-table-thead"
           >
             <tr>
-              <th
-                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
-                style="position: sticky; left: 0px;"
-              />
               <th
                 class="rc-table-cell"
                 scope="col"
@@ -1263,28 +1189,11 @@ LoadedCheerio {
                    
                 </div>
               </td>
-              <td
-                style="padding: 0px; border: 0px; height: 0px;"
-              >
-                <div
-                  style="height: 0px; overflow: hidden;"
-                >
-                   
-                </div>
-              </td>
             </tr>
             <tr
               class="rc-table-row rc-table-row-level-0"
               data-row-key="0"
             >
-              <td
-                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
-                style="position: sticky; left: 0px;"
-              >
-                <span
-                  class="rc-table-row-expand-icon rc-table-row-collapsed"
-                />
-              </td>
               <td
                 class="rc-table-cell"
               >
@@ -1305,14 +1214,6 @@ LoadedCheerio {
               class="rc-table-row rc-table-row-level-0"
               data-row-key="1"
             >
-              <td
-                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
-                style="position: sticky; left: 0px;"
-              >
-                <span
-                  class="rc-table-row-expand-icon rc-table-row-collapsed"
-                />
-              </td>
               <td
                 class="rc-table-cell"
               >
@@ -1368,7 +1269,7 @@ LoadedCheerio {
 exports[`Table.Expand > work in expandable fix 2`] = `
 LoadedCheerio {
   "0": <div
-    class="rc-table rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-right"
+    class="rc-table rc-table-fixed-column rc-table-fixed-column-gapped rc-table-scroll-horizontal"
   >
     <div
       class="rc-table-container"
@@ -1411,8 +1312,8 @@ LoadedCheerio {
                 Gender
               </th>
               <th
-                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-right rc-table-cell-fix-right-first"
-                style="position: sticky; right: 0px;"
+                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
+                style="position: sticky; left: 0px;"
               />
             </tr>
           </thead>
@@ -1481,8 +1382,8 @@ LoadedCheerio {
                 F
               </td>
               <td
-                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-right rc-table-cell-fix-right-first"
-                style="position: sticky; right: 0px;"
+                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
+                style="position: sticky; left: 0px;"
               >
                 <span
                   class="rc-table-row-expand-icon rc-table-row-collapsed"
@@ -1509,8 +1410,8 @@ LoadedCheerio {
                 M
               </td>
               <td
-                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-right rc-table-cell-fix-right-first"
-                style="position: sticky; right: 0px;"
+                class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix-left rc-table-cell-fix-left-last"
+                style="position: sticky; left: 0px;"
               >
                 <span
                   class="rc-table-row-expand-icon rc-table-row-collapsed"


### PR DESCRIPTION
修复表格expandable中设置fixed：right不生效，issues：https://github.com/ant-design/ant-design/issues/50846

- 问题原因

对于fixed的处理不正确，一个是判断逻辑有问题，fixed不应该和expandIconColumnIndex一起判断，一个是插入扩展列的时候没有按照fixed的值来处理

- 如何修复

1. 插入时增加判断，当设置fixed为left或者，fixed没设置时，默认插入到列数据数组第一个，如果fixed为right则插入到最后一个
2. 修改fixedColumn变量表达传入位置到逻辑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 增强了列管理的灵活性，允许更动态地处理展开列的位置和列的固定状态。
- **测试**
	- 新增测试用例以验证固定列在可展开行中的行为，确保固定列功能与可展开特性正确配合。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->