### PR TITLE
fix: Adjust the top height of the proxy to solve the sliding issue

### DIFF
--- a/src/VirtualTable/BodyGrid.tsx
+++ b/src/VirtualTable/BodyGrid.tsx
@@ -93,6 +93,17 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
       },
     });
 
+    // https://github.com/ant-design/ant-design/issues/54734
+    Object.defineProperty(obj, 'scrollTop', {
+      get: () => listRef.current?.getScrollInfo().y || 0,
+
+      set: (value: number) => {
+        listRef.current?.scrollTo({
+          top: value,
+        });
+      },
+    });
+
     return obj;
   });
 


### PR DESCRIPTION
background: https://github.com/ant-design/ant-design/issues/54734

### Reason

antd 侧在 https://github.com/ant-design/ant-design/blob/ddd525c7891fe94123e6c5b160f80ed630e8de26/components/table/InternalTable.tsx#L279-L281 使用了元素进行滑动操作。 [scrollTo](https://github.com/ant-design/ant-design/blob/ddd525c7891fe94123e6c5b160f80ed630e8de26/components/_util/scrollTo.ts) 源码可以知道。 如果传递的容器不是一个 html 最终会通过设置 scrollTop 来实现滑动。


### Solution

普通表格中， ref 转发出去的是一个真实的 dom 。所以可以通过 scrollTop 方法进行滑动。
而在虚拟表中， [转发出去的 ref 是一个对象](https://github.com/react-component/table/blob/6c7dee3b88ec1fce680d6d2bd21289f3b46a4313/src/VirtualTable/BodyGrid.tsx#L77-L97)

所以我们需要像 `scrollLeft` 一样，代理一个 `scrollTop` 来解决无法滑动的问题
