### PR TITLE
fix: should pass colGroup

### DIFF
--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -40,6 +40,7 @@ export interface FixedHeaderProps<RecordType> extends HeaderProps<RecordType> {
   tableLayout?: TableLayout;
   onScroll: (info: { currentTarget: HTMLDivElement; scrollLeft?: number }) => void;
   children: (info: HeaderProps<RecordType>) => React.ReactNode;
+  colGroup?: React.ReactNode;
 }
 
 const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((props, ref) => {
@@ -54,6 +55,7 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
     columns,
     flattenColumns,
     colWidths,
+    colGroup,
     columCount,
     stickyOffsets,
     direction,
@@ -185,7 +187,9 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
           width: scrollX,
         }}
       >
-        {isColGroupEmpty ? null : (
+        {isColGroupEmpty ? (
+          colGroup
+        ) : (
           <ColGroup
             colWidths={[...mergedColumnWidth, combinationScrollBarSize]}
             columCount={columCount + 1}

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -741,6 +741,7 @@ const Table = <RecordType extends DefaultRecordType>(
             stickyTopOffset={offsetHeader}
             className={`${prefixCls}-header`}
             ref={scrollHeaderRef}
+            colGroup={bodyColGroup}
           >
             {renderFixedHeaderTable}
           </FixedHolder>
@@ -756,6 +757,7 @@ const Table = <RecordType extends DefaultRecordType>(
             stickyBottomOffset={offsetSummary}
             className={`${prefixCls}-summary`}
             ref={scrollSummaryRef}
+            colGroup={bodyColGroup}
           >
             {renderFixedFooterTable}
           </FixedHolder>

--- a/tests/__snapshots__/FixedColumn.spec.tsx.snap
+++ b/tests/__snapshots__/FixedColumn.spec.tsx.snap
@@ -2696,6 +2696,26 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
       <table
         style="table-layout: fixed; min-width: 100%; width: 1200px;"
       >
+        <colgroup>
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
+          <col />
+          <col />
+          <col />
+          <col />
+          <col />
+          <col />
+          <col />
+          <col />
+          <col />
+          <col
+            style="width: 100px;"
+          />
+        </colgroup>
         <thead
           class="rc-table-thead"
         >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 支持为固定表头与汇总自定义列组，实现更灵活的列宽与结构渲染；无需改动数据源即可生效。
- Bug 修复
  - 解决表头、表体与汇总列组不一致引发的列宽与对齐偏差问题；三者现共享同一列组，含水平滚动与滚动条场景下对齐更稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->