### PR TITLE
Use Column width

### DIFF
--- a/docs/examples/stickyHeader.tsx
+++ b/docs/examples/stickyHeader.tsx
@@ -150,7 +150,7 @@ const columns3: ColumnType<RecordType>[] = [
     dataIndex: 'age',
     key: '7',
   },
-  { title: 'Column 8', dataIndex: 'address', key: '8' },
+  { title: 'Column 8', dataIndex: 'address', width: 200, key: '8' },
   { title: 'Column 9', dataIndex: 'name', key: '9' },
   { title: 'Column 10', dataIndex: 'address', key: '10' },
   { title: 'Column 11', dataIndex: 'address', key: '11' },

--- a/src/Body/MeasureCell.tsx
+++ b/src/Body/MeasureCell.tsx
@@ -25,7 +25,7 @@ export default function MeasureCell({ columnKey, onColumnResize, column }: Measu
         style={{ paddingTop: 0, paddingBottom: 0, borderTop: 0, borderBottom: 0, height: 0 }}
       >
         <div style={{ height: 0, overflow: 'hidden', fontWeight: 'bold' }}>
-          {column?.title || '\xa0'}
+          {('width' in column ? '' : column?.title) || '\xa0'}
         </div>
       </td>
     </ResizeObserver>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 虚拟表格支持列最小宽度（minWidth），列宽计算更合理。
- 变更
  - 横向滚动改用 scrollX 配置，替代样式对象方式。
- 修复
  - 无列时不再渲染空表头结构，避免潜在渲染异常。
  - 设定宽度的列不再用标题参与宽度测量，减少错位。
- 文档
  - 新增粘性表头与横向滚动示例，补充对齐问题说明与链接。
- 样式
  - 移除单元格强制断词，遵循浏览器默认换行。
- 杂项
  - 版本升级至 7.52.6。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->