### PR TITLE
fix: virtual scroll ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@rc-component/context": "^1.4.0",
     "classnames": "^2.2.5",
     "rc-resize-observer": "^1.1.0",
-    "rc-util": "^5.41.0",
+    "rc-util": "^5.44.3",
     "rc-virtual-list": "^3.14.2"
   },
   "devDependencies": {

--- a/src/stickyScrollBar.tsx
+++ b/src/stickyScrollBar.tsx
@@ -1,12 +1,12 @@
 import { useContext } from '@rc-component/context';
 import classNames from 'classnames';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
-import { getOffset } from 'rc-util/lib/Dom/css';
 import getScrollBarSize from 'rc-util/lib/getScrollBarSize';
 import * as React from 'react';
 import TableContext from './context/TableContext';
 import { useLayoutState } from './hooks/useFrame';
 import raf from 'rc-util/lib/raf';
+import { getOffset } from './utils/offsetUtil';
 
 interface StickyScrollBarProps {
   scrollBodyRef: React.RefObject<HTMLDivElement>;

--- a/src/utils/offsetUtil.ts
+++ b/src/utils/offsetUtil.ts
@@ -1,0 +1,20 @@
+import { getDOM } from 'rc-util/lib/Dom/findDOMNode';
+
+// Copy from `rc-util/Dom/css.js`
+export function getOffset(node: HTMLElement | Window) {
+  const element = getDOM(node);
+  const box = element.getBoundingClientRect();
+  const docElem = document.documentElement;
+
+  // < ie8 not support win.pageXOffset, use docElem.scrollLeft instead
+  return {
+    left:
+      box.left +
+      (window.pageXOffset || docElem.scrollLeft) -
+      (docElem.clientLeft || document.body.clientLeft || 0),
+    top:
+      box.top +
+      (window.pageYOffset || docElem.scrollTop) -
+      (docElem.clientTop || document.body.clientTop || 0),
+  };
+}

--- a/tests/Sticky.spec.jsx
+++ b/tests/Sticky.spec.jsx
@@ -56,7 +56,7 @@ describe('Table.Sticky', () => {
     vi.useRealTimers();
   });
 
-  it('Sticky scroll1', async () => {
+  it('Sticky scroll', async () => {
     window.pageYOffset = 900;
     document.documentElement.scrollTop = 200;
     let scrollLeft = 100;

--- a/tests/Sticky.spec.jsx
+++ b/tests/Sticky.spec.jsx
@@ -56,7 +56,7 @@ describe('Table.Sticky', () => {
     vi.useRealTimers();
   });
 
-  it('Sticky scroll', async () => {
+  it('Sticky scroll1', async () => {
     window.pageYOffset = 900;
     document.documentElement.scrollTop = 200;
     let scrollLeft = 100;


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/52276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **依赖更新**
	- 将 `rc-util` 依赖版本从 `^5.41.0` 升级到 `^5.44.3`

- **新功能**
	- 新增 `getOffset` 实用函数，用于跨浏览器兼容的元素偏移计算

- **测试**
	- 重命名现有的粘性滚动测试用例
	- 添加带自定义容器的粘性滚动测试用例

<!-- end of auto-generated comment: release notes by coderabbit.ai -->