### PR TITLE
chore: end fixed zIndex should smaller than start

### DIFF
--- a/src/utils/fixUtil.ts
+++ b/src/utils/fixUtil.ts
@@ -61,12 +61,12 @@ export function getCellFixedInfo(
   if (fixStart !== null) {
     fixedStartShadow = !columns[colEnd + 1] || !isFixedStart(columns[colEnd + 1]);
     zIndex = columns.length * 2 - colStart; // Fix start always overlay fix end
-    zIndexReverse = colStart;
+    zIndexReverse = columns.length + colStart;
   }
   if (fixEnd !== null) {
     fixedEndShadow = !columns[colStart - 1] || !isFixedEnd(columns[colStart - 1]);
     zIndex = colEnd;
-    zIndexReverse = columns.length * 2 - colEnd; // Fix end always overlay fix start
+    zIndexReverse = columns.length - colEnd; // Fix end always overlay fix start
   }
 
   // Check if scrollLeft will show the shadow

--- a/tests/__snapshots__/ExpandRow.spec.jsx.snap
+++ b/tests/__snapshots__/ExpandRow.spec.jsx.snap
@@ -461,12 +461,12 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
           <tr>
             <th
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
             />
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 7; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 7; --z-offset-reverse: 5;"
             >
               Name
             </th>
@@ -479,7 +479,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               scope="col"
-              style="inset-inline-end: 0; --z-offset: 3; --z-offset-reverse: 5;"
+              style="inset-inline-end: 0; --z-offset: 3; --z-offset-reverse: 1;"
             >
               Gender
             </th>
@@ -536,7 +536,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
           >
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-expanded"
@@ -544,7 +544,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 7; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 7; --z-offset-reverse: 5;"
             >
               Lucy
             </td>
@@ -555,7 +555,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 3; --z-offset-reverse: 5;"
+              style="inset-inline-end: 0; --z-offset: 3; --z-offset-reverse: 1;"
             >
               F
             </td>
@@ -583,7 +583,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
           >
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-expanded"
@@ -591,7 +591,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 7; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 7; --z-offset-reverse: 5;"
             >
               Jack
             </td>
@@ -602,7 +602,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 3; --z-offset-reverse: 5;"
+              style="inset-inline-end: 0; --z-offset: 3; --z-offset-reverse: 1;"
             >
               M
             </td>
@@ -1072,7 +1072,7 @@ exports[`Table.Expand > work in expandable fix 2`] = `
             </th>
             <th
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 5; --z-offset-reverse: 3;"
+              style="inset-inline-start: 0; --z-offset: 5; --z-offset-reverse: 7;"
             />
           </tr>
         </thead>
@@ -1142,7 +1142,7 @@ exports[`Table.Expand > work in expandable fix 2`] = `
             </td>
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 5; --z-offset-reverse: 3;"
+              style="inset-inline-start: 0; --z-offset: 5; --z-offset-reverse: 7;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-collapsed"
@@ -1170,7 +1170,7 @@ exports[`Table.Expand > work in expandable fix 2`] = `
             </td>
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 5; --z-offset-reverse: 3;"
+              style="inset-inline-start: 0; --z-offset: 5; --z-offset-reverse: 7;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-collapsed"

--- a/tests/__snapshots__/FixedColumn.spec.tsx.snap
+++ b/tests/__snapshots__/FixedColumn.spec.tsx.snap
@@ -41,14 +41,14 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               title1
             </th>
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 13;"
               title="title2"
             >
               <span
@@ -114,7 +114,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               scope="col"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             >
               title12
             </th>
@@ -243,13 +243,13 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               123
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -305,7 +305,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             >
               xxxxxxxx
             </td>
@@ -316,13 +316,13 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               cdd
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -378,7 +378,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             >
               edd12221
             </td>
@@ -389,13 +389,13 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -437,7 +437,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -446,13 +446,13 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -494,7 +494,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -503,13 +503,13 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -551,7 +551,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -560,13 +560,13 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -608,7 +608,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -617,13 +617,13 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -665,7 +665,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -674,13 +674,13 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -722,7 +722,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -731,13 +731,13 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 0; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -779,7 +779,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
         </tbody>
@@ -832,14 +832,14 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               title1
             </th>
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
               scope="col"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="title2"
             >
               <span
@@ -905,7 +905,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               scope="col"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             >
               title12
             </th>
@@ -1034,13 +1034,13 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               123
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -1096,7 +1096,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             >
               xxxxxxxx
             </td>
@@ -1107,13 +1107,13 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               cdd
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -1169,7 +1169,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             >
               edd12221
             </td>
@@ -1180,13 +1180,13 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -1228,7 +1228,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -1237,13 +1237,13 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -1285,7 +1285,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -1294,13 +1294,13 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -1342,7 +1342,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -1351,13 +1351,13 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -1399,7 +1399,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -1408,13 +1408,13 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -1456,7 +1456,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -1465,13 +1465,13 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -1513,7 +1513,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -1522,13 +1522,13 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -1570,7 +1570,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
         </tbody>
@@ -1621,14 +1621,14 @@ exports[`Table.FixedColumn > renders correctly > scrollX - without data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               title1
             </th>
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
               scope="col"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="title2"
             >
               <span
@@ -1694,7 +1694,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - without data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               scope="col"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             >
               title12
             </th>
@@ -1901,14 +1901,14 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 26; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 26; --z-offset-reverse: 13;"
             >
               title1
             </th>
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
               scope="col"
-              style="inset-inline-start: 1000px; --z-offset: 25; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 25; --z-offset-reverse: 14;"
               title="title2"
             >
               <span
@@ -1974,13 +1974,13 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               scope="col"
-              style="inset-inline-end: 15px; --z-offset: 11; --z-offset-reverse: 15;"
+              style="inset-inline-end: 15px; --z-offset: 11; --z-offset-reverse: 2;"
             >
               title12
             </th>
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-scrollbar"
-              style="inset-inline-end: 0; --z-offset: 12; --z-offset-reverse: 14;"
+              style="inset-inline-end: 0; --z-offset: 12; --z-offset-reverse: 1;"
             />
           </tr>
         </thead>
@@ -2136,13 +2136,13 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               123
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -2198,7 +2198,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             >
               xxxxxxxx
             </td>
@@ -2209,13 +2209,13 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               cdd
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -2271,7 +2271,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             >
               edd12221
             </td>
@@ -2282,13 +2282,13 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -2330,7 +2330,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -2339,13 +2339,13 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -2387,7 +2387,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -2396,13 +2396,13 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -2444,7 +2444,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -2453,13 +2453,13 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -2501,7 +2501,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -2510,13 +2510,13 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -2558,7 +2558,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -2567,13 +2567,13 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -2615,7 +2615,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -2624,13 +2624,13 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
-              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="1111"
             >
               <span
@@ -2672,7 +2672,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 13;"
+              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
         </tbody>
@@ -2744,14 +2744,14 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 26; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 26; --z-offset-reverse: 13;"
             >
               title1
             </th>
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
               scope="col"
-              style="inset-inline-start: 1000px; --z-offset: 25; --z-offset-reverse: 1;"
+              style="inset-inline-start: 1000px; --z-offset: 25; --z-offset-reverse: 14;"
               title="title2"
             >
               <span
@@ -2817,13 +2817,13 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               scope="col"
-              style="inset-inline-end: 15px; --z-offset: 11; --z-offset-reverse: 15;"
+              style="inset-inline-end: 15px; --z-offset: 11; --z-offset-reverse: 2;"
             >
               title12
             </th>
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-scrollbar"
-              style="inset-inline-end: 0; --z-offset: 12; --z-offset-reverse: 14;"
+              style="inset-inline-end: 0; --z-offset: 12; --z-offset-reverse: 1;"
             />
           </tr>
         </thead>

--- a/tests/__snapshots__/Summary.spec.tsx.snap
+++ b/tests/__snapshots__/Summary.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`Table.Summary > support data type 1`] = `
     <td
       class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
       colspan="2"
-      style="inset-inline-start: 0; --z-offset: 6; --z-offset-reverse: 0;"
+      style="inset-inline-start: 0; --z-offset: 6; --z-offset-reverse: 3;"
     >
       Light
     </td>

--- a/tests/__snapshots__/Table.spec.jsx.snap
+++ b/tests/__snapshots__/Table.spec.jsx.snap
@@ -100,7 +100,7 @@ exports[`Table.Basic > custom components > renders fixed column and header corre
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
               name="my-header-cell"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
             >
               Name
             </th>
@@ -115,14 +115,14 @@ exports[`Table.Basic > custom components > renders fixed column and header corre
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               name="my-header-cell"
               scope="col"
-              style="inset-inline-end: 15px; --z-offset: 2; --z-offset-reverse: 6;"
+              style="inset-inline-end: 15px; --z-offset: 2; --z-offset-reverse: 2;"
             >
               Gender
             </th>
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-scrollbar"
               name="my-header-cell"
-              style="inset-inline-end: 0; --z-offset: 3; --z-offset-reverse: 5;"
+              style="inset-inline-end: 0; --z-offset: 3; --z-offset-reverse: 1;"
             />
           </tr>
         </thead>
@@ -182,7 +182,7 @@ exports[`Table.Basic > custom components > renders fixed column and header corre
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
               name="my-body-cell"
-              style="inset-inline-start: 0; --z-offset: 6; --z-offset-reverse: 0;"
+              style="inset-inline-start: 0; --z-offset: 6; --z-offset-reverse: 3;"
             >
               Lucy
             </td>
@@ -195,7 +195,7 @@ exports[`Table.Basic > custom components > renders fixed column and header corre
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               name="my-body-cell"
-              style="inset-inline-end: 0; --z-offset: 2; --z-offset-reverse: 4;"
+              style="inset-inline-end: 0; --z-offset: 2; --z-offset-reverse: 1;"
             >
               F
             </td>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化了固定区域中元素的显示层级，使固定列的叠加效果更加准确和一致，从而在复杂布局下提供更直观、稳定的视觉体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->