### PR TITLE
fix: fix first rows scroll down when expand

### DIFF
--- a/src/VirtualTable/BodyGrid.tsx
+++ b/src/VirtualTable/BodyGrid.tsx
@@ -163,19 +163,6 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
         }
       });
     }
-    // For non-first row changes, we want to preserve the scroll position
-    else if (shouldPreserveScroll.current && currentScrollInfo) {
-      const savedScrollPos = scrollPositionRef.current;
-      shouldPreserveScroll.current = false;
-
-      if (savedScrollPos > 0) {
-        requestAnimationFrame(() => {
-          if (listRef.current) {
-            listRef.current.scrollTo({ top: savedScrollPos });
-          }
-        });
-      }
-    }
 
     const { start, end, getSize, offsetY } = info;
 


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/53334
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新功能**
  - 优化了虚拟表格在行展开和收缩时的滚动表现：第一行展开或收缩时自动回到顶部，而其他行保持之前的滚动位置，从而提升用户体验。

- **Tests**
  - 添加了针对行展开/收缩行为的测试，确保滚动位置在操作后能稳定保持。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->