### PR TITLE
chore: defensive program

### DIFF
--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -89,10 +89,12 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
         e.preventDefault();
       }
     }
-    scrollRef.current?.addEventListener('wheel', onWheel, { passive: false });
+
+    const scrollEle = scrollRef.current;
+    scrollEle?.addEventListener('wheel', onWheel, { passive: false });
 
     return () => {
-      scrollRef.current?.removeEventListener('wheel', onWheel);
+      scrollEle?.removeEventListener('wheel', onWheel);
     };
   }, []);
 


### PR DESCRIPTION
根据 #1266 截图描述，问题出现在 effect 卸载时 ref 的元素被清理。但是实际看了一圈并不会有这种情况，test case 中也无法复现。

由于 https://github.com/react-component/table/pull/1266#discussion_r2092668082 并没有提供复现。这里仅仅做防御性编程，保证卸载时铆钉的元素是装载时的元素。