### PR TITLE
fix: table forceScroll setTimeout issue

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -417,7 +417,7 @@ function Table<RecordType extends DefaultRecordType>(
 
   const [setScrollTarget, getScrollTarget] = useTimeoutLock(null);
 
-  function forceScroll(scrollLeft: number, target: HTMLDivElement | ((left: number) => void)) {
+  function forceScroll(scrollLeft: number, target: HTMLDivElement & {_scrollTimeout?: number | null} | ((left: number) => void)) {
     if (!target) {
       return;
     }
@@ -426,11 +426,17 @@ function Table<RecordType extends DefaultRecordType>(
     } else if (target.scrollLeft !== scrollLeft) {
       target.scrollLeft = scrollLeft;
 
+      if (target._scrollTimeout) {
+        window.clearTimeout(target._scrollTimeout);
+        target._scrollTimeout = null;
+      }
+
       // Delay to force scroll position if not sync
       // ref: https://github.com/ant-design/ant-design/issues/37179
       if (target.scrollLeft !== scrollLeft) {
-        setTimeout(() => {
+        target._scrollTimeout = setTimeout(() => {
           target.scrollLeft = scrollLeft;
+          target._scrollTimeout = null;
         }, 0);
       }
     }


### PR DESCRIPTION
f修复 forceScroll 方法中当 setTimeout 调用不是最后一次时机时，有可能会出现最后一次的 target.scrollLeft 赋值操作被后续setTimeout中的 target.scrollLeft 赋值给覆盖，由此一来造成表头和表体错位的问题。