### PR TITLE
无用的getRowKey

### DIFF
--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -19,7 +19,6 @@ export interface BodyRowProps<RecordType> {
   scopeCellComponent: CustomizeComponent;
   indent?: number;
   rowKey: React.Key;
-  getRowKey: GetRowKey<RecordType>;
 }
 
 // ==================================================================================

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -4,7 +4,7 @@ import Cell from '../Cell';
 import { responseImmutable } from '../context/TableContext';
 import devRenderTimes from '../hooks/useRenderTimes';
 import useRowInfo from '../hooks/useRowInfo';
-import type { ColumnType, CustomizeComponent, GetRowKey } from '../interface';
+import type { ColumnType, CustomizeComponent } from '../interface';
 import ExpandedRow from './ExpandedRow';
 import { computedExpandedClassName } from '../utils/expandUtil';
 

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -73,7 +73,6 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
           rowComponent={trComponent}
           cellComponent={tdComponent}
           scopeCellComponent={thComponent}
-          getRowKey={getRowKey}
           indent={indent}
         />
       );


### PR DESCRIPTION
BodyRow并没有用到这个getRowKey函数，可以删除。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 简化了 `BodyRow` 组件的属性，移除了 `getRowKey` 属性。

- **bug 修复**
	- 确保 `BodyRow` 组件的功能保持不变，优化了属性传递。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->