### PR TITLE
chore: bump @rc-component/context to drop rc-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@rc-component/context": "^2.0.0",
+    "@rc-component/context": "^2.0.1",
     "@rc-component/resize-observer": "^1.0.0",
     "@rc-component/util": "^1.1.0",
     "clsx": "^2.1.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 升级依赖 “@rc-component/context” 至 ^2.0.1，带来运行时更新与修复。
  * 未引入新功能或界面调整，现有行为保持一致，无需用户额外操作；如遇兼容性问题请反馈。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->