### PR TITLE
Fix fixed property not being inherited by children columns

### DIFF
--- a/src/hooks/useColumns/index.tsx
+++ b/src/hooks/useColumns/index.tsx
@@ -72,8 +72,8 @@ function flatColumns<RecordType>(
         return [
           ...list,
           ...flatColumns(subColumns, mergedKey).map(subColum => ({
-            fixed: parsedFixed,
             ...subColum,
+            fixed: subColum.fixed ?? parsedFixed,
           })),
         ];
       }


### PR DESCRIPTION
Fixes [https://github.com/ant-design/ant-design/issues/51812](https://github.com/react-component/table/pull/url)

Similar issue: [https://table-react-component.vercel.app/demo/fixed-columns-and-header-rtl](https://github.com/react-component/table/pull/url)

![fixedColumnsAndHeaderRtl](https://github.com/user-attachments/assets/5bd4d77a-ec41-476a-a8db-4ba89af3a2e0)

Applying to Fix Left and Fix title3 should make the parent column fixed as well as the children.

Due to misordering of the properties of the column, the fixed property isn't inherited from the parent due to property overriding from object spread.