### PR TITLE
feat: add inner div for cell with append node

### DIFF
--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -238,6 +238,7 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
     additionalProps.className,
     legacyCellProps?.className,
   );
+  const innerCellDivClassName = cls(`${cellPrefixCls}-inner-div`, { [`${cellPrefixCls}-with-append`]: appendNode});
 
   // >>>>> Style
   const alignStyle: React.CSSProperties = {};
@@ -287,8 +288,10 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
       colSpan={mergedColSpan !== 1 ? mergedColSpan : null}
       rowSpan={mergedRowSpan !== 1 ? mergedRowSpan : null}
     >
-      {appendNode}
-      {mergedChildNode}
+      <div className={innerCellDivClassName}>
+        {appendNode}
+        {mergedChildNode}
+      </div>
     </Component>
   );
 }


### PR DESCRIPTION
背景：当想让nest expandable button垂直居中时，当前没有很好的方式在不影响父元素table-cell的同时，实现expandable居中，因此想要在外层加一个div，方便后续基于这个div进行自定义的扩展。
修改方式：通过在外层新增div的方式，增加样式扩展点，方便样式定制。