### PR TITLE
fix: Fix the shadow issue when scrollX is smaller than the sum of col…

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -455,7 +455,7 @@ function Table<RecordType extends DefaultRecordType>(
       const measureTarget = currentTarget || scrollHeaderRef.current;
       if (measureTarget) {
         const scrollWidth =
-          // Same logic as scrollWidth of useColumns
+          // Should use mergedScrollX in virtual table(useInternalHooks && tailor === true)
           useInternalHooks && tailor && typeof mergedScrollX === 'number'
             ? mergedScrollX
             : measureTarget.scrollWidth;

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -455,7 +455,10 @@ function Table<RecordType extends DefaultRecordType>(
       const measureTarget = currentTarget || scrollHeaderRef.current;
       if (measureTarget) {
         const scrollWidth =
-          typeof mergedScrollX === 'number' ? mergedScrollX : measureTarget.scrollWidth;
+          // Same logic as scrollWidth of useColumns
+          useInternalHooks && tailor && typeof mergedScrollX === 'number'
+            ? mergedScrollX
+            : measureTarget.scrollWidth;
         const clientWidth = measureTarget.clientWidth;
         // There is no space to scroll
         if (scrollWidth === clientWidth) {

--- a/tests/FixedColumn.spec.tsx
+++ b/tests/FixedColumn.spec.tsx
@@ -341,4 +341,38 @@ describe('Table.FixedColumn', () => {
     expect(container.querySelectorAll('.rc-table-cell-fix-right-first').length).toBe(101);
     expect(container).toMatchSnapshot();
   });
+
+  it('right shadow should be shown when scrollX is less than the sum of the widths of all columns', async () => {
+    const wrapper = mount(
+      <Table
+        columns={[
+          { title: 'a', width: 200, fixed: 'left' },
+          { title: 'b', width: 200 },
+          { title: 'c', width: 200 },
+          { title: 'd', width: 200, fixed: 'right' },
+        ]}
+        data={data}
+        scroll={{ x: 100 }}
+        style={{ width: 400 }}
+      />,
+    );
+
+    await safeAct(wrapper);
+    // Use `onScroll` directly since simulate not support `currentTarget`
+    act(() => {
+      wrapper
+        .find('.rc-table-content')
+        .props()
+        .onScroll({
+          currentTarget: {
+            scrollLeft: 10,
+            scrollWidth: 800,
+            clientWidth: 400,
+          },
+        } as any);
+    });
+    wrapper.update();
+    expect(wrapper.find('.rc-table').hasClass('rc-table-ping-left')).toBeTruthy();
+    expect(wrapper.find('.rc-table').hasClass('rc-table-ping-right')).toBeTruthy();
+  });
 });

--- a/tests/__snapshots__/ExpandRow.spec.jsx.snap
+++ b/tests/__snapshots__/ExpandRow.spec.jsx.snap
@@ -625,7 +625,7 @@ LoadedCheerio {
 exports[`Table.Expand > renders fixed column correctly > work 1`] = `
 LoadedCheerio {
   "0": <div
-    class="rc-table rc-table-ping-right rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left rc-table-has-fix-right"
+    class="rc-table rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left rc-table-has-fix-right"
   >
     <div
       class="rc-table-container"

--- a/tests/__snapshots__/FixedColumn.spec.tsx.snap
+++ b/tests/__snapshots__/FixedColumn.spec.tsx.snap
@@ -823,7 +823,7 @@ LoadedCheerio {
 exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
 LoadedCheerio {
   "0": <div
-    class="rc-table rc-table-ping-right rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left rc-table-has-fix-right"
+    class="rc-table rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left rc-table-has-fix-right"
   >
     <div
       class="rc-table-container"
@@ -1642,7 +1642,7 @@ LoadedCheerio {
 exports[`Table.FixedColumn > renders correctly > scrollX - without data 1`] = `
 LoadedCheerio {
   "0": <div
-    class="rc-table rc-table-ping-right rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left rc-table-has-fix-right"
+    class="rc-table rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left rc-table-has-fix-right"
   >
     <div
       class="rc-table-container"
@@ -1931,7 +1931,7 @@ LoadedCheerio {
 exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
 LoadedCheerio {
   "0": <div
-    class="rc-table rc-table-ping-right rc-table-fixed-header rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left rc-table-has-fix-right"
+    class="rc-table rc-table-fixed-header rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left rc-table-has-fix-right"
   >
     <div
       class="rc-table-container"
@@ -2804,7 +2804,7 @@ LoadedCheerio {
 exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
 LoadedCheerio {
   "0": <div
-    class="rc-table rc-table-ping-right rc-table-fixed-header rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left rc-table-has-fix-right"
+    class="rc-table rc-table-fixed-header rc-table-fixed-column rc-table-scroll-horizontal rc-table-has-fix-left rc-table-has-fix-right"
   >
     <div
       class="rc-table-container"


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/51170



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 添加了 `rowExpandable` 属性以配置行展开逻辑。
  - 引入了 `summary` 属性，允许返回一个 `ReactNode` 的函数。
  - 将 `dataIndex` 属性定义为数组类型。

- **结构变化**
  - 重构了 `expandable` 属性，整合所有与行展开相关的功能。
  - 移除了多个属性，简化了 API。

- **弃用通知**
  - 弃用了所有以前的展开属性，转而使用新的 `expandable` 属性。

- **测试**
  - 为 `Table.FixedColumn` 组件添加了新的测试用例，验证表格在水平滚动时的阴影显示效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->