### PR TITLE
fix: Table columns minWidth props no work when virtualized

### DIFF
--- a/src/VirtualTable/BodyGrid.tsx
+++ b/src/VirtualTable/BodyGrid.tsx
@@ -57,9 +57,10 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
   // ========================== Column ==========================
   const columnsWidth = React.useMemo<[key: React.Key, width: number, total: number][]>(() => {
     let total = 0;
-    return flattenColumns.map(({ width, key }) => {
-      total += width as number;
-      return [key, width as number, total];
+    return flattenColumns.map(({ width, minWidth, key }) => {
+      const finalWidth = Math.max((width as number) || 0, (minWidth as number) || 0);
+      total += finalWidth;
+      return [key, finalWidth, total];
     });
   }, [flattenColumns]);
 


### PR DESCRIPTION
fix: https://github.com/ant-design/ant-design/issues/54856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 修复
  - 虚拟表格列宽现遵循最小宽度设置，避免列过窄与布局错乱。
  - 处理缺失宽度时的计算异常，防止出现 NaN，提升稳定性与可读性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->