### PR TITLE
feat: support classNames and styles

### DIFF
--- a/docs/examples/className.tsx
+++ b/docs/examples/className.tsx
@@ -52,6 +52,20 @@ const Demo = () => (
       expandedRowClassName={(record, i) => `ex-row-${i}`}
       data={data}
       className="table"
+      title={() => <span>title</span>}
+      footer={() => <span>footer</span>}
+    />
+    <h2>scroll</h2>
+     <Table
+      columns={columns}
+      rowClassName={(record, i) => `row-${i}`}
+      expandedRowRender={record => <p>extra: {record.a}</p>}
+      expandedRowClassName={(record, i) => `ex-row-${i}`}
+      data={Array(5).fill(data)}
+      className="table"
+      scroll={{ x: 'calc(700px + 50%)', y: 47 * 5 }}
+      title={() => <span>title</span>}
+      footer={() => <span>footer</span>}
     />
   </div>
 );

--- a/docs/examples/components.tsx
+++ b/docs/examples/components.tsx
@@ -24,6 +24,18 @@ const Demo = () => {
   return (
     <div>
       <Table
+        classNames={{
+          body: {
+            wrapper: 'test-body-wrapper',
+            cell: 'test-body-cell',
+            row: 'test-body-row',
+          },
+          header: {
+            wrapper: 'test-header-wrapper',
+            cell: 'test-header-cell',
+            row: 'test-header-row',
+          },
+        }}
         components={{ header: { table } }}
         sticky
         columns={[

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -1,13 +1,13 @@
 import cls from 'classnames';
 import * as React from 'react';
 import Cell from '../Cell';
-import { useContext } from '@rc-component/context';
-import TableContext, { responseImmutable } from '../context/TableContext';
+import { responseImmutable } from '../context/TableContext';
 import devRenderTimes from '../hooks/useRenderTimes';
 import useRowInfo from '../hooks/useRowInfo';
 import type { ColumnType, CustomizeComponent } from '../interface';
 import ExpandedRow from './ExpandedRow';
 import { computedExpandedClassName } from '../utils/expandUtil';
+import { TableProps } from '..';
 
 export interface BodyRowProps<RecordType> {
   record: RecordType;
@@ -15,6 +15,8 @@ export interface BodyRowProps<RecordType> {
   renderIndex: number;
   className?: string;
   style?: React.CSSProperties;
+  classNames?: TableProps['classNames']['body'];
+  styles?: TableProps['styles']['body'];
   rowComponent: CustomizeComponent;
   cellComponent: CustomizeComponent;
   scopeCellComponent: CustomizeComponent;
@@ -95,6 +97,8 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
   const {
     className,
     style,
+    classNames,
+    styles,
     record,
     index,
     renderIndex,
@@ -103,11 +107,8 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
     rowComponent: RowComponent,
     cellComponent,
     scopeCellComponent,
-    rowType,
   } = props;
-  const { classNames, styles } = useContext(TableContext, ['classNames', 'styles']);
-  const { body: bodyCls, header: headerCls } = classNames || {};
-  const { body: bodyStyles, header: headerStyles } = styles || {};
+
   const rowInfo = useRowInfo(record, rowKey, index, indent);
   const {
     prefixCls,
@@ -143,17 +144,15 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
         `${prefixCls}-row`,
         `${prefixCls}-row-level-${indent}`,
         rowProps?.className,
+        classNames?.row,
         {
-          [headerCls?.row]: headerCls?.row && rowType === 'header',
-          [bodyCls?.row]: bodyCls?.row && rowType === 'body',
           [expandedClsName]: indent >= 1,
         },
       )}
       style={{
         ...style,
         ...rowProps?.style,
-        ...(rowType === 'header' && headerStyles?.row),
-        ...(rowType === 'body' && bodyStyles?.row),
+        ...styles?.row,
       }}
     >
       {flattenColumns.map((column: ColumnType<RecordType>, colIndex) => {
@@ -169,8 +168,8 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
 
         return (
           <Cell<RecordType>
-            rowType="body"
-            className={columnClassName}
+            className={cls(columnClassName, classNames?.cell)}
+            style={styles?.cell}
             ellipsis={column.ellipsis}
             align={column.align}
             scope={column.rowScope}

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -93,6 +93,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
   if (process.env.NODE_ENV !== 'production') {
     devRenderTimes(props);
   }
+
   const {
     className,
     style,
@@ -143,7 +144,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
         `${prefixCls}-row`,
         `${prefixCls}-row-level-${indent}`,
         rowProps?.className,
-        classNames?.row,
+        classNames.row,
         {
           [expandedClsName]: indent >= 1,
         },
@@ -151,7 +152,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
       style={{
         ...style,
         ...rowProps?.style,
-        ...styles?.row,
+        ...styles.row,
       }}
     >
       {flattenColumns.map((column: ColumnType<RecordType>, colIndex) => {
@@ -167,8 +168,8 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
 
         return (
           <Cell<RecordType>
-            className={cls(columnClassName, classNames?.cell)}
-            style={styles?.cell}
+            className={cls(columnClassName, classNames.cell)}
+            style={styles.cell}
             ellipsis={column.ellipsis}
             align={column.align}
             scope={column.rowScope}

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -22,7 +22,6 @@ export interface BodyRowProps<RecordType> {
   scopeCellComponent: CustomizeComponent;
   indent?: number;
   rowKey: React.Key;
-  rowType?: 'header' | 'body' | 'footer';
 }
 
 // ==================================================================================

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -15,8 +15,8 @@ export interface BodyRowProps<RecordType> {
   renderIndex: number;
   className?: string;
   style?: React.CSSProperties;
-  classNames?: TableProps['classNames']['body'];
-  styles?: TableProps['styles']['body'];
+  classNames: TableProps['classNames']['body'];
+  styles: TableProps['styles']['body'];
   rowComponent: CustomizeComponent;
   cellComponent: CustomizeComponent;
   scopeCellComponent: CustomizeComponent;

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -46,8 +46,8 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
     'classNames',
     'styles',
   ]);
-  const { body: bodyCls } = classNames || {};
-  const { body: bodyStyles } = styles || {};
+  const { body: bodyCls = {} } = classNames || {};
+  const { body: bodyStyles = {} } = styles || {};
 
   const flattenData: { record: RecordType; indent: number; index: number }[] =
     useFlattenRecords<RecordType>(data, childrenColumnName, expandedKeys, getRowKey);
@@ -107,8 +107,8 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
   return (
     <PerfContext.Provider value={perfRef.current}>
       <WrapperComponent
-        className={cls(`${prefixCls}-tbody`, bodyCls?.wrapper)}
-        style={bodyStyles?.wrapper}
+        className={cls(`${prefixCls}-tbody`, bodyCls.wrapper)}
+        style={bodyStyles.wrapper}
       >
         {/* Measure body column width with additional hidden col */}
         {measureColumnWidth && (

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -72,8 +72,9 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
 
       return (
         <BodyRow
+          classNames={bodyCls}
+          styles={bodyStyles}
           key={key}
-          rowType="body"
           rowKey={key}
           record={record}
           index={idx}

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -9,6 +9,7 @@ import { getColumnsKey } from '../utils/valueUtil';
 import BodyRow from './BodyRow';
 import ExpandedRow from './ExpandedRow';
 import MeasureRow from './MeasureRow';
+import cls from 'classnames';
 
 export interface BodyProps<RecordType> {
   data: readonly RecordType[];
@@ -31,6 +32,8 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
     expandedKeys,
     childrenColumnName,
     emptyNode,
+    classNames,
+    styles,
   } = useContext(TableContext, [
     'prefixCls',
     'getComponent',
@@ -40,7 +43,11 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
     'expandedKeys',
     'childrenColumnName',
     'emptyNode',
+    'classNames',
+    'styles',
   ]);
+  const { body: bodyCls } = classNames || {};
+  const { body: bodyStyles } = styles || {};
 
   const flattenData: { record: RecordType; indent: number; index: number }[] =
     useFlattenRecords<RecordType>(data, childrenColumnName, expandedKeys, getRowKey);
@@ -66,6 +73,7 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
       return (
         <BodyRow
           key={key}
+          rowType="body"
           rowKey={key}
           record={record}
           index={idx}
@@ -97,7 +105,10 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
 
   return (
     <PerfContext.Provider value={perfRef.current}>
-      <WrapperComponent className={`${prefixCls}-tbody`}>
+      <WrapperComponent
+        className={cls(`${prefixCls}-tbody`, bodyCls?.wrapper)}
+        style={bodyStyles?.wrapper}
+      >
         {/* Measure body column width with additional hidden col */}
         {measureColumnWidth && (
           <MeasureRow

--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -129,6 +129,8 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     'classNames',
     'styles',
   ]);
+  const { body: bodyCls, header: headerCls } = classNames || {};
+  const { body: bodyStyles, header: headerStyles } = styles || {};
 
   // ====================== Value =======================
   const [childNode, legacyCellProps] = useCellRender(
@@ -220,6 +222,9 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     classNames?.item,
     className,
     {
+      [headerCls?.cell]: headerCls?.cell && rowType === 'header',
+      [bodyCls?.cell]: bodyCls?.cell && rowType === 'body',
+
       // Fixed
       [`${cellPrefixCls}-fix`]: isFixStart || isFixEnd,
       [`${cellPrefixCls}-fix-start`]: isFixStart,
@@ -254,7 +259,10 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     ...alignStyle,
     ...additionalProps.style,
     ...styles?.item,
+    ...(rowType === 'header' && headerStyles?.cell),
+    ...(rowType === 'body' && bodyStyles?.cell),
   };
+  console.log('rowType', rowType);
 
   // >>>>> Children Node
   let mergedChildNode = childNode;

--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -125,12 +125,10 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
 
   const cellPrefixCls = `${prefixCls}-cell`;
 
-  const {
-    allColumnsFixedLeft,
-    rowHoverable,
-    classNames = {},
-    styles = {},
-  } = useContext(TableContext, ['allColumnsFixedLeft', 'rowHoverable', 'classNames', 'styles']);
+  const { allColumnsFixedLeft, rowHoverable } = useContext(TableContext, [
+    'allColumnsFixedLeft',
+    'rowHoverable',
+  ]);
 
   // ====================== Value =======================
   const [childNode, legacyCellProps] = useCellRender(
@@ -219,7 +217,6 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
   // >>>>> ClassName
   const mergedClassName = cls(
     cellPrefixCls,
-    classNames.cell,
     className,
     {
       // Fixed
@@ -255,7 +252,6 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     ...fixedStyle,
     ...alignStyle,
     ...additionalProps.style,
-    ...styles.cell,
     ...style,
   };
 

--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -1,5 +1,5 @@
 import { useContext } from '@rc-component/context';
-import classNames from 'classnames';
+import cls from 'classnames';
 import * as React from 'react';
 import TableContext from '../context/TableContext';
 import devRenderTimes from '../hooks/useRenderTimes';
@@ -122,10 +122,8 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
   } = props;
 
   const cellPrefixCls = `${prefixCls}-cell`;
-  const { allColumnsFixedLeft, rowHoverable } = useContext(TableContext, [
-    'allColumnsFixedLeft',
-    'rowHoverable',
-  ]);
+
+  const { allColumnsFixedLeft, rowHoverable, classNames, styles } = useContext(TableContext);
 
   // ====================== Value =======================
   const [childNode, legacyCellProps] = useCellRender(
@@ -212,8 +210,9 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     });
 
   // >>>>> ClassName
-  const mergedClassName = classNames(
+  const mergedClassName = cls(
     cellPrefixCls,
+    classNames?.item,
     className,
     {
       // Fixed
@@ -249,6 +248,7 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     ...fixedStyle,
     ...alignStyle,
     ...additionalProps.style,
+    ...styles?.item,
   };
 
   // >>>>> Children Node

--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -123,7 +123,12 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
 
   const cellPrefixCls = `${prefixCls}-cell`;
 
-  const { allColumnsFixedLeft, rowHoverable, classNames, styles } = useContext(TableContext);
+  const { allColumnsFixedLeft, rowHoverable, classNames, styles } = useContext(TableContext, [
+    'allColumnsFixedLeft',
+    'rowHoverable',
+    'classNames',
+    'styles',
+  ]);
 
   // ====================== Value =======================
   const [childNode, legacyCellProps] = useCellRender(

--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -125,12 +125,12 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
 
   const cellPrefixCls = `${prefixCls}-cell`;
 
-  const { allColumnsFixedLeft, rowHoverable, classNames, styles } = useContext(TableContext, [
-    'allColumnsFixedLeft',
-    'rowHoverable',
-    'classNames',
-    'styles',
-  ]);
+  const {
+    allColumnsFixedLeft,
+    rowHoverable,
+    classNames = {},
+    styles = {},
+  } = useContext(TableContext, ['allColumnsFixedLeft', 'rowHoverable', 'classNames', 'styles']);
 
   // ====================== Value =======================
   const [childNode, legacyCellProps] = useCellRender(
@@ -219,7 +219,7 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
   // >>>>> ClassName
   const mergedClassName = cls(
     cellPrefixCls,
-    classNames?.item,
+    classNames.cell,
     className,
     {
       // Fixed
@@ -255,7 +255,7 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     ...fixedStyle,
     ...alignStyle,
     ...additionalProps.style,
-    ...styles?.item,
+    ...styles.cell,
     ...style,
   };
 

--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -19,6 +19,7 @@ import { useEvent } from '@rc-component/util';
 export interface CellProps<RecordType extends DefaultRecordType> {
   prefixCls?: string;
   className?: string;
+  style?: React.CSSProperties;
   record?: RecordType;
   /** `column` index is the real show rowIndex */
   index?: number;
@@ -88,6 +89,7 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     // Style
     prefixCls,
     className,
+    style,
     align,
 
     // Value
@@ -129,8 +131,6 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     'classNames',
     'styles',
   ]);
-  const { body: bodyCls, header: headerCls } = classNames || {};
-  const { body: bodyStyles, header: headerStyles } = styles || {};
 
   // ====================== Value =======================
   const [childNode, legacyCellProps] = useCellRender(
@@ -222,9 +222,6 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     classNames?.item,
     className,
     {
-      [headerCls?.cell]: headerCls?.cell && rowType === 'header',
-      [bodyCls?.cell]: bodyCls?.cell && rowType === 'body',
-
       // Fixed
       [`${cellPrefixCls}-fix`]: isFixStart || isFixEnd,
       [`${cellPrefixCls}-fix-start`]: isFixStart,
@@ -259,10 +256,8 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     ...alignStyle,
     ...additionalProps.style,
     ...styles?.item,
-    ...(rowType === 'header' && headerStyles?.cell),
-    ...(rowType === 'body' && bodyStyles?.cell),
+    ...style,
   };
-  console.log('rowType', rowType);
 
   // >>>>> Children Node
   let mergedChildNode = childNode;

--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -46,6 +46,7 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
 
   const {
     className,
+    style,
     noData,
     columns,
     flattenColumns,
@@ -159,6 +160,7 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
       style={{
         overflow: 'hidden',
         ...(isSticky ? { top: stickyTopOffset, bottom: stickyBottomOffset } : {}),
+        ...style,
       }}
       ref={setScrollRef}
       className={classNames(className, {

--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -26,6 +26,7 @@ function useColumnWidth(colWidths: readonly number[], columCount: number) {
 
 export interface FixedHeaderProps<RecordType> extends HeaderProps<RecordType> {
   className: string;
+  style?: React.CSSProperties;
   noData: boolean;
   maxContentScroll: boolean;
   colWidths: readonly number[];

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -12,9 +12,12 @@ import type {
 } from '../interface';
 import HeaderRow from './HeaderRow';
 import cls from 'classnames';
+import { TableProps } from '..';
 
 function parseHeaderRows<RecordType>(
   rootColumns: ColumnsType<RecordType>,
+  classNames: TableProps['classNames']['header'],
+  styles: TableProps['styles']['header'],
 ): CellType<RecordType>[][] {
   const rows: CellType<RecordType>[][] = [];
 
@@ -30,7 +33,8 @@ function parseHeaderRows<RecordType>(
     const colSpans: number[] = columns.filter(Boolean).map(column => {
       const cell: CellType<RecordType> = {
         key: column.key,
-        className: column.className || '',
+        className: cls(column.className, classNames?.cell) || '',
+        style: styles?.cell,
         children: column.title,
         column,
         colStart: currentColIndex,
@@ -106,7 +110,10 @@ const Header = <RecordType extends any>(props: HeaderProps<RecordType>) => {
   ]);
   const { header: headerCls } = classNames || {};
   const { header: headerStyles } = styles || {};
-  const rows = React.useMemo<CellType<RecordType>[][]>(() => parseHeaderRows(columns), [columns]);
+  const rows = React.useMemo<CellType<RecordType>[][]>(
+    () => parseHeaderRows(columns, headerCls, headerStyles),
+    [columns, headerCls, headerStyles],
+  );
 
   const WrapperComponent = getComponent(['header', 'wrapper'], 'thead');
   const trComponent = getComponent(['header', 'row'], 'tr');

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -33,8 +33,8 @@ function parseHeaderRows<RecordType>(
     const colSpans: number[] = columns.filter(Boolean).map(column => {
       const cell: CellType<RecordType> = {
         key: column.key,
-        className: cls(column.className, classNames?.cell) || '',
-        style: styles?.cell,
+        className: cls(column.className, classNames.cell) || '',
+        style: styles.cell,
         children: column.title,
         column,
         colStart: currentColIndex,
@@ -108,8 +108,8 @@ const Header = <RecordType extends any>(props: HeaderProps<RecordType>) => {
     'classNames',
     'styles',
   ]);
-  const { header: headerCls } = classNames || {};
-  const { header: headerStyles } = styles || {};
+  const { header: headerCls = {} } = classNames || {};
+  const { header: headerStyles = {} } = styles || {};
   const rows = React.useMemo<CellType<RecordType>[][]>(
     () => parseHeaderRows(columns, headerCls, headerStyles),
     [columns, headerCls, headerStyles],
@@ -121,12 +121,14 @@ const Header = <RecordType extends any>(props: HeaderProps<RecordType>) => {
 
   return (
     <WrapperComponent
-      className={cls(`${prefixCls}-thead`, headerCls?.wrapper)}
-      style={headerStyles?.wrapper}
+      className={cls(`${prefixCls}-thead`, headerCls.wrapper)}
+      style={headerStyles.wrapper}
     >
       {rows.map((row, rowIndex) => {
         const rowNode = (
           <HeaderRow
+            classNames={headerCls}
+            styles={headerStyles}
             key={rowIndex}
             flattenColumns={flattenColumns}
             cells={row}

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -11,6 +11,7 @@ import type {
   StickyOffsets,
 } from '../interface';
 import HeaderRow from './HeaderRow';
+import cls from 'classnames';
 
 function parseHeaderRows<RecordType>(
   rootColumns: ColumnsType<RecordType>,
@@ -97,7 +98,14 @@ const Header = <RecordType extends any>(props: HeaderProps<RecordType>) => {
 
   const { stickyOffsets, columns, flattenColumns, onHeaderRow } = props;
 
-  const { prefixCls, getComponent } = useContext(TableContext, ['prefixCls', 'getComponent']);
+  const { prefixCls, getComponent, classNames, styles } = useContext(TableContext, [
+    'prefixCls',
+    'getComponent',
+    'classNames',
+    'styles',
+  ]);
+  const { header: headerCls } = classNames || {};
+  const { header: headerStyles } = styles || {};
   const rows = React.useMemo<CellType<RecordType>[][]>(() => parseHeaderRows(columns), [columns]);
 
   const WrapperComponent = getComponent(['header', 'wrapper'], 'thead');
@@ -105,7 +113,10 @@ const Header = <RecordType extends any>(props: HeaderProps<RecordType>) => {
   const thComponent = getComponent(['header', 'cell'], 'th');
 
   return (
-    <WrapperComponent className={`${prefixCls}-thead`}>
+    <WrapperComponent
+      className={cls(`${prefixCls}-thead`, headerCls?.wrapper)}
+      style={headerStyles?.wrapper}
+    >
       {rows.map((row, rowIndex) => {
         const rowNode = (
           <HeaderRow

--- a/src/Header/HeaderRow.tsx
+++ b/src/Header/HeaderRow.tsx
@@ -32,7 +32,13 @@ const HeaderRow = <RecordType extends any>(props: RowProps<RecordType>) => {
     onHeaderRow,
     index,
   } = props;
-  const { prefixCls } = useContext(TableContext, ['prefixCls']);
+  const { prefixCls, styles, classNames } = useContext(TableContext, [
+    'prefixCls',
+    'styles',
+    'classNames',
+  ]);
+  const { header: headerCls } = classNames || {};
+  const { header: headerStyles } = styles || {};
   let rowProps: React.HTMLAttributes<HTMLElement>;
   if (onHeaderRow) {
     rowProps = onHeaderRow(
@@ -44,7 +50,7 @@ const HeaderRow = <RecordType extends any>(props: RowProps<RecordType>) => {
   const columnsKey = getColumnsKey(cells.map(cell => cell.column));
 
   return (
-    <RowComponent {...rowProps}>
+    <RowComponent {...rowProps} className={headerCls?.row} style={headerStyles?.row}>
       {cells.map((cell: CellType<RecordType>, cellIndex) => {
         const { column } = cell;
         const fixedInfo = getCellFixedInfo(

--- a/src/Header/HeaderRow.tsx
+++ b/src/Header/HeaderRow.tsx
@@ -21,8 +21,8 @@ export interface RowProps<RecordType> {
   cellComponent: CustomizeComponent;
   onHeaderRow: GetComponentProps<readonly ColumnType<RecordType>[]>;
   index: number;
-  classNames?: TableProps['classNames']['header'];
-  styles?: TableProps['styles']['header'];
+  classNames: TableProps['classNames']['header'];
+  styles: TableProps['styles']['header'];
 }
 
 const HeaderRow = <RecordType extends any>(props: RowProps<RecordType>) => {

--- a/src/Header/HeaderRow.tsx
+++ b/src/Header/HeaderRow.tsx
@@ -11,6 +11,7 @@ import type {
 } from '../interface';
 import { getCellFixedInfo } from '../utils/fixUtil';
 import { getColumnsKey } from '../utils/valueUtil';
+import { TableProps } from '..';
 
 export interface RowProps<RecordType> {
   cells: readonly CellType<RecordType>[];
@@ -20,6 +21,8 @@ export interface RowProps<RecordType> {
   cellComponent: CustomizeComponent;
   onHeaderRow: GetComponentProps<readonly ColumnType<RecordType>[]>;
   index: number;
+  classNames?: TableProps['classNames']['header'];
+  styles?: TableProps['styles']['header'];
 }
 
 const HeaderRow = <RecordType extends any>(props: RowProps<RecordType>) => {
@@ -31,14 +34,10 @@ const HeaderRow = <RecordType extends any>(props: RowProps<RecordType>) => {
     cellComponent: CellComponent,
     onHeaderRow,
     index,
+    classNames,
+    styles,
   } = props;
-  const { prefixCls, styles, classNames } = useContext(TableContext, [
-    'prefixCls',
-    'styles',
-    'classNames',
-  ]);
-  const { header: headerCls } = classNames || {};
-  const { header: headerStyles } = styles || {};
+  const { prefixCls } = useContext(TableContext, ['prefixCls']);
   let rowProps: React.HTMLAttributes<HTMLElement>;
   if (onHeaderRow) {
     rowProps = onHeaderRow(
@@ -50,7 +49,7 @@ const HeaderRow = <RecordType extends any>(props: RowProps<RecordType>) => {
   const columnsKey = getColumnsKey(cells.map(cell => cell.column));
 
   return (
-    <RowComponent {...rowProps} className={headerCls?.row} style={headerStyles?.row}>
+    <RowComponent {...rowProps} className={classNames.row} style={styles.row}>
       {cells.map((cell: CellType<RecordType>, cellIndex) => {
         const { column } = cell;
         const fixedInfo = getCellFixedInfo(

--- a/src/Panel/index.tsx
+++ b/src/Panel/index.tsx
@@ -3,10 +3,11 @@ import * as React from 'react';
 export interface TitleProps {
   className: string;
   children: React.ReactNode;
+  style: React.CSSProperties;
 }
 
-function Panel({ className, children }: TitleProps) {
-  return <div className={className}>{children}</div>;
+function Panel({ className, style, children }: TitleProps) {
+  return <div className={className} style={style}>{children}</div>;
 }
 
 export default Panel;

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -85,14 +85,21 @@ const EMPTY_DATA = [];
 // Used for customize scroll
 const EMPTY_SCROLL_TARGET = {};
 
-export type SemanticName =  'section'| 'header' | 'title' | 'footer' | 'body' | 'content' | 'item';
+export type SemanticName = 'section' | 'title' | 'footer' | 'content' | 'item';
+export type ComponentsSemantic = 'wrapper' | 'cell' | 'row';
 export interface TableProps<RecordType = any>
   extends Omit<LegacyExpandableProps<RecordType>, 'showExpandColumn'> {
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;
-  classNames?: Partial<Record<SemanticName, string>>;
-  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
+  classNames?: Partial<Record<SemanticName, string>> & {
+    body?: Partial<Record<ComponentsSemantic, string>>;
+    header?: Partial<Record<ComponentsSemantic, string>>;
+  };
+  styles?: Partial<Record<SemanticName, React.CSSProperties>> & {
+    body?: Partial<Record<ComponentsSemantic, React.CSSProperties>>;
+    header?: Partial<Record<ComponentsSemantic, React.CSSProperties>>;
+  };
   children?: React.ReactNode;
   data?: readonly RecordType[];
   columns?: ColumnsType<RecordType>;
@@ -660,11 +667,10 @@ function Table<RecordType extends DefaultRecordType>(
           style={{
             ...scrollXStyle,
             ...scrollYStyle,
-            ...styles?.body,
           }}
           onScroll={onBodyScroll}
           ref={scrollBodyRef}
-          className={cls(`${prefixCls}-body`, classNames?.body)}
+          className={`${prefixCls}-body`}
         >
           <TableComponent
             style={{
@@ -704,8 +710,7 @@ function Table<RecordType extends DefaultRecordType>(
           <FixedHolder
             {...fixedHolderProps}
             stickyTopOffset={offsetHeader}
-            className={cls(`${prefixCls}-header`, classNames?.header)}
-            style={styles?.header}
+            className={`${prefixCls}-header`}
             ref={scrollHeaderRef}
           >
             {renderFixedHeaderTable}
@@ -800,11 +805,23 @@ function Table<RecordType extends DefaultRecordType>(
       ref={fullTableRef}
       {...dataProps}
     >
-      {title && <Panel className={cls(`${prefixCls}-title`, classNames?.title)} style={styles?.title}>{title(mergedData)}</Panel>}
-      <div ref={scrollBodyContainerRef} className={cls(`${prefixCls}-container`, classNames?.section)} style={styles?.section}>
+      {title && (
+        <Panel className={cls(`${prefixCls}-title`, classNames?.title)} style={styles?.title}>
+          {title(mergedData)}
+        </Panel>
+      )}
+      <div
+        ref={scrollBodyContainerRef}
+        className={cls(`${prefixCls}-container`, classNames?.section)}
+        style={styles?.section}
+      >
         {groupTableNode}
       </div>
-      {footer && <Panel className={cls(`${prefixCls}-footer`, classNames?.footer)} style={styles?.footer}>{footer(mergedData)}</Panel>}
+      {footer && (
+        <Panel className={cls(`${prefixCls}-footer`, classNames?.footer)} style={styles?.footer}>
+          {footer(mergedData)}
+        </Panel>
+      )}
     </div>
   );
 

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -85,7 +85,7 @@ const EMPTY_DATA = [];
 // Used for customize scroll
 const EMPTY_SCROLL_TARGET = {};
 
-export type SemanticName = 'section' | 'title' | 'footer' | 'content' | 'item';
+export type SemanticName = 'section' | 'title' | 'footer' | 'content' | 'cell';
 export type ComponentsSemantic = 'wrapper' | 'cell' | 'row';
 export interface TableProps<RecordType = any>
   extends Omit<LegacyExpandableProps<RecordType>, 'showExpandColumn'> {

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -25,7 +25,7 @@
  */
 
 import type { CompareProps } from '@rc-component/context/lib/Immutable';
-import classNames from 'classnames';
+import cls from 'classnames';
 import ResizeObserver from '@rc-component/resize-observer';
 import isVisible from '@rc-component/util/lib/Dom/isVisible';
 import { getTargetScrollBarSize } from '@rc-component/util/lib/getScrollBarSize';
@@ -85,11 +85,14 @@ const EMPTY_DATA = [];
 // Used for customize scroll
 const EMPTY_SCROLL_TARGET = {};
 
+export type SemanticName =  'section'| 'header' | 'title' | 'footer' | 'body' | 'content' | 'item';
 export interface TableProps<RecordType = any>
   extends Omit<LegacyExpandableProps<RecordType>, 'showExpandColumn'> {
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;
+  classNames?: Partial<Record<SemanticName, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
   children?: React.ReactNode;
   data?: readonly RecordType[];
   columns?: ColumnsType<RecordType>;
@@ -190,6 +193,8 @@ function Table<RecordType extends DefaultRecordType>(
     className,
     rowClassName,
     style,
+    classNames,
+    styles,
     data,
     rowKey,
     scroll,
@@ -655,10 +660,11 @@ function Table<RecordType extends DefaultRecordType>(
           style={{
             ...scrollXStyle,
             ...scrollYStyle,
+            ...styles?.body,
           }}
           onScroll={onBodyScroll}
           ref={scrollBodyRef}
-          className={classNames(`${prefixCls}-body`)}
+          className={cls(`${prefixCls}-body`, classNames?.body)}
         >
           <TableComponent
             style={{
@@ -698,7 +704,8 @@ function Table<RecordType extends DefaultRecordType>(
           <FixedHolder
             {...fixedHolderProps}
             stickyTopOffset={offsetHeader}
-            className={`${prefixCls}-header`}
+            className={cls(`${prefixCls}-header`, classNames?.header)}
+            style={styles?.header}
             ref={scrollHeaderRef}
           >
             {renderFixedHeaderTable}
@@ -739,8 +746,9 @@ function Table<RecordType extends DefaultRecordType>(
         style={{
           ...scrollXStyle,
           ...scrollYStyle,
+          ...styles?.content,
         }}
-        className={classNames(`${prefixCls}-content`)}
+        className={cls(`${prefixCls}-content`, classNames?.content)}
         onScroll={onInternalScroll}
         ref={scrollBodyRef}
       >
@@ -773,7 +781,7 @@ function Table<RecordType extends DefaultRecordType>(
 
   let fullTable = (
     <div
-      className={classNames(prefixCls, className, {
+      className={cls(prefixCls, className, {
         [`${prefixCls}-rtl`]: direction === 'rtl',
         [`${prefixCls}-fix-start-shadow`]: horizonScroll,
         [`${prefixCls}-fix-end-shadow`]: horizonScroll,
@@ -792,11 +800,11 @@ function Table<RecordType extends DefaultRecordType>(
       ref={fullTableRef}
       {...dataProps}
     >
-      {title && <Panel className={`${prefixCls}-title`}>{title(mergedData)}</Panel>}
-      <div ref={scrollBodyContainerRef} className={`${prefixCls}-container`}>
+      {title && <Panel className={cls(`${prefixCls}-title`, classNames?.title)} style={styles?.title}>{title(mergedData)}</Panel>}
+      <div ref={scrollBodyContainerRef} className={cls(`${prefixCls}-container`, classNames?.section)} style={styles?.section}>
         {groupTableNode}
       </div>
-      {footer && <Panel className={`${prefixCls}-footer`}>{footer(mergedData)}</Panel>}
+      {footer && <Panel className={cls(`${prefixCls}-footer`, classNames?.footer)} style={styles?.footer}>{footer(mergedData)}</Panel>}
     </div>
   );
 
@@ -811,6 +819,9 @@ function Table<RecordType extends DefaultRecordType>(
       // Scroll
       scrollX: mergedScrollX,
       scrollInfo,
+
+      classNames,
+      styles,
 
       // Table
       prefixCls,

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -85,7 +85,7 @@ const EMPTY_DATA = [];
 // Used for customize scroll
 const EMPTY_SCROLL_TARGET = {};
 
-export type SemanticName = 'section' | 'title' | 'footer' | 'content' | 'cell';
+export type SemanticName = 'section' | 'title' | 'footer' | 'content';
 export type ComponentsSemantic = 'wrapper' | 'cell' | 'row';
 export interface TableProps<RecordType = any>
   extends Omit<LegacyExpandableProps<RecordType>, 'showExpandColumn'> {

--- a/src/context/TableContext.tsx
+++ b/src/context/TableContext.tsx
@@ -24,7 +24,6 @@ export type ScrollInfoType = [scrollLeft: number, scrollRange: number];
 export interface TableContextProps<RecordType = any> {
   // Scroll
   scrollX: number | string | true;
-  style?: React.CSSProperties;
   classNames?: Partial<Record<SemanticName, string>>;
   styles?: Partial<Record<SemanticName, React.CSSProperties>>;
 

--- a/src/context/TableContext.tsx
+++ b/src/context/TableContext.tsx
@@ -14,7 +14,7 @@ import type {
   TriggerEventHandler,
 } from '../interface';
 import type { FixedInfo } from '../utils/fixUtil';
-import { SemanticName } from '../Table';
+import { TableProps } from '../Table';
 
 const { makeImmutable, responseImmutable, useImmutableMark } = createImmutable();
 export { makeImmutable, responseImmutable, useImmutableMark };
@@ -24,8 +24,8 @@ export type ScrollInfoType = [scrollLeft: number, scrollRange: number];
 export interface TableContextProps<RecordType = any> {
   // Scroll
   scrollX: number | string | true;
-  classNames?: Partial<Record<SemanticName, string>>;
-  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
+  classNames?: TableProps['classNames'];
+  styles?: TableProps['styles'];
 
   // Table
   prefixCls: string;

--- a/src/context/TableContext.tsx
+++ b/src/context/TableContext.tsx
@@ -14,6 +14,7 @@ import type {
   TriggerEventHandler,
 } from '../interface';
 import type { FixedInfo } from '../utils/fixUtil';
+import { SemanticName } from '../Table';
 
 const { makeImmutable, responseImmutable, useImmutableMark } = createImmutable();
 export { makeImmutable, responseImmutable, useImmutableMark };
@@ -23,6 +24,9 @@ export type ScrollInfoType = [scrollLeft: number, scrollRange: number];
 export interface TableContextProps<RecordType = any> {
   // Scroll
   scrollX: number | string | true;
+  style?: React.CSSProperties;
+  classNames?: Partial<Record<SemanticName, string>>;
+  styles?: Partial<Record<SemanticName, React.CSSProperties>>;
 
   // Table
   prefixCls: string;

--- a/tests/semantic.spec.tsx
+++ b/tests/semantic.spec.tsx
@@ -43,44 +43,61 @@ describe('support classNames and styles', () => {
   const commonTableProps = {
     columns: columns,
     rowClassName: (record, i) => `row-${i}`,
-    expandedRowRender: (record) => <p>extra: {record.a}</p>,
+    expandedRowRender: record => <p>extra: {record.a}</p>,
     expandedRowClassName: (record, i) => `ex-row-${i}`,
-    className: "table",
+    className: 'table',
     title: () => <span>title</span>,
     footer: () => <span>footer</span>,
   };
   it('should support className and style', () => {
     const testClassNames = {
       section: 'test-section',
-      header: 'test-header',
       title: 'test-title',
-      body: 'test-body',
       footer: 'test-footer',
       content: 'test-content',
       item: 'test-item',
-    }
+      body: {
+        wrapper: 'test-body-wrapper',
+        cell: 'test-body-cell',
+        row: 'test-body-row',
+      },
+      header: {
+        wrapper: 'test-header-wrapper',
+        cell: 'test-header-cell',
+        row: 'test-header-row',
+      },
+    };
     const testStyles = {
       section: { background: 'red' },
-      header: { background: 'blue' },
       title: { background: 'green' },
-      body: { background: 'yellow' },
       footer: { background: 'pink' },
       content: { background: 'purple' },
-      item: { background: 'orange' },
-    }
+      item: { fontSize: '19px' },
+      body: {
+        wrapper: { background: 'cyan' },
+        cell: { background: 'lime' },
+        row: { background: 'teal' },
+      },
+      header: {
+        wrapper: { background: 'magenta' },
+        cell: { background: 'gold' },
+        row: { background: 'silver' },
+      },
+    };
     const { container } = render(
-      <Table
-        {...commonTableProps}
-        classNames={testClassNames}
-        styles={testStyles}
-        data={data}
-      />
-    )
+      <Table {...commonTableProps} classNames={testClassNames} styles={testStyles} data={data} />,
+    );
     const section = container.querySelector('.rc-table-container');
     const title = container.querySelector('.rc-table-title');
     const footer = container.querySelector('.rc-table-footer');
     const content = container.querySelector('.rc-table-content');
     const item = container.querySelector('.rc-table-cell');
+    const headerWrapper = container.querySelector('.rc-table-thead');
+    const headerCell = container.querySelector('.rc-table-cell');
+    const headerRow = container.querySelector('tr');
+    const bodyWrapper = container.querySelector('.rc-table-tbody');
+    const bodyCell = container.querySelector('.rc-table-tbody .rc-table-cell');
+    const bodyRow = container.querySelector('.rc-table-row');
     expect(section).toHaveClass(testClassNames.section);
     expect(section).toHaveStyle(testStyles.section);
     expect(title).toHaveClass(testClassNames.title);
@@ -90,23 +107,19 @@ describe('support classNames and styles', () => {
     expect(content).toHaveClass(testClassNames.content);
     expect(content).toHaveStyle(testStyles.content);
     expect(item).toHaveClass(testClassNames.item);
-    expect(item).toHaveStyle(testStyles.item);
+    expect(item).toHaveStyle({ fontSize: testStyles.item.fontSize });
 
-    const { container: scrollContainer } = render(
-      <Table
-        {...commonTableProps}
-        classNames={testClassNames}
-        styles={testStyles}
-        data={data}
-        scroll={{ y: 200 }}
-      />
-    )
-    const header = scrollContainer.querySelector('.rc-table-header');
-    const body = scrollContainer.querySelector('.rc-table-body');
-    expect(header).toHaveClass(testClassNames.header);
-    expect(header).toHaveStyle(testStyles.header);
-    expect(body).toHaveClass(testClassNames.body);
-    expect(body).toHaveStyle(testStyles.body);
-  })
-})
-
+    expect(headerWrapper).toHaveClass(testClassNames.header.wrapper);
+    expect(headerWrapper).toHaveStyle(testStyles.header.wrapper);
+    expect(headerCell).toHaveClass(testClassNames.header.cell);
+    expect(headerCell).toHaveStyle({ background: testStyles.header.cell.background });
+    expect(headerRow).toHaveClass(testClassNames.header.row);
+    expect(headerRow).toHaveStyle(testStyles.header.row);
+    expect(bodyWrapper).toHaveClass(testClassNames.body.wrapper);
+    expect(bodyWrapper).toHaveStyle(testStyles.body.wrapper);
+    expect(bodyCell).toHaveClass(testClassNames.body.cell);
+    expect(bodyCell).toHaveStyle(testStyles.body.cell);
+    expect(bodyRow).toHaveClass(testClassNames.body.row);
+    expect(bodyRow).toHaveStyle(testStyles.body.row);
+  });
+});

--- a/tests/semantic.spec.tsx
+++ b/tests/semantic.spec.tsx
@@ -55,7 +55,7 @@ describe('support classNames and styles', () => {
       title: 'test-title',
       footer: 'test-footer',
       content: 'test-content',
-      item: 'test-item',
+      cell: 'test-cell',
       body: {
         wrapper: 'test-body-wrapper',
         cell: 'test-body-cell',
@@ -72,7 +72,7 @@ describe('support classNames and styles', () => {
       title: { background: 'green' },
       footer: { background: 'pink' },
       content: { background: 'purple' },
-      item: { fontSize: '19px' },
+      cell: { fontSize: '19px' },
       body: {
         wrapper: { background: 'cyan' },
         cell: { background: 'lime' },
@@ -91,7 +91,7 @@ describe('support classNames and styles', () => {
     const title = container.querySelector('.rc-table-title');
     const footer = container.querySelector('.rc-table-footer');
     const content = container.querySelector('.rc-table-content');
-    const item = container.querySelector('.rc-table-cell');
+    const cell = container.querySelector('.rc-table-cell');
     const headerWrapper = container.querySelector('.rc-table-thead');
     const headerCell = container.querySelector('.rc-table-cell');
     const headerRow = container.querySelector('tr');
@@ -106,8 +106,8 @@ describe('support classNames and styles', () => {
     expect(footer).toHaveStyle(testStyles.footer);
     expect(content).toHaveClass(testClassNames.content);
     expect(content).toHaveStyle(testStyles.content);
-    expect(item).toHaveClass(testClassNames.item);
-    expect(item).toHaveStyle({ fontSize: testStyles.item.fontSize });
+    expect(cell).toHaveClass(testClassNames.cell);
+    expect(cell).toHaveStyle({ fontSize: testStyles.cell.fontSize });
 
     expect(headerWrapper).toHaveClass(testClassNames.header.wrapper);
     expect(headerWrapper).toHaveStyle(testStyles.header.wrapper);

--- a/tests/semantic.spec.tsx
+++ b/tests/semantic.spec.tsx
@@ -55,7 +55,6 @@ describe('support classNames and styles', () => {
       title: 'test-title',
       footer: 'test-footer',
       content: 'test-content',
-      cell: 'test-cell',
       body: {
         wrapper: 'test-body-wrapper',
         cell: 'test-body-cell',
@@ -72,7 +71,6 @@ describe('support classNames and styles', () => {
       title: { background: 'green' },
       footer: { background: 'pink' },
       content: { background: 'purple' },
-      cell: { fontSize: '19px' },
       body: {
         wrapper: { background: 'cyan' },
         cell: { background: 'lime' },
@@ -91,7 +89,6 @@ describe('support classNames and styles', () => {
     const title = container.querySelector('.rc-table-title');
     const footer = container.querySelector('.rc-table-footer');
     const content = container.querySelector('.rc-table-content');
-    const cell = container.querySelector('.rc-table-cell');
     const headerWrapper = container.querySelector('.rc-table-thead');
     const headerCell = container.querySelector('.rc-table-cell');
     const headerRow = container.querySelector('tr');
@@ -106,8 +103,6 @@ describe('support classNames and styles', () => {
     expect(footer).toHaveStyle(testStyles.footer);
     expect(content).toHaveClass(testClassNames.content);
     expect(content).toHaveStyle(testStyles.content);
-    expect(cell).toHaveClass(testClassNames.cell);
-    expect(cell).toHaveStyle({ fontSize: testStyles.cell.fontSize });
 
     expect(headerWrapper).toHaveClass(testClassNames.header.wrapper);
     expect(headerWrapper).toHaveStyle(testStyles.header.wrapper);

--- a/tests/semantic.spec.tsx
+++ b/tests/semantic.spec.tsx
@@ -1,0 +1,112 @@
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import Table, { TableProps } from '../src';
+describe('support classNames and styles', () => {
+  const columns: TableProps['columns'] = [
+    {
+      title: 'title1',
+      dataIndex: 'a',
+      className: 'a',
+      key: 'a',
+      width: 100,
+    },
+    {
+      title: 'title2',
+      dataIndex: 'b',
+      className: 'b',
+      key: 'b',
+      width: 100,
+    },
+    {
+      title: 'title3',
+      dataIndex: 'c',
+      className: 'c',
+      key: 'c',
+      width: 200,
+    },
+    {
+      title: 'Operations',
+      dataIndex: '',
+      className: 'd',
+      key: 'd',
+      render() {
+        return <a href="#">Operations</a>;
+      },
+    },
+  ];
+
+  const data = [
+    { a: '123', key: '1' },
+    { a: 'cdd', b: 'edd', key: '2' },
+    { a: '1333', c: 'eee', d: 2, key: '3' },
+  ];
+  const commonTableProps = {
+    columns: columns,
+    rowClassName: (record, i) => `row-${i}`,
+    expandedRowRender: (record) => <p>extra: {record.a}</p>,
+    expandedRowClassName: (record, i) => `ex-row-${i}`,
+    className: "table",
+    title: () => <span>title</span>,
+    footer: () => <span>footer</span>,
+  };
+  it('should support className and style', () => {
+    const testClassNames = {
+      section: 'test-section',
+      header: 'test-header',
+      title: 'test-title',
+      body: 'test-body',
+      footer: 'test-footer',
+      content: 'test-content',
+      item: 'test-item',
+    }
+    const testStyles = {
+      section: { background: 'red' },
+      header: { background: 'blue' },
+      title: { background: 'green' },
+      body: { background: 'yellow' },
+      footer: { background: 'pink' },
+      content: { background: 'purple' },
+      item: { background: 'orange' },
+    }
+    const { container } = render(
+      <Table
+        {...commonTableProps}
+        classNames={testClassNames}
+        styles={testStyles}
+        data={data}
+      />
+    )
+    const section = container.querySelector('.rc-table-container');
+    const title = container.querySelector('.rc-table-title');
+    const footer = container.querySelector('.rc-table-footer');
+    const content = container.querySelector('.rc-table-content');
+    const item = container.querySelector('.rc-table-cell');
+    expect(section).toHaveClass(testClassNames.section);
+    expect(section).toHaveStyle(testStyles.section);
+    expect(title).toHaveClass(testClassNames.title);
+    expect(title).toHaveStyle(testStyles.title);
+    expect(footer).toHaveClass(testClassNames.footer);
+    expect(footer).toHaveStyle(testStyles.footer);
+    expect(content).toHaveClass(testClassNames.content);
+    expect(content).toHaveStyle(testStyles.content);
+    expect(item).toHaveClass(testClassNames.item);
+    expect(item).toHaveStyle(testStyles.item);
+
+    const { container: scrollContainer } = render(
+      <Table
+        {...commonTableProps}
+        classNames={testClassNames}
+        styles={testStyles}
+        data={data}
+        scroll={{ y: 200 }}
+      />
+    )
+    const header = scrollContainer.querySelector('.rc-table-header');
+    const body = scrollContainer.querySelector('.rc-table-body');
+    expect(header).toHaveClass(testClassNames.header);
+    expect(header).toHaveStyle(testStyles.header);
+    expect(body).toHaveClass(testClassNames.body);
+    expect(body).toHaveStyle(testStyles.body);
+  })
+})
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 表格组件现支持为各个语义部分（如标题、页脚、表头、内容区、行等）自定义 className 和内联样式，提升了样式定制能力。
  - 示例文档新增演示，展示了表格标题/页脚渲染和可滚动表格的用法。
  - 单元格、固定头部和面板组件新增支持通过 style 属性传入自定义内联样式。
  - 表体和表头行、单元格支持接收上下文传递的 className 和样式，实现更灵活的样式控制。

- **测试**
  - 新增测试用例，验证自定义 className 和样式在表格各部分的正确应用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->