### PR TITLE
update React 16 to React 19

### DIFF
--- a/docs/examples/animation.tsx
+++ b/docs/examples/animation.tsx
@@ -11,7 +11,7 @@ type MotionBodyProps = React.HTMLAttributes<HTMLTableSectionElement>;
 
 const MotionBody: React.FC<MotionBodyProps> = ({ children, ...props }) => {
   const nodeList = toArray(children);
-  const nodesRef = React.useRef<Record<string, React.ReactElement>>({});
+  const nodesRef = React.useRef<Record<string, React.ReactElement<any>>>({});
 
   // Better apply clean up logic to avoid OOM
   const keys: React.Key[] = [];
@@ -26,7 +26,7 @@ const MotionBody: React.FC<MotionBodyProps> = ({ children, ...props }) => {
       <CSSMotionList keys={keys} component={false} motionName="move">
         {({ key, className }) => {
           const node = nodesRef.current[key];
-          return React.cloneElement(node, {
+          return React.cloneElement<any>(node, {
             className: classNames(node.props.className, className),
           });
         }}

--- a/docs/examples/fixedColumnsAndHeaderRtl.tsx
+++ b/docs/examples/fixedColumnsAndHeaderRtl.tsx
@@ -37,7 +37,7 @@ const useColumn = (
   ellipsis: boolean,
   percentage: boolean,
 ) => {
-  const columns: ColumnsType<RecordType> = React.useMemo(
+  const columns = React.useMemo<ColumnsType<RecordType>>(
     () => [
       {
         title: 'title1',

--- a/docs/examples/jsx.tsx
+++ b/docs/examples/jsx.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-named-as-default-member */
 import React from 'react';
 import Table from 'rc-table';
 import '../../assets/index.less';

--- a/docs/examples/scrollY.tsx
+++ b/docs/examples/scrollY.tsx
@@ -13,7 +13,7 @@ for (let i = 0; i < 20; i += 1) {
 }
 
 const Test = () => {
-  const tblRef = React.useRef<Reference>();
+  const tblRef = React.useRef<Reference>(null);
   const [showBody, setShowBody] = React.useState(true);
 
   const toggleBody = () => {
@@ -94,7 +94,7 @@ const Test = () => {
         data={data}
         scroll={{ y: 300 }}
         rowKey={record => record.key}
-        onRow={(record, index) => ({ style: { backgroundColor: 'red' } })}
+        onRow={() => ({ style: { backgroundColor: 'red' } })}
       />
       <h3>Column align issue</h3>
       <p>https://github.com/ant-design/ant-design/issues/54889</p>

--- a/docs/examples/shadow.tsx
+++ b/docs/examples/shadow.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import type { TableProps } from 'rc-table';
 import Table from 'rc-table';
 import '../../assets/index.less';
 import type { ColumnsType } from '@/interface';

--- a/docs/examples/stickyHeader.tsx
+++ b/docs/examples/stickyHeader.tsx
@@ -166,7 +166,7 @@ const columns3: ColumnType<RecordType>[] = [
 ];
 
 const Demo = () => {
-  const container = useRef();
+  const container = useRef(null);
   return (
     <div>
       <h2>Sticky</h2>

--- a/docs/examples/virtual-list-grid.tsx
+++ b/docs/examples/virtual-list-grid.tsx
@@ -23,7 +23,7 @@ for (let i = 0; i < 100000; i += 1) {
   });
 }
 const Demo = () => {
-  const gridRef = React.useRef<any>();
+  const gridRef = React.useRef<any>(null);
   const [connectObject] = React.useState<any>(() => {
     const obj = {};
     Object.defineProperty(obj, 'scrollLeft', {

--- a/docs/examples/virtual-list.tsx
+++ b/docs/examples/virtual-list.tsx
@@ -33,13 +33,10 @@ const Cell = ({ columnIndex, rowIndex, style }) => (
 );
 
 const Demo = () => {
-  const gridRef = React.useRef<any>();
+  const gridRef = React.useRef<any>(null);
 
   React.useEffect(() => {
-    gridRef.current.resetAfterIndices({
-      columnIndex: 0,
-      shouldForceUpdate: false,
-    });
+    gridRef.current.resetAfterIndices({ columnIndex: 0, shouldForceUpdate: false });
   }, []);
 
   const renderVirtualList = (rawData: object[], { scrollbarSize }: any) => (

--- a/docs/examples/virtual.tsx
+++ b/docs/examples/virtual.tsx
@@ -189,7 +189,7 @@ const data: RecordType[] = new Array(4 * 10000).fill(null).map((_, index) => ({
 }));
 
 const Demo: React.FC = () => {
-  const tableRef = React.useRef<Reference>();
+  const tableRef = React.useRef<Reference>(null);
   return (
     <div style={{ width: 800, padding: `0 64px` }}>
       <button onClick={() => tableRef.current?.scrollTo({ top: 9999999999999 })}>

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^30.0.0",
+    "@types/node": "^24.4.0",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@types/responselike": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@rc-component/father-plugin": "^2.0.1",
     "@rc-component/np": "^1.0.3",
     "@testing-library/jest-dom": "^6.4.0",
-    "@testing-library/react": "^12.1.5",
+    "@testing-library/react": "^16.3.0",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",

--- a/package.json
+++ b/package.json
@@ -48,15 +48,11 @@
     "now-build": "npm run docs:build",
     "prepare": "husky"
   },
-  "peerDependencies": {
-    "react": ">=16.9.0",
-    "react-dom": ">=16.9.0"
-  },
   "dependencies": {
     "@rc-component/context": "^1.4.0",
+    "@rc-component/resize-observer": "^1.0.0",
     "@rc-component/util": "^1.1.0",
     "classnames": "^2.2.5",
-    "@rc-component/resize-observer": "^1.0.0",
     "rc-virtual-list": "^3.14.2"
   },
   "devDependencies": {
@@ -65,8 +61,8 @@
     "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/react": "^12.1.5",
     "@types/jest": "^30.0.0",
-    "@types/react": "^18.0.28",
-    "@types/react-dom": "^19.0.4",
+    "@types/react": "^19.1.13",
+    "@types/react-dom": "^19.1.9",
     "@types/responselike": "^1.0.0",
     "@types/styled-components": "^5.1.32",
     "@umijs/fabric": "^4.0.1",
@@ -88,10 +84,10 @@
     "rc-dropdown": "~4.0.1",
     "rc-menu": "~9.16.1",
     "rc-tooltip": "^6.2.0",
-    "react": "^16.0.0",
+    "react": "^19.1.1",
     "react-dnd": "^2.5.4",
     "react-dnd-html5-backend": "^2.5.4",
-    "react-dom": "^16.0.0",
+    "react-dom": "^19.1.1",
     "react-resizable": "^3.0.5",
     "react-virtualized": "^9.12.0",
     "react-window": "^1.8.5",
@@ -99,6 +95,10 @@
     "styled-components": "^6.1.1",
     "typescript": "~5.9.2",
     "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   },
   "lint-staged": {
     "**/*.{js,jsx,tsx,ts,md,json}": [

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@rc-component/father-plugin": "^2.0.1",
     "@rc-component/np": "^1.0.3",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^30.0.0",

--- a/script/update-content.js
+++ b/script/update-content.js
@@ -18,12 +18,12 @@ paths.forEach(path => {
 <code src="../examples/${name}.tsx">
 `,
     'utf8',
-    function(error) {
-      if(error){
+    function (error) {
+      if (error) {
         console.log(error);
         return false;
       }
       console.log(`${name} 更新成功~`);
-    }
-  )
+    },
+  );
 });

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -6,6 +6,7 @@ import devRenderTimes from '../hooks/useRenderTimes';
 import useRowInfo from '../hooks/useRowInfo';
 import type { ColumnType, CustomizeComponent } from '../interface';
 import ExpandedRow from './ExpandedRow';
+import type { ExpandedRowProps } from './ExpandedRow';
 import { computedExpandedClassName } from '../utils/expandUtil';
 import type { TableProps } from '..';
 
@@ -224,7 +225,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
   );
 
   // ======================== Expand Row =========================
-  let expandRowNode: React.ReactElement;
+  let expandRowNode: React.ReactElement<ExpandedRowProps>;
   if (rowSupportExpand && (expandedRef.current || expanded)) {
     const expandContent = expandedRowRender(record, index, indent + 1, expanded);
 

--- a/src/Body/BodyRow.tsx
+++ b/src/Body/BodyRow.tsx
@@ -116,9 +116,9 @@ export function getCellProps<RecordType>(
 // ==================================================================================
 // ==                                 getCellProps                                 ==
 // ==================================================================================
-function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
+const BodyRow = <RecordType extends { children?: readonly RecordType[] }>(
   props: BodyRowProps<RecordType>,
-) {
+) => {
   if (process.env.NODE_ENV !== 'production') {
     devRenderTimes(props);
   }
@@ -255,7 +255,7 @@ function BodyRow<RecordType extends { children?: readonly RecordType[] }>(
       {expandRowNode}
     </>
   );
-}
+};
 
 if (process.env.NODE_ENV !== 'production') {
   BodyRow.displayName = 'BodyRow';

--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -59,12 +59,7 @@ function ExpandedRow(props: ExpandedRowProps) {
   }
 
   return (
-    <Component
-      className={className}
-      style={{
-        display: expanded ? null : 'none',
-      }}
-    >
+    <Component className={className} style={{ display: expanded ? null : 'none' }}>
       <Cell component={cellComponent} prefixCls={prefixCls} colSpan={colSpan}>
         {contentNode}
       </Cell>

--- a/src/Body/ExpandedRow.tsx
+++ b/src/Body/ExpandedRow.tsx
@@ -17,7 +17,7 @@ export interface ExpandedRowProps {
   stickyOffset?: number;
 }
 
-function ExpandedRow(props: ExpandedRowProps) {
+const ExpandedRow: React.FC<ExpandedRowProps> = props => {
   if (process.env.NODE_ENV !== 'production') {
     devRenderTimes(props);
   }
@@ -65,6 +65,6 @@ function ExpandedRow(props: ExpandedRowProps) {
       </Cell>
     </Component>
   );
-}
+};
 
 export default ExpandedRow;

--- a/src/Body/MeasureCell.tsx
+++ b/src/Body/MeasureCell.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
 import ResizeObserver from '@rc-component/resize-observer';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
-import type { ColumnType } from '../interface';
 
 export interface MeasureCellProps {
   columnKey: React.Key;
   onColumnResize: (key: React.Key, width: number) => void;
-  column?: ColumnType<any>;
+  title?: React.ReactNode;
 }
 
-export default function MeasureCell({ columnKey, onColumnResize, column }: MeasureCellProps) {
-  const cellRef = React.useRef<HTMLTableCellElement>();
+const MeasureCell: React.FC<MeasureCellProps> = props => {
+  const { columnKey, onColumnResize, title } = props;
+
+  const cellRef = React.useRef<HTMLTableCellElement>(null);
 
   useLayoutEffect(() => {
     if (cellRef.current) {
@@ -24,10 +25,10 @@ export default function MeasureCell({ columnKey, onColumnResize, column }: Measu
         ref={cellRef}
         style={{ paddingTop: 0, paddingBottom: 0, borderTop: 0, borderBottom: 0, height: 0 }}
       >
-        <div style={{ height: 0, overflow: 'hidden', fontWeight: 'bold' }}>
-          {column?.title || '\xa0'}
-        </div>
+        <div style={{ height: 0, overflow: 'hidden', fontWeight: 'bold' }}>{title || '\xa0'}</div>
       </td>
     </ResizeObserver>
   );
-}
+};
+
+export default MeasureCell;

--- a/src/Body/MeasureRow.tsx
+++ b/src/Body/MeasureRow.tsx
@@ -13,13 +13,14 @@ export interface MeasureRowProps {
   columns: readonly ColumnType<any>[];
 }
 
-export default function MeasureRow({
+const MeasureRow: React.FC<MeasureRowProps> = ({
   prefixCls,
   columnsKey,
   onColumnResize,
   columns,
-}: MeasureRowProps) {
+}) => {
   const ref = React.useRef<HTMLTableRowElement>(null);
+
   const { measureRowRender } = useContext(TableContext, ['measureRowRender']);
 
   const measureRow = (
@@ -40,7 +41,7 @@ export default function MeasureRow({
               key={columnKey}
               columnKey={columnKey}
               onColumnResize={onColumnResize}
-              column={column}
+              title={column?.title}
             />
           );
         })}
@@ -48,5 +49,7 @@ export default function MeasureRow({
     </tr>
   );
 
-  return measureRowRender ? measureRowRender(measureRow) : measureRow;
-}
+  return typeof measureRowRender === 'function' ? measureRowRender(measureRow) : measureRow;
+};
+
+export default MeasureRow;

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -16,7 +16,7 @@ export interface BodyProps<RecordType> {
   measureColumnWidth: boolean;
 }
 
-function Body<RecordType>(props: BodyProps<RecordType>) {
+const Body = <RecordType,>(props: BodyProps<RecordType>) => {
   if (process.env.NODE_ENV !== 'production') {
     devRenderTimes(props);
   }
@@ -135,8 +135,8 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
   return (
     <PerfContext.Provider value={perfRef.current}>
       <WrapperComponent
-        className={cls(`${prefixCls}-tbody`, bodyCls.wrapper)}
         style={bodyStyles.wrapper}
+        className={cls(`${prefixCls}-tbody`, bodyCls.wrapper)}
       >
         {/* Measure body column width with additional hidden col */}
         {measureColumnWidth && (
@@ -151,7 +151,7 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
       </WrapperComponent>
     </PerfContext.Provider>
   );
-}
+};
 
 if (process.env.NODE_ENV !== 'production') {
   Body.displayName = 'Body';

--- a/src/Body/index.tsx
+++ b/src/Body/index.tsx
@@ -64,9 +64,7 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
   const rowKeys = React.useMemo(() => flattenData.map(item => item.rowKey), [flattenData]);
 
   // =================== Performance ====================
-  const perfRef = React.useRef<PerfRecord>({
-    renderWithProps: false,
-  });
+  const perfRef = React.useRef<PerfRecord>({ renderWithProps: false });
 
   // ===================== Expanded =====================
   // `expandedRowOffset` data is same for all the rows.
@@ -149,7 +147,6 @@ function Body<RecordType>(props: BodyProps<RecordType>) {
             columns={flattenColumns}
           />
         )}
-
         {rows}
       </WrapperComponent>
     </PerfContext.Provider>

--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -68,7 +68,10 @@ const getTitleFromCellRenderChildren = ({
   if (ellipsisConfig && (ellipsisConfig.showTitle || rowType === 'header')) {
     if (typeof children === 'string' || typeof children === 'number') {
       title = children.toString();
-    } else if (React.isValidElement(children) && typeof children.props.children === 'string') {
+    } else if (
+      React.isValidElement<React.PropsWithChildren<any>>(children) &&
+      typeof children.props.children === 'string'
+    ) {
       title = children.props.children;
     }
   }
@@ -247,7 +250,7 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
 
   // The order is important since user can overwrite style.
   // For example ant-design/ant-design#51763
-  const mergedStyle = {
+  const mergedStyle: React.CSSProperties = {
     ...legacyCellProps?.style,
     ...fixedStyle,
     ...alignStyle,

--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -78,7 +78,7 @@ const getTitleFromCellRenderChildren = ({
   return title;
 };
 
-function Cell<RecordType>(props: CellProps<RecordType>) {
+const Cell = <RecordType,>(props: CellProps<RecordType>) => {
   if (process.env.NODE_ENV !== 'production') {
     devRenderTimes(props);
   }
@@ -294,6 +294,6 @@ function Cell<RecordType>(props: CellProps<RecordType>) {
       {mergedChildNode}
     </Component>
   );
-}
+};
 
 export default React.memo(Cell) as typeof Cell;

--- a/src/Cell/index.tsx
+++ b/src/Cell/index.tsx
@@ -69,10 +69,10 @@ const getTitleFromCellRenderChildren = ({
     if (typeof children === 'string' || typeof children === 'number') {
       title = children.toString();
     } else if (
-      React.isValidElement<React.PropsWithChildren<any>>(children) &&
-      typeof children.props.children === 'string'
+      React.isValidElement<any>(children) &&
+      typeof (children.props as any)?.children === 'string'
     ) {
-      title = children.props.children;
+      title = (children.props as any)?.children;
     }
   }
   return title;

--- a/src/ColGroup.tsx
+++ b/src/ColGroup.tsx
@@ -10,7 +10,9 @@ export interface ColGroupProps<RecordType> {
   columCount?: number;
 }
 
-function ColGroup<RecordType>({ colWidths, columns, columCount }: ColGroupProps<RecordType>) {
+const ColGroup = <RecordType,>(props: ColGroupProps<RecordType>) => {
+  const { colWidths, columns, columCount } = props;
+
   const { tableLayout } = useContext(TableContext, ['tableLayout']);
 
   const cols: React.ReactElement<any>[] = [];
@@ -41,6 +43,6 @@ function ColGroup<RecordType>({ colWidths, columns, columCount }: ColGroupProps<
   }
 
   return cols.length > 0 ? <colgroup>{cols}</colgroup> : null;
-}
+};
 
 export default ColGroup;

--- a/src/ColGroup.tsx
+++ b/src/ColGroup.tsx
@@ -13,7 +13,7 @@ export interface ColGroupProps<RecordType> {
 function ColGroup<RecordType>({ colWidths, columns, columCount }: ColGroupProps<RecordType>) {
   const { tableLayout } = useContext(TableContext, ['tableLayout']);
 
-  const cols: React.ReactElement[] = [];
+  const cols: React.ReactElement<any>[] = [];
   const len = columCount || columns.length;
 
   // Only insert col with width & additional props

--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -75,6 +75,7 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
     'isSticky',
     'getComponent',
   ]);
+
   const TableComponent = getComponent(['header', 'table'], 'table');
 
   const combinationScrollBarSize = isSticky && !fixHeader ? 0 : scrollbarSize;

--- a/src/Footer/Cell.tsx
+++ b/src/Footer/Cell.tsx
@@ -8,21 +8,14 @@ import SummaryContext from './SummaryContext';
 
 export interface SummaryCellProps {
   className?: string;
-  children?: React.ReactNode;
   index: number;
   colSpan?: number;
   rowSpan?: number;
   align?: AlignType;
 }
 
-export default function SummaryCell({
-  className,
-  index,
-  children,
-  colSpan = 1,
-  rowSpan,
-  align,
-}: SummaryCellProps) {
+const SummaryCell: React.FC<React.PropsWithChildren<SummaryCellProps>> = props => {
+  const { className, index, children, colSpan = 1, rowSpan, align } = props;
   const { prefixCls } = useContext(TableContext, ['prefixCls']);
   const { scrollColumnIndex, stickyOffsets, flattenColumns } = React.useContext(SummaryContext);
   const lastIndex = index + colSpan - 1;
@@ -48,4 +41,6 @@ export default function SummaryCell({
       {...fixedInfo}
     />
   );
-}
+};
+
+export default SummaryCell;

--- a/src/Footer/Row.tsx
+++ b/src/Footer/Row.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 
-export interface FooterRowProps extends React.HTMLAttributes<HTMLTableRowElement> {
+export interface FooterRowProps {
   className?: string;
   style?: React.CSSProperties;
+  onClick?: React.MouseEventHandler<HTMLTableRowElement>;
 }
 
 const FooterRow: React.FC<React.PropsWithChildren<FooterRowProps>> = props => {

--- a/src/Footer/Row.tsx
+++ b/src/Footer/Row.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 
-export interface FooterRowProps {
+export interface FooterRowProps extends React.HTMLAttributes<HTMLTableRowElement> {
   className?: string;
   style?: React.CSSProperties;
-  onClick?: (e?: React.MouseEvent<HTMLElement>) => void;
 }
 
 const FooterRow: React.FC<React.PropsWithChildren<FooterRowProps>> = props => {

--- a/src/Footer/Row.tsx
+++ b/src/Footer/Row.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 
 export interface FooterRowProps {
-  children?: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
   onClick?: (e?: React.MouseEvent<HTMLElement>) => void;
 }
 
-export default function FooterRow({ children, ...props }: FooterRowProps) {
-  return <tr {...props}>{children}</tr>;
-}
+const FooterRow: React.FC<React.PropsWithChildren<FooterRowProps>> = props => {
+  const { children, ...restProps } = props;
+  return <tr {...restProps}>{children}</tr>;
+};
+
+export default FooterRow;

--- a/src/Footer/Summary.tsx
+++ b/src/Footer/Summary.tsx
@@ -9,11 +9,15 @@ export interface SummaryProps {
 /**
  * Syntactic sugar. Do not support HOC.
  */
-const Summary: React.FC<React.PropsWithChildren<SummaryProps>> = ({ children }) => {
-  return children as React.ReactElement<any>;
+const Summary: React.FC<React.PropsWithChildren<SummaryProps>> & {
+  Row: typeof Row;
+  Cell: typeof Cell;
+} = props => {
+  const { children } = props;
+  return children;
 };
 
-(Summary as any).Row = Row;
-(Summary as any).Cell = Cell;
+Summary.Row = Row;
+Summary.Cell = Cell;
 
 export default Summary;

--- a/src/Footer/Summary.tsx
+++ b/src/Footer/Summary.tsx
@@ -4,17 +4,16 @@ import Row from './Row';
 
 export interface SummaryProps {
   fixed?: boolean | 'top' | 'bottom';
-  children?: React.ReactNode;
 }
 
 /**
  * Syntactic sugar. Do not support HOC.
  */
-function Summary({ children }: SummaryProps) {
-  return children as React.ReactElement;
-}
+const Summary: React.FC<React.PropsWithChildren<SummaryProps>> = ({ children }) => {
+  return children as React.ReactElement<any>;
+};
 
-Summary.Row = Row;
-Summary.Cell = Cell;
+(Summary as any).Row = Row;
+(Summary as any).Cell = Cell;
 
 export default Summary;

--- a/src/Footer/index.tsx
+++ b/src/Footer/index.tsx
@@ -14,7 +14,7 @@ export interface FooterProps<RecordType> {
   flattenColumns: FlattenColumns<RecordType>;
 }
 
-function Footer<RecordType>(props: FooterProps<RecordType>) {
+const Footer = <RecordType,>(props: FooterProps<RecordType>) => {
   if (process.env.NODE_ENV !== 'production') {
     devRenderTimes(props);
   }
@@ -40,7 +40,7 @@ function Footer<RecordType>(props: FooterProps<RecordType>) {
       <tfoot className={`${prefixCls}-summary`}>{children}</tfoot>
     </SummaryContext.Provider>
   );
-}
+};
 
 export default responseImmutable(Footer);
 

--- a/src/Panel/index.tsx
+++ b/src/Panel/index.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
-export interface TitleProps {
-  className: string;
-  children: React.ReactNode;
-  style: React.CSSProperties;
+export interface TitleProps extends React.HTMLAttributes<HTMLDivElement> {
+  className?: string;
+  style?: React.CSSProperties;
 }
 
-function Panel({ className, style, children }: TitleProps) {
-  return <div className={className} style={style}>{children}</div>;
-}
+const Panel: React.FC<React.PropsWithChildren<TitleProps>> = props => {
+  const { children, ...restProps } = props;
+  return <div {...restProps}>{children}</div>;
+};
 
 export default Panel;

--- a/src/Panel/index.tsx
+++ b/src/Panel/index.tsx
@@ -1,13 +1,17 @@
 import * as React from 'react';
 
-export interface TitleProps extends React.HTMLAttributes<HTMLDivElement> {
-  className?: string;
-  style?: React.CSSProperties;
+export interface TitleProps {
+  className: string;
+  style: React.CSSProperties;
 }
 
 const Panel: React.FC<React.PropsWithChildren<TitleProps>> = props => {
-  const { children, ...restProps } = props;
-  return <div {...restProps}>{children}</div>;
+  const { children, className, style } = props;
+  return (
+    <div className={className} style={style}>
+      {children}
+    </div>
+  );
 };
 
 export default Panel;

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -333,18 +333,15 @@ function Table<RecordType extends DefaultRecordType>(
   const mergedScrollX = flattenScrollX ?? scrollX;
 
   const columnContext = React.useMemo(
-    () => ({
-      columns,
-      flattenColumns,
-    }),
+    () => ({ columns, flattenColumns }),
     [columns, flattenColumns],
   );
 
   // ======================= Refs =======================
-  const fullTableRef = React.useRef<HTMLDivElement>();
-  const scrollHeaderRef = React.useRef<HTMLDivElement>();
-  const scrollBodyRef = React.useRef<HTMLDivElement>();
-  const scrollBodyContainerRef = React.useRef<HTMLDivElement>();
+  const fullTableRef = React.useRef<HTMLDivElement>(null);
+  const scrollHeaderRef = React.useRef<HTMLDivElement>(null);
+  const scrollBodyRef = React.useRef<HTMLDivElement>(null);
+  const scrollBodyContainerRef = React.useRef<HTMLDivElement>(null);
 
   React.useImperativeHandle(ref, () => {
     return {
@@ -382,7 +379,7 @@ function Table<RecordType extends DefaultRecordType>(
   });
 
   // ====================== Scroll ======================
-  const scrollSummaryRef = React.useRef<HTMLDivElement>();
+  const scrollSummaryRef = React.useRef<HTMLDivElement>(null);
   const [shadowStart, setShadowStart] = React.useState(false);
   const [shadowEnd, setShadowEnd] = React.useState(false);
   const [colsWidths, updateColsWidths] = React.useState(new Map<React.Key, number>());
@@ -400,7 +397,8 @@ function Table<RecordType extends DefaultRecordType>(
   const stickyRef = React.useRef<{
     setScrollLeft: (left: number) => void;
     checkScrollBarVisible: () => void;
-  }>();
+  }>(null);
+
   const { isSticky, offsetHeader, offsetSummary, offsetScroll, stickyClassName, container } =
     useSticky(sticky, prefixCls);
 
@@ -636,7 +634,7 @@ function Table<RecordType extends DefaultRecordType>(
   };
 
   // Empty
-  const emptyNode: React.ReactNode = React.useMemo(() => {
+  const emptyNode = React.useMemo<React.ReactNode>(() => {
     if (hasData) {
       return null;
     }
@@ -985,7 +983,7 @@ function Table<RecordType extends DefaultRecordType>(
 
 export type ForwardGenericTable = (<RecordType extends DefaultRecordType = any>(
   props: TableProps<RecordType> & React.RefAttributes<Reference>,
-) => React.ReactElement) & { displayName?: string };
+) => React.ReactElement<any>) & { displayName?: string };
 
 const RefTable = React.forwardRef(Table) as ForwardGenericTable;
 

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -191,10 +191,10 @@ function defaultEmpty() {
   return 'No Data';
 }
 
-function Table<RecordType extends DefaultRecordType>(
+const Table = <RecordType extends DefaultRecordType>(
   tableProps: TableProps<RecordType>,
   ref: React.Ref<Reference>,
-) {
+) => {
   const props = {
     rowKey: 'key',
     prefixCls: DEFAULT_PREFIX,
@@ -927,6 +927,8 @@ function Table<RecordType extends DefaultRecordType>(
       // Scroll
       mergedScrollX,
       scrollInfo,
+      classNames,
+      styles,
 
       // Table
       prefixCls,
@@ -979,7 +981,7 @@ function Table<RecordType extends DefaultRecordType>(
   );
 
   return <TableContext.Provider value={TableContextValue}>{fullTable}</TableContext.Provider>;
-}
+};
 
 export type ForwardGenericTable = (<RecordType extends DefaultRecordType = any>(
   props: TableProps<RecordType> & React.RefAttributes<Reference>,
@@ -991,11 +993,12 @@ if (process.env.NODE_ENV !== 'production') {
   RefTable.displayName = 'Table';
 }
 
-export function genTable(shouldTriggerRender?: CompareProps<typeof Table>) {
+export function genTable(shouldTriggerRender?: CompareProps<ForwardGenericTable>) {
   return makeImmutable(RefTable, shouldTriggerRender) as ForwardGenericTable;
 }
 
 const ImmutableTable = genTable();
+
 type ImmutableTableType = typeof ImmutableTable & {
   EXPAND_COLUMN: typeof EXPAND_COLUMN;
   INTERNAL_HOOKS: typeof INTERNAL_HOOKS;

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -993,9 +993,9 @@ if (process.env.NODE_ENV !== 'production') {
   RefTable.displayName = 'Table';
 }
 
-export function genTable(shouldTriggerRender?: CompareProps<ForwardGenericTable>) {
-  return makeImmutable(RefTable, shouldTriggerRender) as ForwardGenericTable;
-}
+export const genTable = (shouldTriggerRender?: CompareProps<ForwardGenericTable>) => {
+  return makeImmutable(RefTable, shouldTriggerRender);
+};
 
 const ImmutableTable = genTable();
 

--- a/src/VirtualTable/BodyGrid.tsx
+++ b/src/VirtualTable/BodyGrid.tsx
@@ -40,6 +40,7 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
     'scrollX',
     'direction',
   ]);
+
   const {
     sticky,
     scrollY,
@@ -49,7 +50,7 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
   } = useContext(StaticContext);
 
   // =========================== Ref ============================
-  const listRef = React.useRef<ListRef>();
+  const listRef = React.useRef<ListRef>(null);
 
   // =========================== Data ===========================
   const flattenData = useFlattenRecords(data, childrenColumnName, expandedKeys, getRowKey);
@@ -188,7 +189,7 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
     }
 
     // Patch extra line on the page
-    const nodes: React.ReactElement[] = spanLines.map(index => {
+    const nodes = spanLines.map<React.ReactElement<any>>(index => {
       const item = flattenData[index];
 
       const rowKey = getRowKey(item.record, index);

--- a/src/VirtualTable/BodyGrid.tsx
+++ b/src/VirtualTable/BodyGrid.tsx
@@ -84,11 +84,7 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
 
         // If offset is provided, force align to 'top' for consistent behavior
         if (offset) {
-          listRef.current?.scrollTo({
-            ...restConfig,
-            offset,
-            align: 'top',
-          });
+          listRef.current?.scrollTo({ ...restConfig, offset, align: 'top' });
         } else {
           listRef.current?.scrollTo(config);
         }

--- a/src/VirtualTable/BodyLine.tsx
+++ b/src/VirtualTable/BodyLine.tsx
@@ -39,7 +39,7 @@ const BodyLine = React.forwardRef<HTMLDivElement, BodyLineProps>((props, ref) =>
   // ========================== Expand ==========================
   const { rowSupportExpand, expanded, rowProps, expandedRowRender, expandedRowClassName } = rowInfo;
 
-  let expandRowNode: React.ReactElement;
+  let expandRowNode: React.ReactElement<any>;
   if (rowSupportExpand && expanded) {
     const expandContent = expandedRowRender(record, index, indent + 1, expanded);
 

--- a/src/VirtualTable/VirtualCell.tsx
+++ b/src/VirtualTable/VirtualCell.tsx
@@ -36,7 +36,7 @@ export function getColumnWidth(colIndex: number, colSpan: number, columnsOffset:
   return columnsOffset[colIndex + mergedColSpan] - (columnsOffset[colIndex] || 0);
 }
 
-function VirtualCell<RecordType = any>(props: VirtualCellProps<RecordType>) {
+const VirtualCell = <RecordType,>(props: VirtualCellProps<RecordType>) => {
   const {
     rowInfo,
     column,
@@ -135,6 +135,6 @@ function VirtualCell<RecordType = any>(props: VirtualCellProps<RecordType>) {
       }}
     />
   );
-}
+};
 
 export default VirtualCell;

--- a/src/VirtualTable/index.tsx
+++ b/src/VirtualTable/index.tsx
@@ -16,8 +16,8 @@ const renderBody: CustomizeScrollBody<any> = (rawData, props) => {
 };
 
 export interface VirtualTableProps<RecordType> extends Omit<TableProps<RecordType>, 'scroll'> {
-  scroll: { x?: number; y: number };
   listItemHeight?: number;
+  scroll: { x?: number; y?: number };
 }
 
 const VirtualTable = <RecordType,>(

--- a/src/VirtualTable/index.tsx
+++ b/src/VirtualTable/index.tsx
@@ -96,7 +96,7 @@ function VirtualTable<RecordType>(props: VirtualTableProps<RecordType>, ref: Rea
 
 export type ForwardGenericVirtualTable = (<RecordType>(
   props: TableProps<RecordType> & React.RefAttributes<Reference>,
-) => React.ReactElement) & { displayName?: string };
+) => React.ReactElement<any>) & { displayName?: string };
 
 const RefVirtualTable = React.forwardRef(VirtualTable) as ForwardGenericVirtualTable;
 

--- a/src/VirtualTable/index.tsx
+++ b/src/VirtualTable/index.tsx
@@ -12,19 +12,18 @@ import getValue from '@rc-component/util/lib/utils/get';
 
 const renderBody: CustomizeScrollBody<any> = (rawData, props) => {
   const { ref, onScroll } = props;
-
   return <Grid ref={ref as any} data={rawData as any} onScroll={onScroll} />;
 };
 
 export interface VirtualTableProps<RecordType> extends Omit<TableProps<RecordType>, 'scroll'> {
-  scroll: {
-    x?: number;
-    y: number;
-  };
+  scroll: { x?: number; y: number };
   listItemHeight?: number;
 }
 
-function VirtualTable<RecordType>(props: VirtualTableProps<RecordType>, ref: React.Ref<Reference>) {
+const VirtualTable = <RecordType,>(
+  props: VirtualTableProps<RecordType>,
+  ref: React.Ref<Reference>,
+) => {
   const {
     data,
     columns,
@@ -92,7 +91,7 @@ function VirtualTable<RecordType>(props: VirtualTableProps<RecordType>, ref: Rea
       />
     </StaticContext.Provider>
   );
-}
+};
 
 export type ForwardGenericVirtualTable = (<RecordType>(
   props: TableProps<RecordType> & React.RefAttributes<Reference>,
@@ -104,8 +103,8 @@ if (process.env.NODE_ENV !== 'production') {
   RefVirtualTable.displayName = 'VirtualTable';
 }
 
-export function genVirtualTable(shouldTriggerRender?: CompareProps<typeof Table>) {
-  return makeImmutable(RefVirtualTable, shouldTriggerRender) as ForwardGenericVirtualTable;
-}
+export const genVirtualTable = (shouldTriggerRender?: CompareProps<ForwardGenericVirtualTable>) => {
+  return makeImmutable(RefVirtualTable, shouldTriggerRender);
+};
 
 export default genVirtualTable();

--- a/src/hooks/useColumns/index.tsx
+++ b/src/hooks/useColumns/index.tsx
@@ -20,8 +20,9 @@ export function convertChildrenToColumns<RecordType>(
   children: React.ReactNode,
 ): ColumnsType<RecordType> {
   return toArray(children)
-    .filter(node => React.isValidElement<React.PropsWithChildren<any>>(node))
-    .map(({ key, props }) => {
+    .filter(node => React.isValidElement<any>(node))
+    .map(node => {
+      const { key, props } = node as React.ReactElement<any>;
       const { children: nodeChildren, ...restProps } = props;
       const column = {
         key,

--- a/src/hooks/useColumns/index.tsx
+++ b/src/hooks/useColumns/index.tsx
@@ -20,8 +20,8 @@ export function convertChildrenToColumns<RecordType>(
   children: React.ReactNode,
 ): ColumnsType<RecordType> {
   return toArray(children)
-    .filter(node => React.isValidElement(node))
-    .map(({ key, props }: React.ReactElement) => {
+    .filter(node => React.isValidElement<React.PropsWithChildren<any>>(node))
+    .map(({ key, props }) => {
       const { children: nodeChildren, ...restProps } = props;
       const column = {
         key,

--- a/src/hooks/useFlattenRecords.ts
+++ b/src/hooks/useFlattenRecords.ts
@@ -62,7 +62,7 @@ export default function useFlattenRecords<T>(
   expandedKeys: Set<Key>,
   getRowKey: GetRowKey<T>,
 ): FlattenData<T>[] {
-  const arr: FlattenData<T>[] = React.useMemo(() => {
+  const arr = React.useMemo<FlattenData<T>[]>(() => {
     if (expandedKeys?.size) {
       const list: FlattenData<T>[] = [];
 

--- a/src/hooks/useFrame.ts
+++ b/src/hooks/useFrame.ts
@@ -50,19 +50,21 @@ export function useLayoutState<State>(
 }
 
 /** Lock frame, when frame pass reset the lock. */
-export function useTimeoutLock<State>(defaultState?: State): [(state: State) => void, () => State | null] {
+export function useTimeoutLock<State>(
+  defaultState?: State,
+): [(state: State) => void, () => State | null] {
   const frameRef = useRef<State | null>(defaultState || null);
-  const timeoutRef = useRef<number>();
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   function cleanUp() {
-    window.clearTimeout(timeoutRef.current);
+    clearTimeout(timeoutRef.current);
   }
 
   function setState(newState: State) {
     frameRef.current = newState;
     cleanUp();
 
-    timeoutRef.current = window.setTimeout(() => {
+    timeoutRef.current = setTimeout(() => {
       frameRef.current = null;
       timeoutRef.current = undefined;
     }, 100);

--- a/src/hooks/useStickyOffsets.ts
+++ b/src/hooks/useStickyOffsets.ts
@@ -8,7 +8,7 @@ function useStickyOffsets<RecordType>(
   colWidths: number[],
   flattenColumns: readonly ColumnType<RecordType>[],
 ) {
-  const stickyOffsets: StickyOffsets = useMemo(() => {
+  const stickyOffsets = useMemo<StickyOffsets>(() => {
     const columnCount = flattenColumns.length;
 
     const getOffsets = (startIndex: number, endIndex: number, offset: number) => {

--- a/src/stickyScrollBar.tsx
+++ b/src/stickyScrollBar.tsx
@@ -30,7 +30,7 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
   const bodyWidth = scrollBodyRef.current?.clientWidth || 0;
   const scrollBarWidth = bodyScrollWidth && bodyWidth * (bodyWidth / bodyScrollWidth);
 
-  const scrollBarRef = React.useRef<HTMLDivElement>();
+  const scrollBarRef = React.useRef<HTMLDivElement>(null);
   const [scrollState, setScrollState] = useLayoutState<{
     scrollLeft: number;
     isHiddenScrollBar: boolean;
@@ -38,13 +38,7 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
     scrollLeft: 0,
     isHiddenScrollBar: true,
   });
-  const refState = React.useRef<{
-    delta: number;
-    x: number;
-  }>({
-    delta: 0,
-    x: 0,
-  });
+  const refState = React.useRef<{ delta: number; x: number }>({ delta: 0, x: 0 });
   const [isActive, setActive] = React.useState(false);
   const rafRef = React.useRef<number | null>(null);
 

--- a/src/stickyScrollBar.tsx
+++ b/src/stickyScrollBar.tsx
@@ -22,9 +22,10 @@ interface StickyScrollBarProps {
 }
 
 const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarProps> = (
-  { scrollBodyRef, onScroll, offsetScroll, container, direction },
+  props,
   ref,
 ) => {
+  const { scrollBodyRef, onScroll, offsetScroll, container, direction } = props;
   const prefixCls = useContext(TableContext, 'prefixCls');
   const bodyScrollWidth = scrollBodyRef.current?.scrollWidth || 0;
   const bodyWidth = scrollBodyRef.current?.clientWidth || 0;
@@ -34,10 +35,7 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
   const [scrollState, setScrollState] = useLayoutState<{
     scrollLeft: number;
     isHiddenScrollBar: boolean;
-  }>({
-    scrollLeft: 0,
-    isHiddenScrollBar: true,
-  });
+  }>({ scrollLeft: 0, isHiddenScrollBar: true });
   const refState = React.useRef<{ delta: number; x: number }>({ delta: 0, x: 0 });
   const [isActive, setActive] = React.useState(false);
   const rafRef = React.useRef<number | null>(null);
@@ -146,7 +144,9 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
 
   // Loop for scroll event check
   React.useEffect(() => {
-    if (!scrollBodyRef.current) return;
+    if (!scrollBodyRef.current) {
+      return;
+    }
 
     const scrollParents: (HTMLElement | SVGElement)[] = [];
     let parent = getDOM(scrollBodyRef.current);

--- a/src/stickyScrollBar.tsx
+++ b/src/stickyScrollBar.tsx
@@ -144,28 +144,28 @@ const StickyScrollBar: React.ForwardRefRenderFunction<unknown, StickyScrollBarPr
 
   // Loop for scroll event check
   React.useEffect(() => {
-    if (!scrollBodyRef.current) {
-      return;
+    if (scrollBodyRef.current) {
+      const scrollParents: (HTMLElement | SVGElement)[] = [];
+      let parent = getDOM(scrollBodyRef.current);
+      while (parent) {
+        scrollParents.push(parent);
+        parent = parent.parentElement;
+      }
+      scrollParents.forEach(p => {
+        p.addEventListener(SCROLL_EVENT, checkScrollBarVisible, false);
+      });
+      window.addEventListener(RESIZE_EVENT, checkScrollBarVisible, false);
+      window.addEventListener(SCROLL_EVENT, checkScrollBarVisible, false);
+      container.addEventListener(SCROLL_EVENT, checkScrollBarVisible, false);
+      return () => {
+        scrollParents.forEach(p => {
+          p.removeEventListener(SCROLL_EVENT, checkScrollBarVisible);
+        });
+        window.removeEventListener(RESIZE_EVENT, checkScrollBarVisible);
+        window.removeEventListener(SCROLL_EVENT, checkScrollBarVisible);
+        container.removeEventListener(SCROLL_EVENT, checkScrollBarVisible);
+      };
     }
-
-    const scrollParents: (HTMLElement | SVGElement)[] = [];
-    let parent = getDOM(scrollBodyRef.current);
-    while (parent) {
-      scrollParents.push(parent);
-      parent = parent.parentElement;
-    }
-
-    scrollParents.forEach(p => p.addEventListener(SCROLL_EVENT, checkScrollBarVisible, false));
-    window.addEventListener(RESIZE_EVENT, checkScrollBarVisible, false);
-    window.addEventListener(SCROLL_EVENT, checkScrollBarVisible, false);
-    container.addEventListener(SCROLL_EVENT, checkScrollBarVisible, false);
-
-    return () => {
-      scrollParents.forEach(p => p.removeEventListener(SCROLL_EVENT, checkScrollBarVisible));
-      window.removeEventListener(RESIZE_EVENT, checkScrollBarVisible);
-      window.removeEventListener(SCROLL_EVENT, checkScrollBarVisible);
-      container.removeEventListener(SCROLL_EVENT, checkScrollBarVisible);
-    };
   }, [container]);
 
   React.useEffect(() => {

--- a/tests/Table.spec.jsx
+++ b/tests/Table.spec.jsx
@@ -1234,7 +1234,7 @@ describe('Table.Basic', () => {
       return record;
     });
     const Demo = props => {
-      const gridRef = React.useRef();
+      const gridRef = React.useRef(null);
       const [connectObject] = React.useState(() => {
         const obj = {};
         Object.defineProperty(obj, 'scrollLeft', {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 无

* **重构**
  * 大范围类型与组件声明调整（函数改为 const 箭头、React.FC/PropsWithChildren、refs 初始值改为 null），部分导出签名与组件类型表面发生变化（含 Table/VirtualTable/genTable 等），且将 scroll.y 由必需改为可选。

* **文档**
  * 示例调整与 ESLint 指令移除，示例回调参数用法有小变更。

* **测试**
  * 测试中 ref 初始化改为 null（无行为变化）。

* **杂务**
  * 依赖升级：迁移至 React 19 系列并更新相关类型与测试库，移除重复依赖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->