### PR TITLE
chore: sync antd-5.x to master

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/docs/examples/stickyHeader.tsx
+++ b/docs/examples/stickyHeader.tsx
@@ -2,7 +2,7 @@
 import React, { useRef } from 'react';
 import Table from 'rc-table';
 import '../../assets/index.less';
-import type { ColumnType } from '@/interface';
+import type { ColumnType, ColumnsType } from '@/interface';
 
 interface RecordType {
   a?: string;
@@ -79,6 +79,41 @@ const columns: ColumnType<RecordType>[] = [
   },
 ];
 
+const columnsWithWidth: ColumnType<RecordType>[] = [
+  { title: 'title1', dataIndex: 'a', key: 'a', width: 100 },
+  { title: 'title2', dataIndex: 'b', key: 'b', width: 100 },
+  { title: 'title3', dataIndex: 'c', key: 'c', width: 200 },
+  { title: 'title4', dataIndex: 'd', key: 'd', width: 100 },
+];
+
+const columnsGrouped: ColumnsType<any> = [
+  {
+    title: '',
+    dataIndex: 'productType',
+    key: 'productType',
+    rowSpan: 2,
+    rowScope: 'row',
+  },
+  {
+    title: 'Mars',
+    dataIndex: 'mars',
+    key: 'mars',
+    children: [
+      { title: 'ProducedProducedProduced', dataIndex: 'producedMars', key: 'producedMars' },
+      { title: 'Sold', dataIndex: 'soldMars', key: 'soldMars' },
+    ],
+  },
+  {
+    title: 'Venus',
+    dataIndex: 'venus',
+    key: 'venus',
+    children: [
+      { title: 'Produced Produced', dataIndex: 'producedVenus', key: 'producedVenus' },
+      { title: 'Sold Sold Sold Sold', dataIndex: 'soldVenus', key: 'soldVenus' },
+    ],
+  },
+];
+
 const data = [
   { a: '123', key: '1' },
   { a: 'cdd', b: 'edd', key: '2' },
@@ -105,11 +140,7 @@ const data = [
 const Demo = () => {
   const container = useRef();
   return (
-    <div
-      style={{
-        height: 10000,
-      }}
-    >
+    <div>
       <h2>Sticky</h2>
       <Table<RecordType>
         columns={columns}
@@ -212,6 +243,79 @@ const Demo = () => {
         suscipit asperiores, id ullam in iste soluta dignissimos vero incidunt, rem ex consectetur
         beatae totam aperiam. Sunt, laudantium?
       </div>
+
+      <h2>Sticky header with empty data</h2>
+      <Table
+        columns={fixedColumns}
+        data={[]}
+        scroll={{
+          x: 'max-content',
+        }}
+        sticky
+      />
+      <br />
+      <Table
+        columns={fixedColumns}
+        data={[]}
+        scroll={{
+          x: 1200,
+        }}
+        sticky
+      />
+      <br />
+      <Table
+        columns={columnsWithWidth}
+        data={[]}
+        scroll={{
+          x: 'max-content',
+        }}
+        sticky
+      />
+      <br />
+      <Table
+        columns={fixedColumns}
+        data={[{}]}
+        scroll={{
+          x: 'max-content',
+        }}
+        sticky
+      />
+      <br />
+      <Table
+        columns={columnsWithWidth}
+        data={[{}]}
+        scroll={{
+          x: 1200,
+        }}
+        sticky
+      />
+      <br />
+      <Table
+        columns={fixedColumns.map(column => ({ ...column, width: undefined }))}
+        data={[]}
+        scroll={{
+          x: 'max-content',
+        }}
+        sticky
+      />
+      <br />
+      <Table
+        columns={fixedColumns.map(column => ({ ...column, width: undefined }))}
+        data={[{}]}
+        scroll={{
+          x: 'max-content',
+        }}
+        sticky
+      />
+      <br />
+      <Table
+        columns={columnsGrouped}
+        data={[{}, {}]}
+        scroll={{
+          x: 'max-content',
+        }}
+        sticky
+      />
     </div>
   );
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rc-component/table",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "table ui component for react",
   "engines": {
     "node": ">=8.x"

--- a/src/Body/MeasureCell.tsx
+++ b/src/Body/MeasureCell.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import ResizeObserver from '@rc-component/resize-observer';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import type { ColumnType } from '../interface';
 
 export interface MeasureCellProps {
   columnKey: React.Key;
   onColumnResize: (key: React.Key, width: number) => void;
+  column?: ColumnType<any>;
 }
 
-export default function MeasureCell({ columnKey, onColumnResize }: MeasureCellProps) {
+export default function MeasureCell({ columnKey, onColumnResize, column }: MeasureCellProps) {
   const cellRef = React.useRef<HTMLTableCellElement>();
 
   useLayoutEffect(() => {
@@ -18,8 +20,13 @@ export default function MeasureCell({ columnKey, onColumnResize }: MeasureCellPr
 
   return (
     <ResizeObserver data={columnKey}>
-      <td ref={cellRef} style={{ padding: 0, border: 0, height: 0 }}>
-        <div style={{ height: 0, overflow: 'hidden' }}>&nbsp;</div>
+      <td
+        ref={cellRef}
+        style={{ paddingTop: 0, paddingBottom: 0, borderTop: 0, borderBottom: 0, height: 0 }}
+      >
+        <div style={{ height: 0, overflow: 'hidden', fontWeight: 'bold' }}>
+          {column?.title || '\xa0'}
+        </div>
       </td>
     </ResizeObserver>
   );

--- a/src/Body/MeasureRow.tsx
+++ b/src/Body/MeasureRow.tsx
@@ -2,23 +2,25 @@ import * as React from 'react';
 import ResizeObserver from '@rc-component/resize-observer';
 import MeasureCell from './MeasureCell';
 import isVisible from '@rc-component/util/lib/Dom/isVisible';
+import type { ColumnType } from '../interface';
 
-export interface MeasureCellProps {
+export interface MeasureRowProps {
   prefixCls: string;
   onColumnResize: (key: React.Key, width: number) => void;
   columnsKey: React.Key[];
+  columns: readonly ColumnType<any>[];
 }
 
-export default function MeasureRow({ prefixCls, columnsKey, onColumnResize }: MeasureCellProps) {
+export default function MeasureRow({
+  prefixCls,
+  columnsKey,
+  onColumnResize,
+  columns,
+}: MeasureRowProps) {
   const ref = React.useRef<HTMLTableRowElement>(null);
 
   return (
-    <tr
-      aria-hidden="true"
-      className={`${prefixCls}-measure-row`}
-      style={{ height: 0, fontSize: 0 }}
-      ref={ref}
-    >
+    <tr aria-hidden="true" className={`${prefixCls}-measure-row`} style={{ height: 0 }} ref={ref}>
       <ResizeObserver.Collection
         onBatchResize={infoList => {
           if (isVisible(ref.current)) {
@@ -28,9 +30,17 @@ export default function MeasureRow({ prefixCls, columnsKey, onColumnResize }: Me
           }
         }}
       >
-        {columnsKey.map(columnKey => (
-          <MeasureCell key={columnKey} columnKey={columnKey} onColumnResize={onColumnResize} />
-        ))}
+        {columnsKey.map(columnKey => {
+          const column = columns.find(col => col.key === columnKey);
+          return (
+            <MeasureCell
+              key={columnKey}
+              columnKey={columnKey}
+              onColumnResize={onColumnResize}
+              column={column}
+            />
+          );
+        })}
       </ResizeObserver.Collection>
     </tr>
   );

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -146,6 +146,7 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
             prefixCls={prefixCls}
             columnsKey={columnsKey}
             onColumnResize={onColumnResize}
+            columns={flattenColumns}
           />
         )}
 

--- a/src/ColGroup.tsx
+++ b/src/ColGroup.tsx
@@ -22,7 +22,7 @@ function ColGroup<RecordType>({ colWidths, columns, columCount }: ColGroupProps<
   for (let i = len - 1; i >= 0; i -= 1) {
     const width = colWidths[i];
     const column = columns && columns[i];
-    let additionalProps;
+    let additionalProps: Record<string, unknown>;
     let minWidth: number;
     if (column) {
       additionalProps = column[INTERNAL_COL_DEFINE];

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -719,6 +719,8 @@ function Table<RecordType extends DefaultRecordType>(
       ...columnContext,
       direction,
       stickyClassName,
+      scrollTableStyle,
+      tableLayout: mergedTableLayout,
       onScroll: onInternalScroll,
     };
 

--- a/tests/__snapshots__/ExpandRow.spec.jsx.snap
+++ b/tests/__snapshots__/ExpandRow.spec.jsx.snap
@@ -158,42 +158,42 @@ exports[`Table.Expand > does not crash if scroll is not set 1`] = `
           <tr
             aria-hidden="true"
             class="rc-table-measure-row"
-            style="height: 0px; font-size: 0px;"
+            style="height: 0px;"
           >
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
                  
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Name
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Age
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Gender
               </div>
             </td>
           </tr>
@@ -313,42 +313,42 @@ exports[`Table.Expand > does not crash if scroll is not set 2`] = `
           <tr
             aria-hidden="true"
             class="rc-table-measure-row"
-            style="height: 0px; font-size: 0px;"
+            style="height: 0px;"
           >
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
                  
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Name
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Age
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Gender
               </div>
             </td>
           </tr>
@@ -557,42 +557,42 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
           <tr
             aria-hidden="true"
             class="rc-table-measure-row"
-            style="height: 0px; font-size: 0px;"
+            style="height: 0px;"
           >
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
                  
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Name
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Age
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Gender
               </div>
             </td>
           </tr>
@@ -1023,42 +1023,42 @@ exports[`Table.Expand > work in expandable fix 1`] = `
           <tr
             aria-hidden="true"
             class="rc-table-measure-row"
-            style="height: 0px; font-size: 0px;"
+            style="height: 0px;"
           >
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
                  
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Name
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Age
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Gender
               </div>
             </td>
           </tr>
@@ -1181,40 +1181,40 @@ exports[`Table.Expand > work in expandable fix 2`] = `
           <tr
             aria-hidden="true"
             class="rc-table-measure-row"
-            style="height: 0px; font-size: 0px;"
+            style="height: 0px;"
           >
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Name
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Age
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Gender
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
                  
               </div>

--- a/tests/__snapshots__/FixedColumn.spec.tsx.snap
+++ b/tests/__snapshots__/FixedColumn.spec.tsx.snap
@@ -126,114 +126,114 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           <tr
             aria-hidden="true"
             class="rc-table-measure-row"
-            style="height: 0px; font-size: 0px;"
+            style="height: 0px;"
           >
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title1
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title2
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title3
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title4
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title5
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title6
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title7
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title8
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title9
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title10
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title11
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title12
               </div>
             </td>
           </tr>
@@ -917,114 +917,114 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           <tr
             aria-hidden="true"
             class="rc-table-measure-row"
-            style="height: 0px; font-size: 0px;"
+            style="height: 0px;"
           >
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title1
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title2
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title3
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title4
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title5
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title6
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title7
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title8
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title9
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title10
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title11
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title12
               </div>
             </td>
           </tr>
@@ -1706,114 +1706,114 @@ exports[`Table.FixedColumn > renders correctly > scrollX - without data 1`] = `
           <tr
             aria-hidden="true"
             class="rc-table-measure-row"
-            style="height: 0px; font-size: 0px;"
+            style="height: 0px;"
           >
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title1
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title2
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title3
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title4
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title5
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title6
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title7
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title8
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title9
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title10
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title11
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title12
               </div>
             </td>
           </tr>
@@ -1851,7 +1851,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
       style="overflow: hidden;"
     >
       <table
-        style="table-layout: fixed;"
+        style="table-layout: fixed; width: 1200px; min-width: 100%;"
       >
         <colgroup>
           <col
@@ -2019,114 +2019,114 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           <tr
             aria-hidden="true"
             class="rc-table-measure-row"
-            style="height: 0px; font-size: 0px;"
+            style="height: 0px;"
           >
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title1
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title2
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title3
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title4
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title5
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title6
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title7
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title8
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title9
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title10
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title11
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title12
               </div>
             </td>
           </tr>
@@ -2694,49 +2694,8 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
       style="overflow: hidden;"
     >
       <table
-        style="table-layout: fixed;"
+        style="table-layout: fixed; width: 1200px; min-width: 100%;"
       >
-        <colgroup>
-          <col
-            style="width: 1000px;"
-          />
-          <col
-            style="width: 1000px;"
-          />
-          <col
-            style="width: 1000px;"
-          />
-          <col
-            style="width: 1000px;"
-          />
-          <col
-            style="width: 1000px;"
-          />
-          <col
-            style="width: 1000px;"
-          />
-          <col
-            style="width: 1000px;"
-          />
-          <col
-            style="width: 1000px;"
-          />
-          <col
-            style="width: 1000px;"
-          />
-          <col
-            style="width: 1000px;"
-          />
-          <col
-            style="width: 1000px;"
-          />
-          <col
-            style="width: 1000px;"
-          />
-          <col
-            style="width: 15px;"
-          />
-        </colgroup>
         <thead
           class="rc-table-thead"
         >
@@ -2862,114 +2821,114 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
           <tr
             aria-hidden="true"
             class="rc-table-measure-row"
-            style="height: 0px; font-size: 0px;"
+            style="height: 0px;"
           >
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title1
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title2
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title3
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title4
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title5
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title6
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title7
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title8
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title9
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title10
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title11
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                title12
               </div>
             </td>
           </tr>

--- a/tests/__snapshots__/Table.spec.jsx.snap
+++ b/tests/__snapshots__/Table.spec.jsx.snap
@@ -86,22 +86,8 @@ exports[`Table.Basic > custom components > renders fixed column and header corre
       style="overflow: hidden;"
     >
       <table
-        style="table-layout: fixed;"
+        style="table-layout: fixed; width: 100px; min-width: 100%;"
       >
-        <colgroup>
-          <col
-            style="width: 0px;"
-          />
-          <col
-            style="width: 0px;"
-          />
-          <col
-            style="width: 0px;"
-          />
-          <col
-            style="width: 15px;"
-          />
-        </colgroup>
         <thead
           class="rc-table-thead"
           name="my-header-wrapper"
@@ -157,33 +143,33 @@ exports[`Table.Basic > custom components > renders fixed column and header corre
           <tr
             aria-hidden="true"
             class="rc-table-measure-row"
-            style="height: 0px; font-size: 0px;"
+            style="height: 0px;"
           >
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Name
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Age
               </div>
             </td>
             <td
-              style="padding: 0px; border: 0px; height: 0px;"
+              style="padding-top: 0px; padding-bottom: 0px; border-top: 0px; border-bottom: 0px; height: 0px;"
             >
               <div
-                style="height: 0px; overflow: hidden;"
+                style="height: 0px; overflow: hidden; font-weight: bold;"
               >
-                 
+                Gender
               </div>
             </td>
           </tr>
@@ -232,7 +218,7 @@ exports[`Table.Basic > custom components > scroll content > with scroll 1`] = `
       style="overflow: hidden;"
     >
       <table
-        style="table-layout: fixed;"
+        style="table-layout: fixed; width: 100px; min-width: 100%;"
       >
         <colgroup>
           <col


### PR DESCRIPTION
https://github.com/react-component/table/compare/1b75be26f0a69ff0c578166f68f041fefcd9770e...antd-5.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 固定表头/列支持自定义 tableLayout 与滚动区域样式（可配置表格布局与滚动样式）。
  - 宽度测量改进：测量单元格会使用列标题参与宽度计算，提升分组与空数据场景下列宽精度。

- 文档
  - 新增“空数据的粘性表头”示例，展示固定列、显式列宽与分组表头用法并优化示例布局（移除多余固定高度）。

- 杂务
  - 包版本更新至 1.5.3；新增 .npmrc 配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->