### PR TITLE
Changes the order of fixed and other properties in flatColumns

### DIFF
--- a/src/hooks/useColumns/index.tsx
+++ b/src/hooks/useColumns/index.tsx
@@ -72,8 +72,8 @@ function flatColumns<RecordType>(
         return [
           ...list,
           ...flatColumns(subColumns, mergedKey).map(subColum => ({
-            fixed: parsedFixed,
             ...subColum,
+            fixed: parsedFixed,
           })),
         ];
       }


### PR DESCRIPTION
Fixes [https://github.com/ant-design/ant-design/issues/51812](url)

A similar issue can be found in the example from [https://table-react-component.vercel.app/demo/fixed-columns-and-header-rtl](url), where Fix Left and Fix title3 should make the parent column fixed, but the child columns are not responding.

![fixedColumnsAndHeaderRtl](https://github.com/user-attachments/assets/fc8ca9a1-02b4-423e-808d-88e9821e4ee0)

In the function mentioned, the property wasn't inherited due to misordering of the properties of column.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复问题**
  * 修正了列固定属性的优先级，确保父列的固定属性会覆盖子列的同名属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->