### PR TITLE
fix: optimize and fix the implementation of emptyNode shake

### DIFF
--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -61,8 +61,6 @@ function ExpandedRow(props: ExpandedRowProps) {
       className={className}
       style={{
         display: expanded ? null : 'none',
-        // fix https://github.com/ant-design/ant-design/issues/49279
-        visibility: isEmpty && horizonScroll && !componentWidth ? 'hidden' : null,
       }}
     >
       <Cell component={cellComponent} prefixCls={prefixCls} colSpan={colSpan}>

--- a/tests/__snapshots__/ExpandRow.spec.jsx.snap
+++ b/tests/__snapshots__/ExpandRow.spec.jsx.snap
@@ -569,7 +569,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
             >
               <div
                 class="rc-table-expanded-row-fixed"
-                style="width: 0px; position: sticky; left: 0px; overflow: hidden;"
+                style="width: 1128px; position: sticky; left: 0px; overflow: hidden;"
               >
                 <p>
                   extra data
@@ -616,7 +616,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
             >
               <div
                 class="rc-table-expanded-row-fixed"
-                style="width: 0px; position: sticky; left: 0px; overflow: hidden;"
+                style="width: 1128px; position: sticky; left: 0px; overflow: hidden;"
               >
                 <p>
                   extra data

--- a/tests/__snapshots__/FixedColumn.spec.tsx.snap
+++ b/tests/__snapshots__/FixedColumn.spec.tsx.snap
@@ -1819,7 +1819,6 @@ exports[`Table.FixedColumn > renders correctly > scrollX - without data 1`] = `
           </tr>
           <tr
             class="rc-table-placeholder"
-            style=""
           >
             <td
               class="rc-table-cell"
@@ -2976,7 +2975,6 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
           </tr>
           <tr
             class="rc-table-placeholder"
-            style=""
           >
             <td
               class="rc-table-cell"


### PR DESCRIPTION
优化 https://github.com/react-component/table/pull/1142 的实现，用 useLayoutEffect 获取宽度解决不同步的问题。

用 ResizeObserver 几乎都有这个问题，比如其他地方有用到宽度，需要 useLayoutEffect 获取一下避免闪烁。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 优化了表格在水平滚动状态变化时的自适应宽度调整，提升了表格在不同场景下的显示效果。
  - 修正了展开行在特定条件下的可见性样式问题，确保内容显示更加一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->