### PR TITLE
fix: Table columns minWidth props no work when virtualized (for 5.x)

### DIFF
--- a/src/VirtualTable/BodyGrid.tsx
+++ b/src/VirtualTable/BodyGrid.tsx
@@ -57,9 +57,10 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
   // ========================== Column ==========================
   const columnsWidth = React.useMemo<[key: React.Key, width: number, total: number][]>(() => {
     let total = 0;
-    return flattenColumns.map(({ width, key }) => {
-      total += width as number;
-      return [key, width as number, total];
+    return flattenColumns.map(({ width, minWidth, key }) => {
+      const finalWidth = Math.max((width as number) || 0, (minWidth as number) || 0);
+      total += finalWidth;
+      return [key, finalWidth, total];
     });
   }, [flattenColumns]);
 


### PR DESCRIPTION
Cherry-pick #1334 for `antd@5.x`