### PR TITLE
fix: column header not align before column width being calculated

### DIFF
--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -169,7 +169,7 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
           ...scrollTableStyle,
         }}
       >
-        {getColGroup()}
+        {colGroupNode}
         {children({
           ...restProps,
           stickyOffsets: headerStickyOffsets,

--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -137,7 +137,7 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
 
   const mergedColumnWidth = useColumnWidth(colWidths, columCount);
 
-  const getColGroup = () => {
+  const colGroupNode = useMemo(() => {
     // use original ColGroup if no data or no calculated column width, otherwise use calculated column width
     if (noData || !mergedColumnWidth) {
       return colGroup;
@@ -149,7 +149,7 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
         columns={flattenColumnsWithScrollbar}
       />
     );
-  };
+  }, [noData, mergedColumnWidth, colGroup, combinationScrollBarSize, columCount, flattenColumnsWithScrollbar]);
 
   return (
     <div

--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -137,6 +137,20 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
 
   const mergedColumnWidth = useColumnWidth(colWidths, columCount);
 
+  const getColGroup = () => {
+    // use original ColGroup if no data or no calculated column width, otherwise use calculated column width
+    if (noData || !mergedColumnWidth) {
+      return colGroup;
+    }
+    return (
+      <ColGroup
+        colWidths={[...mergedColumnWidth, combinationScrollBarSize]}
+        columCount={columCount + 1}
+        columns={flattenColumnsWithScrollbar}
+      />
+    );
+  };
+
   return (
     <div
       style={{
@@ -155,16 +169,7 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
           ...scrollTableStyle,
         }}
       >
-        {/* use original ColGroup if no data, otherwise use calculated column width */}
-        {noData ? (
-          colGroup
-        ) : (
-          <ColGroup
-            colWidths={mergedColumnWidth ? [...mergedColumnWidth, combinationScrollBarSize] : []}
-            columCount={columCount + 1}
-            columns={flattenColumnsWithScrollbar}
-          />
-        )}
+        {getColGroup()}
         {children({
           ...restProps,
           stickyOffsets: headerStickyOffsets,


### PR DESCRIPTION
<img width="800" height="442" alt="图片" src="https://github.com/user-attachments/assets/cff84cb4-6f47-4bae-990c-69a35e099e41" />

<img width="800" height="469" alt="图片" src="https://github.com/user-attachments/assets/adf3b986-dddb-4a01-bbda-03a576dcbe1a" />

解决第一帧对不齐的问题，如果列宽度未计算出来时，直接使用自带的 bodyColGroup。cc @crazyair 