### PR TITLE
feat: add measureRowRender prop

### DIFF
--- a/docs/examples/measureRowRender.tsx
+++ b/docs/examples/measureRowRender.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Table } from 'rc-table';
+import { ConfigProvider } from 'antd';
+
+// 示例：使用 measureRowRender 包裹 ConfigProvider 来隐藏 MeasureRow 中的弹层
+const MeasureRowRenderExample = () => {
+  const columns = [
+    {
+      title: (
+        <div>
+          Name
+          <ConfigProvider
+            getPopupContainer={node => node} // 将弹层渲染到 MeasureRow 内部
+          >
+            <div>Filter Dropdown</div>
+          </ConfigProvider>
+        </div>
+      ),
+      dataIndex: 'name',
+      key: 'name',
+      width: 100,
+    },
+    {
+      title: 'Age',
+      dataIndex: 'age',
+      key: 'age',
+      width: 80,
+    },
+  ];
+
+  const data = [
+    { key: 1, name: 'John', age: 25 },
+    { key: 2, name: 'Jane', age: 30 },
+  ];
+
+  // 自定义 MeasureRow 渲染，包裹 ConfigProvider 来隐藏弹层
+  const measureRowRender = measureRow => (
+    <ConfigProvider
+      getPopupContainer={() => {
+        // 创建一个隐藏的容器来承载弹层
+        const hiddenContainer = document.createElement('div');
+        hiddenContainer.style.display = 'none';
+        hiddenContainer.style.position = 'absolute';
+        hiddenContainer.style.left = '-9999px';
+        hiddenContainer.style.top = '-9999px';
+        document.body.appendChild(hiddenContainer);
+        return hiddenContainer;
+      }}
+    >
+      {measureRow}
+    </ConfigProvider>
+  );
+
+  return (
+    <Table
+      columns={columns}
+      data={data}
+      sticky
+      scroll={{ x: true }}
+      measureRowRender={measureRowRender}
+    />
+  );
+};
+
+export default MeasureRowRenderExample;

--- a/docs/examples/measureRowRender.tsx
+++ b/docs/examples/measureRowRender.tsx
@@ -1,19 +1,16 @@
 import React from 'react';
-import { Table } from 'rc-table';
-import { ConfigProvider } from 'antd';
+import Table from 'rc-table';
 
-// 示例：使用 measureRowRender 包裹 ConfigProvider 来隐藏 MeasureRow 中的弹层
+// 示例：使用 measureRowRender 来隐藏 MeasureRow 中的弹层
 const MeasureRowRenderExample = () => {
   const columns = [
     {
       title: (
         <div>
           Name
-          <ConfigProvider
-            getPopupContainer={node => node} // 将弹层渲染到 MeasureRow 内部
-          >
-            <div>Filter Dropdown</div>
-          </ConfigProvider>
+          <div className="filter-dropdown" style={{ display: 'none' }}>
+            Filter Content
+          </div>
         </div>
       ),
       dataIndex: 'name',
@@ -33,23 +30,8 @@ const MeasureRowRenderExample = () => {
     { key: 2, name: 'Jane', age: 30 },
   ];
 
-  // 自定义 MeasureRow 渲染，包裹 ConfigProvider 来隐藏弹层
-  const measureRowRender = measureRow => (
-    <ConfigProvider
-      getPopupContainer={() => {
-        // 创建一个隐藏的容器来承载弹层
-        const hiddenContainer = document.createElement('div');
-        hiddenContainer.style.display = 'none';
-        hiddenContainer.style.position = 'absolute';
-        hiddenContainer.style.left = '-9999px';
-        hiddenContainer.style.top = '-9999px';
-        document.body.appendChild(hiddenContainer);
-        return hiddenContainer;
-      }}
-    >
-      {measureRow}
-    </ConfigProvider>
-  );
+  // 自定义 MeasureRow 渲染，隐藏弹层内容
+  const measureRowRender = measureRow => <div style={{ display: 'none' }}>{measureRow}</div>;
 
   return (
     <Table

--- a/src/Body/MeasureRow.tsx
+++ b/src/Body/MeasureRow.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import ResizeObserver from 'rc-resize-observer';
 import MeasureCell from './MeasureCell';
 import isVisible from 'rc-util/lib/Dom/isVisible';
+import { useContext } from '@rc-component/context';
+import TableContext from '../context/TableContext';
 import type { ColumnType } from '../interface';
 
 export interface MeasureRowProps {
@@ -18,9 +20,10 @@ export default function MeasureRow({
   columns,
 }: MeasureRowProps) {
   const ref = React.useRef<HTMLTableRowElement>(null);
+  const { measureRowRender } = useContext(TableContext, ['measureRowRender']);
 
-  return (
-    <tr aria-hidden="true" className={`${prefixCls}-measure-row`} style={{ height: 0 }} ref={ref}>
+  const measureRow = (
+    <tr className={`${prefixCls}-measure-row`} style={{ height: 0 }} ref={ref} tabIndex={-1}>
       <ResizeObserver.Collection
         onBatchResize={infoList => {
           if (isVisible(ref.current)) {
@@ -44,4 +47,6 @@ export default function MeasureRow({
       </ResizeObserver.Collection>
     </tr>
   );
+
+  return measureRowRender ? measureRowRender(measureRow) : measureRow;
 }

--- a/src/Body/MeasureRow.tsx
+++ b/src/Body/MeasureRow.tsx
@@ -23,7 +23,7 @@ export default function MeasureRow({
   const { measureRowRender } = useContext(TableContext, ['measureRowRender']);
 
   const measureRow = (
-    <tr className={`${prefixCls}-measure-row`} style={{ height: 0 }} ref={ref} tabIndex={-1}>
+    <tr aria-hidden="true" className={`${prefixCls}-measure-row`} style={{ height: 0 }} ref={ref} tabIndex={-1}>
       <ResizeObserver.Collection
         onBatchResize={infoList => {
           if (isVisible(ref.current)) {

--- a/src/Body/MeasureRow.tsx
+++ b/src/Body/MeasureRow.tsx
@@ -23,7 +23,7 @@ export default function MeasureRow({
   const { measureRowRender } = useContext(TableContext, ['measureRowRender']);
 
   const measureRow = (
-    <tr aria-hidden="true" className={`${prefixCls}-measure-row`} style={{ height: 0 }} ref={ref} tabIndex={-1}>
+    <tr aria-hidden="true" className={`${prefixCls}-measure-row`} style={{ height: 0 }} ref={ref}>
       <ResizeObserver.Collection
         onBatchResize={infoList => {
           if (isVisible(ref.current)) {

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -168,6 +168,12 @@ export interface TableProps<RecordType = any>
   internalRefs?: {
     body: React.MutableRefObject<HTMLDivElement>;
   };
+  /**
+   * @private Internal usage, may remove by refactor.
+   *
+   * !!! DO NOT USE IN PRODUCTION ENVIRONMENT !!!
+   */
+  measureRowRender?: (measureRow: React.ReactNode) => React.ReactNode;
 }
 
 function defaultEmpty() {
@@ -209,6 +215,9 @@ function Table<RecordType extends DefaultRecordType>(
     emptyText,
     onRow,
     onHeaderRow,
+
+    // Measure Row
+    measureRowRender,
 
     // Events
     onScroll,
@@ -850,6 +859,9 @@ function Table<RecordType extends DefaultRecordType>(
       childrenColumnName: mergedChildrenColumnName,
 
       rowHoverable,
+
+      // Measure Row
+      measureRowRender,
     }),
     [
       // Scroll
@@ -901,6 +913,8 @@ function Table<RecordType extends DefaultRecordType>(
       mergedChildrenColumnName,
 
       rowHoverable,
+
+      measureRowRender,
     ],
   );
 

--- a/src/context/TableContext.tsx
+++ b/src/context/TableContext.tsx
@@ -72,6 +72,9 @@ export interface TableContextProps<RecordType = any> {
   rowHoverable?: boolean;
 
   expandedRowOffset: ExpandableConfig<RecordType>['expandedRowOffset'];
+
+  // Measure Row
+  measureRowRender?: (measureRow: React.ReactNode) => React.ReactNode;
 }
 
 const TableContext = createContext<TableContextProps>();

--- a/tests/FixedHeader.spec.jsx
+++ b/tests/FixedHeader.spec.jsx
@@ -265,4 +265,62 @@ describe('Table.FixedHeader', () => {
       'rc-table-cell-fix-left-last',
     );
   });
+
+  it('should support measureRowRender to wrap MeasureRow with custom provider', async () => {
+    const FilterDropdown = ({ visible, onVisibleChange }) => (
+      <div className="test-filter-dropdown" style={{ display: visible ? 'block' : 'none' }}>
+        Filter Content
+        <button onClick={() => onVisibleChange && onVisibleChange(!visible)}>Toggle</button>
+      </div>
+    );
+
+    const columns = [
+      {
+        title: (
+          <div>
+            Name
+            <FilterDropdown visible={true} onVisibleChange={() => {}} />
+          </div>
+        ),
+        dataIndex: 'name',
+        key: 'name',
+        width: 100,
+      },
+    ];
+
+    const data = [
+      {
+        key: 1,
+        name: 'Jack',
+      },
+    ];
+
+    // Mock ConfigProvider-like wrapper
+    const measureRowRender = measureRow => (
+      <div data-testid="measure-row-wrapper" style={{ display: 'none' }}>
+        {measureRow}
+      </div>
+    );
+
+    const wrapper = mount(
+      <Table
+        columns={columns}
+        data={data}
+        sticky
+        scroll={{ x: true }}
+        measureRowRender={measureRowRender}
+      />,
+    );
+
+    await safeAct(wrapper);
+
+    // Check that measureRowRender wrapper is applied
+    const measureRowWrapper = wrapper.find('[data-testid="measure-row-wrapper"]');
+    expect(measureRowWrapper).toHaveLength(1);
+    expect(measureRowWrapper.prop('style').display).toBe('none');
+
+    // Check that MeasureRow is inside the wrapper
+    const measureRowInWrapper = measureRowWrapper.find('.rc-table-measure-row');
+    expect(measureRowInWrapper).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
https://github.com/ant-design/ant-design/issues/54906

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 新增 measureRowRender，可自定义测量行的包装与渲染（并通过上下文可用）。
  - 固定表头支持 scrollX 配置，优化横向滚动布局，替代此前样式控制方式。
- Bug 修复
  - 虚拟表格列宽遵循 minWidth，避免列过窄。
  - 无列时不再渲染空的 colgroup，减少无效 DOM。
- 文档
  - 新增示例：measureRowRender 用法、sticky 与横向滚动、scrollY 对齐问题。
- 样式
  - 表格单元格不再强制断词，长词换行依赖空白符。
- 测试
  - 增加 measureRowRender 相关用例。
- 维护
  - 版本更新至 7.52.7。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->