### PR TITLE
fix expanded & sticky 2

### DIFF
--- a/docs/demo/expandedSticky.md
+++ b/docs/demo/expandedSticky.md
@@ -1,0 +1,8 @@
+---
+title: expandedSticky
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/expandedSticky.tsx"></code>

--- a/docs/examples/className.tsx
+++ b/docs/examples/className.tsx
@@ -52,20 +52,6 @@ const Demo = () => (
       expandedRowClassName={(record, i) => `ex-row-${i}`}
       data={data}
       className="table"
-      title={() => <span>title</span>}
-      footer={() => <span>footer</span>}
-    />
-    <h2>scroll</h2>
-     <Table
-      columns={columns}
-      rowClassName={(record, i) => `row-${i}`}
-      expandedRowRender={record => <p>extra: {record.a}</p>}
-      expandedRowClassName={(record, i) => `ex-row-${i}`}
-      data={Array(5).fill(data)}
-      className="table"
-      scroll={{ x: 'calc(700px + 50%)', y: 47 * 5 }}
-      title={() => <span>title</span>}
-      footer={() => <span>footer</span>}
     />
   </div>
 );

--- a/docs/examples/components.tsx
+++ b/docs/examples/components.tsx
@@ -24,18 +24,6 @@ const Demo = () => {
   return (
     <div>
       <Table
-        classNames={{
-          body: {
-            wrapper: 'test-body-wrapper',
-            cell: 'test-body-cell',
-            row: 'test-body-row',
-          },
-          header: {
-            wrapper: 'test-header-wrapper',
-            cell: 'test-header-cell',
-            row: 'test-header-row',
-          },
-        }}
         components={{ header: { table } }}
         sticky
         columns={[

--- a/docs/examples/expandedSticky.tsx
+++ b/docs/examples/expandedSticky.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import type { ColumnType } from 'rc-table';
+import Table from 'rc-table';
+import '../../assets/index.less';
+
+const Demo = () => {
+  const [expandedRowKeys, setExpandedRowKeys] = useState<readonly React.Key[]>([]);
+
+  const columns: ColumnType<Record<string, any>>[] = [
+    {
+      title: '手机号',
+      dataIndex: 'a',
+      width: 100,
+      fixed: 'left',
+      onCell: (_, index) => {
+        const props: React.TdHTMLAttributes<HTMLTableCellElement> = {};
+        if (index === 1) props.rowSpan = expandedRowKeys.includes('b') ? 3 : 2;
+        if (index === 2) props.rowSpan = 0;
+        return props;
+      },
+    },
+    Table.EXPAND_COLUMN,
+    { title: 'Name', dataIndex: 'c' },
+    { title: 'Address', fixed: 'right', dataIndex: 'd', width: 200 },
+  ];
+
+  return (
+    <div
+      style={{
+        height: 10000,
+      }}
+    >
+      <h2>expanded & sticky</h2>
+      <Table<Record<string, any>>
+        rowKey="key"
+        sticky
+        scroll={{ x: 800 }}
+        columns={columns}
+        data={[
+          { key: 'a', a: '12313132132', c: '小二', d: '文零西路' },
+          { key: 'b', a: '13812340987', c: '张三', d: '文一西路' },
+          { key: 'c', a: '13812340987', c: '张夫', d: '文二西路' },
+        ]}
+        expandable={{
+          expandedRowOffset: { column: 1, width: 100 },
+          expandedRowKeys,
+          onExpandedRowsChange: keys => setExpandedRowKeys(keys),
+          expandedRowRender: record => <p style={{ margin: 0 }}>{record.key}</p>,
+        }}
+        className="table"
+      />
+    </div>
+  );
+};
+
+export default Demo;

--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -14,6 +14,7 @@ export interface ExpandedRowProps {
   children: React.ReactNode;
   colSpan: number;
   isEmpty: boolean;
+  offsetWidth?: number;
 }
 
 function ExpandedRow(props: ExpandedRowProps) {
@@ -30,6 +31,7 @@ function ExpandedRow(props: ExpandedRowProps) {
     expanded,
     colSpan,
     isEmpty,
+    offsetWidth = 0,
   } = props;
 
   const { scrollbarSize, fixHeader, fixColumn, componentWidth, horizonScroll } = useContext(
@@ -39,12 +41,11 @@ function ExpandedRow(props: ExpandedRowProps) {
 
   // Cache render node
   let contentNode = children;
-
   if (isEmpty ? horizonScroll && componentWidth : fixColumn) {
     contentNode = (
       <div
         style={{
-          width: componentWidth - (fixHeader && !isEmpty ? scrollbarSize : 0),
+          width: componentWidth - offsetWidth - (fixHeader && !isEmpty ? scrollbarSize : 0),
           position: 'sticky',
           left: 0,
           overflow: 'hidden',

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -9,7 +9,6 @@ import { getColumnsKey } from '../utils/valueUtil';
 import BodyRow from './BodyRow';
 import ExpandedRow from './ExpandedRow';
 import MeasureRow from './MeasureRow';
-import cls from 'classnames';
 
 export interface BodyProps<RecordType> {
   data: readonly RecordType[];
@@ -32,8 +31,7 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
     expandedKeys,
     childrenColumnName,
     emptyNode,
-    classNames,
-    styles,
+    expandedRowOffset,
   } = useContext(TableContext, [
     'prefixCls',
     'getComponent',
@@ -43,11 +41,8 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
     'expandedKeys',
     'childrenColumnName',
     'emptyNode',
-    'classNames',
-    'styles',
+    'expandedRowOffset',
   ]);
-  const { body: bodyCls = {} } = classNames || {};
-  const { body: bodyStyles = {} } = styles || {};
 
   const flattenData: { record: RecordType; indent: number; index: number }[] =
     useFlattenRecords<RecordType>(data, childrenColumnName, expandedKeys, getRowKey);
@@ -72,8 +67,6 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
 
       return (
         <BodyRow
-          classNames={bodyCls}
-          styles={bodyStyles}
           key={key}
           rowKey={key}
           record={record}
@@ -83,6 +76,7 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
           cellComponent={tdComponent}
           scopeCellComponent={thComponent}
           indent={indent}
+          expandedRowOffset={expandedRowOffset}
         />
       );
     });
@@ -106,10 +100,7 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
 
   return (
     <PerfContext.Provider value={perfRef.current}>
-      <WrapperComponent
-        className={cls(`${prefixCls}-tbody`, bodyCls.wrapper)}
-        style={bodyStyles.wrapper}
-      >
+      <WrapperComponent className={`${prefixCls}-tbody`}>
         {/* Measure body column width with additional hidden col */}
         {measureColumnWidth && (
           <MeasureRow

--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -1,5 +1,5 @@
 import { useContext } from '@rc-component/context';
-import cls from 'classnames';
+import classNames from 'classnames';
 import * as React from 'react';
 import TableContext from '../context/TableContext';
 import devRenderTimes from '../hooks/useRenderTimes';
@@ -19,7 +19,6 @@ import { useEvent } from '@rc-component/util';
 export interface CellProps<RecordType extends DefaultRecordType> {
   prefixCls?: string;
   className?: string;
-  style?: React.CSSProperties;
   record?: RecordType;
   /** `column` index is the real show rowIndex */
   index?: number;
@@ -89,7 +88,6 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     // Style
     prefixCls,
     className,
-    style,
     align,
 
     // Value
@@ -124,7 +122,6 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
   } = props;
 
   const cellPrefixCls = `${prefixCls}-cell`;
-
   const { allColumnsFixedLeft, rowHoverable } = useContext(TableContext, [
     'allColumnsFixedLeft',
     'rowHoverable',
@@ -215,7 +212,7 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     });
 
   // >>>>> ClassName
-  const mergedClassName = cls(
+  const mergedClassName = classNames(
     cellPrefixCls,
     className,
     {
@@ -252,7 +249,6 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     ...fixedStyle,
     ...alignStyle,
     ...additionalProps.style,
-    ...style,
   };
 
   // >>>>> Children Node

--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -26,7 +26,6 @@ function useColumnWidth(colWidths: readonly number[], columCount: number) {
 
 export interface FixedHeaderProps<RecordType> extends HeaderProps<RecordType> {
   className: string;
-  style?: React.CSSProperties;
   noData: boolean;
   maxContentScroll: boolean;
   colWidths: readonly number[];
@@ -47,7 +46,6 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
 
   const {
     className,
-    style,
     noData,
     columns,
     flattenColumns,
@@ -161,7 +159,6 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
       style={{
         overflow: 'hidden',
         ...(isSticky ? { top: stickyTopOffset, bottom: stickyBottomOffset } : {}),
-        ...style,
       }}
       ref={setScrollRef}
       className={classNames(className, {

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -11,13 +11,9 @@ import type {
   StickyOffsets,
 } from '../interface';
 import HeaderRow from './HeaderRow';
-import cls from 'classnames';
-import { TableProps } from '..';
 
 function parseHeaderRows<RecordType>(
   rootColumns: ColumnsType<RecordType>,
-  classNames: TableProps['classNames']['header'],
-  styles: TableProps['styles']['header'],
 ): CellType<RecordType>[][] {
   const rows: CellType<RecordType>[][] = [];
 
@@ -33,8 +29,7 @@ function parseHeaderRows<RecordType>(
     const colSpans: number[] = columns.filter(Boolean).map(column => {
       const cell: CellType<RecordType> = {
         key: column.key,
-        className: cls(column.className, classNames.cell) || '',
-        style: styles.cell,
+        className: column.className || '',
         children: column.title,
         column,
         colStart: currentColIndex,
@@ -102,33 +97,18 @@ const Header = <RecordType extends any>(props: HeaderProps<RecordType>) => {
 
   const { stickyOffsets, columns, flattenColumns, onHeaderRow } = props;
 
-  const { prefixCls, getComponent, classNames, styles } = useContext(TableContext, [
-    'prefixCls',
-    'getComponent',
-    'classNames',
-    'styles',
-  ]);
-  const { header: headerCls = {} } = classNames || {};
-  const { header: headerStyles = {} } = styles || {};
-  const rows = React.useMemo<CellType<RecordType>[][]>(
-    () => parseHeaderRows(columns, headerCls, headerStyles),
-    [columns, headerCls, headerStyles],
-  );
+  const { prefixCls, getComponent } = useContext(TableContext, ['prefixCls', 'getComponent']);
+  const rows = React.useMemo<CellType<RecordType>[][]>(() => parseHeaderRows(columns), [columns]);
 
   const WrapperComponent = getComponent(['header', 'wrapper'], 'thead');
   const trComponent = getComponent(['header', 'row'], 'tr');
   const thComponent = getComponent(['header', 'cell'], 'th');
 
   return (
-    <WrapperComponent
-      className={cls(`${prefixCls}-thead`, headerCls.wrapper)}
-      style={headerStyles.wrapper}
-    >
+    <WrapperComponent className={`${prefixCls}-thead`}>
       {rows.map((row, rowIndex) => {
         const rowNode = (
           <HeaderRow
-            classNames={headerCls}
-            styles={headerStyles}
             key={rowIndex}
             flattenColumns={flattenColumns}
             cells={row}

--- a/src/Header/HeaderRow.tsx
+++ b/src/Header/HeaderRow.tsx
@@ -11,7 +11,6 @@ import type {
 } from '../interface';
 import { getCellFixedInfo } from '../utils/fixUtil';
 import { getColumnsKey } from '../utils/valueUtil';
-import { TableProps } from '..';
 
 export interface RowProps<RecordType> {
   cells: readonly CellType<RecordType>[];
@@ -21,8 +20,6 @@ export interface RowProps<RecordType> {
   cellComponent: CustomizeComponent;
   onHeaderRow: GetComponentProps<readonly ColumnType<RecordType>[]>;
   index: number;
-  classNames: TableProps['classNames']['header'];
-  styles: TableProps['styles']['header'];
 }
 
 const HeaderRow = <RecordType extends any>(props: RowProps<RecordType>) => {
@@ -34,8 +31,6 @@ const HeaderRow = <RecordType extends any>(props: RowProps<RecordType>) => {
     cellComponent: CellComponent,
     onHeaderRow,
     index,
-    classNames,
-    styles,
   } = props;
   const { prefixCls } = useContext(TableContext, ['prefixCls']);
   let rowProps: React.HTMLAttributes<HTMLElement>;
@@ -49,7 +44,7 @@ const HeaderRow = <RecordType extends any>(props: RowProps<RecordType>) => {
   const columnsKey = getColumnsKey(cells.map(cell => cell.column));
 
   return (
-    <RowComponent {...rowProps} className={classNames.row} style={styles.row}>
+    <RowComponent {...rowProps}>
       {cells.map((cell: CellType<RecordType>, cellIndex) => {
         const { column } = cell;
         const fixedInfo = getCellFixedInfo(

--- a/src/Panel/index.tsx
+++ b/src/Panel/index.tsx
@@ -3,11 +3,10 @@ import * as React from 'react';
 export interface TitleProps {
   className: string;
   children: React.ReactNode;
-  style: React.CSSProperties;
 }
 
-function Panel({ className, style, children }: TitleProps) {
-  return <div className={className} style={style}>{children}</div>;
+function Panel({ className, children }: TitleProps) {
+  return <div className={className}>{children}</div>;
 }
 
 export default Panel;

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -25,7 +25,7 @@
  */
 
 import type { CompareProps } from '@rc-component/context/lib/Immutable';
-import cls from 'classnames';
+import classNames from 'classnames';
 import ResizeObserver from '@rc-component/resize-observer';
 import { getTargetScrollBarSize } from '@rc-component/util/lib/getScrollBarSize';
 import useEvent from '@rc-component/util/lib/hooks/useEvent';
@@ -85,21 +85,11 @@ const EMPTY_DATA = [];
 // Used for customize scroll
 const EMPTY_SCROLL_TARGET = {};
 
-export type SemanticName = 'section' | 'title' | 'footer' | 'content';
-export type ComponentsSemantic = 'wrapper' | 'cell' | 'row';
 export interface TableProps<RecordType = any>
   extends Omit<LegacyExpandableProps<RecordType>, 'showExpandColumn'> {
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;
-  classNames?: Partial<Record<SemanticName, string>> & {
-    body?: Partial<Record<ComponentsSemantic, string>>;
-    header?: Partial<Record<ComponentsSemantic, string>>;
-  };
-  styles?: Partial<Record<SemanticName, React.CSSProperties>> & {
-    body?: Partial<Record<ComponentsSemantic, React.CSSProperties>>;
-    header?: Partial<Record<ComponentsSemantic, React.CSSProperties>>;
-  };
   children?: React.ReactNode;
   data?: readonly RecordType[];
   columns?: ColumnsType<RecordType>;
@@ -200,8 +190,6 @@ function Table<RecordType extends DefaultRecordType>(
     className,
     rowClassName,
     style,
-    classNames,
-    styles,
     data,
     rowKey,
     scroll,
@@ -675,7 +663,7 @@ function Table<RecordType extends DefaultRecordType>(
           }}
           onScroll={onBodyScroll}
           ref={scrollBodyRef}
-          className={`${prefixCls}-body`}
+          className={classNames(`${prefixCls}-body`)}
         >
           <TableComponent
             style={{
@@ -756,9 +744,8 @@ function Table<RecordType extends DefaultRecordType>(
         style={{
           ...scrollXStyle,
           ...scrollYStyle,
-          ...styles?.content,
         }}
-        className={cls(`${prefixCls}-content`, classNames?.content)}
+        className={classNames(`${prefixCls}-content`)}
         onScroll={onInternalScroll}
         ref={scrollBodyRef}
       >
@@ -791,7 +778,7 @@ function Table<RecordType extends DefaultRecordType>(
 
   let fullTable = (
     <div
-      className={cls(prefixCls, className, {
+      className={classNames(prefixCls, className, {
         [`${prefixCls}-rtl`]: direction === 'rtl',
         [`${prefixCls}-fix-start-shadow`]: horizonScroll,
         [`${prefixCls}-fix-end-shadow`]: horizonScroll,
@@ -810,23 +797,11 @@ function Table<RecordType extends DefaultRecordType>(
       ref={fullTableRef}
       {...dataProps}
     >
-      {title && (
-        <Panel className={cls(`${prefixCls}-title`, classNames?.title)} style={styles?.title}>
-          {title(mergedData)}
-        </Panel>
-      )}
-      <div
-        ref={scrollBodyContainerRef}
-        className={cls(`${prefixCls}-container`, classNames?.section)}
-        style={styles?.section}
-      >
+      {title && <Panel className={`${prefixCls}-title`}>{title(mergedData)}</Panel>}
+      <div ref={scrollBodyContainerRef} className={`${prefixCls}-container`}>
         {groupTableNode}
       </div>
-      {footer && (
-        <Panel className={cls(`${prefixCls}-footer`, classNames?.footer)} style={styles?.footer}>
-          {footer(mergedData)}
-        </Panel>
-      )}
+      {footer && <Panel className={`${prefixCls}-footer`}>{footer(mergedData)}</Panel>}
     </div>
   );
 
@@ -845,9 +820,6 @@ function Table<RecordType extends DefaultRecordType>(
       // Scroll
       scrollX: mergedScrollX,
       scrollInfo,
-
-      classNames,
-      styles,
 
       // Table
       prefixCls,
@@ -872,6 +844,7 @@ function Table<RecordType extends DefaultRecordType>(
       expandedRowRender: expandableConfig.expandedRowRender,
       onTriggerExpand,
       expandIconColumnIndex: expandableConfig.expandIconColumnIndex,
+      expandedRowOffset: expandableConfig.expandedRowOffset,
       indentSize: expandableConfig.indentSize,
       allColumnsFixedLeft: flattenColumns.every(col => col.fixed === 'start'),
       emptyNode,
@@ -922,6 +895,7 @@ function Table<RecordType extends DefaultRecordType>(
       expandableConfig.expandedRowRender,
       onTriggerExpand,
       expandableConfig.expandIconColumnIndex,
+      expandableConfig.expandedRowOffset,
       expandableConfig.indentSize,
       emptyNode,
 

--- a/src/context/TableContext.tsx
+++ b/src/context/TableContext.tsx
@@ -3,6 +3,7 @@ import type {
   ColumnsType,
   ColumnType,
   Direction,
+  ExpandableConfig,
   ExpandableType,
   ExpandedRowRender,
   GetComponent,
@@ -14,7 +15,6 @@ import type {
   TriggerEventHandler,
 } from '../interface';
 import type { FixedInfo } from '../utils/fixUtil';
-import { TableProps } from '../Table';
 
 const { makeImmutable, responseImmutable, useImmutableMark } = createImmutable();
 export { makeImmutable, responseImmutable, useImmutableMark };
@@ -24,8 +24,6 @@ export type ScrollInfoType = [scrollLeft: number, scrollRange: number];
 export interface TableContextProps<RecordType = any> {
   // Scroll
   scrollX: number | string | true;
-  classNames?: TableProps['classNames'];
-  styles?: TableProps['styles'];
 
   // Table
   prefixCls: string;
@@ -55,6 +53,7 @@ export interface TableContextProps<RecordType = any> {
   expandIcon: RenderExpandIcon<RecordType>;
   onTriggerExpand: TriggerEventHandler<RecordType>;
   expandIconColumnIndex: number;
+  expandedRowOffset: ExpandableConfig<RecordType>['expandedRowOffset'];
   allColumnsFixedLeft: boolean;
 
   // Column

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -256,6 +256,7 @@ export interface ExpandableConfig<RecordType> {
   rowExpandable?: (record: RecordType) => boolean;
   columnWidth?: number | string;
   fixed?: FixedType;
+  expandedRowOffset?: { width: number; column: number };
 }
 
 // =================== Render ===================


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增“expandedSticky”演示文档及示例，展示可展开并支持粘性表头的表格用法。

- **文档**
  - 新增 expandedSticky.md，包含相关代码示例。
  - 简化 className.tsx 和 components.tsx 示例，移除多余的表格和样式类名演示。

- **重构**
  - 移除所有 classNames 和 styles 属性及其相关用法，简化表格组件的样式接口。
  - 扩展表格可展开配置，支持 expandedRowOffset 属性以自定义展开行的偏移量。

- **样式**
  - 组件仅保留必要的 className，移除内联样式支持，统一样式处理方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->