### PR TITLE
fix: duplicate unique identifiers in MeasureRow column headers

### DIFF
--- a/src/Body/MeasureCell.tsx
+++ b/src/Body/MeasureCell.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import ResizeObserver from '@rc-component/resize-observer';
 import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { cleanMeasureRowAttributes } from '../utils/measureUtil';
 
 export interface MeasureCellProps {
   columnKey: React.Key;
@@ -12,12 +13,17 @@ const MeasureCell: React.FC<MeasureCellProps> = props => {
   const { columnKey, onColumnResize, title } = props;
 
   const cellRef = React.useRef<HTMLTableCellElement>(null);
+  const contentRef = React.useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     if (cellRef.current) {
       onColumnResize(columnKey, cellRef.current.offsetWidth);
     }
-  }, []);
+
+    if (contentRef.current) {
+      cleanMeasureRowAttributes(contentRef.current);
+    }
+  }, [title, columnKey, onColumnResize]);
 
   return (
     <ResizeObserver data={columnKey}>
@@ -25,7 +31,9 @@ const MeasureCell: React.FC<MeasureCellProps> = props => {
         ref={cellRef}
         style={{ paddingTop: 0, paddingBottom: 0, borderTop: 0, borderBottom: 0, height: 0 }}
       >
-        <div style={{ height: 0, overflow: 'hidden', fontWeight: 'bold' }}>{title || '\xa0'}</div>
+        <div ref={contentRef} style={{ height: 0, overflow: 'hidden', fontWeight: 'bold' }}>
+          {title || '\xa0'}
+        </div>
       </td>
     </ResizeObserver>
   );

--- a/src/Body/MeasureRow.tsx
+++ b/src/Body/MeasureRow.tsx
@@ -5,6 +5,7 @@ import isVisible from '@rc-component/util/lib/Dom/isVisible';
 import { useContext } from '@rc-component/context';
 import TableContext from '../context/TableContext';
 import type { ColumnType } from '../interface';
+import { prepareMeasureTitle } from '../utils/measureUtil';
 
 export interface MeasureRowProps {
   prefixCls: string;
@@ -37,9 +38,8 @@ const MeasureRow: React.FC<MeasureRowProps> = ({
         {columnsKey.map(columnKey => {
           const column = columns.find(col => col.key === columnKey);
           const rawTitle = column?.title;
-          const titleForMeasure = React.isValidElement<React.RefAttributes<any>>(rawTitle)
-            ? React.cloneElement(rawTitle, { ref: null })
-            : rawTitle;
+          const titleForMeasure = prepareMeasureTitle(rawTitle);
+
           return (
             <MeasureCell
               key={columnKey}

--- a/src/Body/MeasureRow.tsx
+++ b/src/Body/MeasureRow.tsx
@@ -5,7 +5,7 @@ import isVisible from '@rc-component/util/lib/Dom/isVisible';
 import { useContext } from '@rc-component/context';
 import TableContext from '../context/TableContext';
 import type { ColumnType } from '../interface';
-import { prepareMeasureTitle } from '../utils/measureUtil';
+import { cleanMeasureRowAttributes } from '../utils/measureUtil';
 
 export interface MeasureRowProps {
   prefixCls: string;
@@ -24,6 +24,12 @@ const MeasureRow: React.FC<MeasureRowProps> = ({
 
   const { measureRowRender } = useContext(TableContext, ['measureRowRender']);
 
+  React.useLayoutEffect(() => {
+    if (ref.current) {
+      cleanMeasureRowAttributes(ref.current);
+    }
+  }, [columnsKey, columns]);
+
   const measureRow = (
     <tr aria-hidden="true" className={`${prefixCls}-measure-row`} style={{ height: 0 }} ref={ref}>
       <ResizeObserver.Collection
@@ -38,7 +44,9 @@ const MeasureRow: React.FC<MeasureRowProps> = ({
         {columnsKey.map(columnKey => {
           const column = columns.find(col => col.key === columnKey);
           const rawTitle = column?.title;
-          const titleForMeasure = prepareMeasureTitle(rawTitle);
+          const titleForMeasure = React.isValidElement<React.RefAttributes<any>>(rawTitle)
+            ? React.cloneElement(rawTitle, { ref: null })
+            : rawTitle;
 
           return (
             <MeasureCell

--- a/src/Body/MeasureRow.tsx
+++ b/src/Body/MeasureRow.tsx
@@ -5,7 +5,6 @@ import isVisible from '@rc-component/util/lib/Dom/isVisible';
 import { useContext } from '@rc-component/context';
 import TableContext from '../context/TableContext';
 import type { ColumnType } from '../interface';
-import { cleanMeasureRowAttributes } from '../utils/measureUtil';
 
 export interface MeasureRowProps {
   prefixCls: string;
@@ -23,12 +22,6 @@ const MeasureRow: React.FC<MeasureRowProps> = ({
   const ref = React.useRef<HTMLTableRowElement>(null);
 
   const { measureRowRender } = useContext(TableContext, ['measureRowRender']);
-
-  React.useLayoutEffect(() => {
-    if (ref.current) {
-      cleanMeasureRowAttributes(ref.current);
-    }
-  }, [columnsKey, columns]);
 
   const measureRow = (
     <tr aria-hidden="true" className={`${prefixCls}-measure-row`} style={{ height: 0 }} ref={ref}>

--- a/src/utils/measureUtil.ts
+++ b/src/utils/measureUtil.ts
@@ -58,6 +58,9 @@ export function filterMeasureProps<T = any>(
     filteredProps[prop] = undefined;
   });
 
+  // Nullify ref to avoid warnings and conflicts
+  filteredProps.ref = null;
+
   // Recursively filter children if deep filtering is enabled
   if (deep && filteredProps.children) {
     filteredProps.children = filterMeasureChildren(filteredProps.children);

--- a/src/utils/measureUtil.ts
+++ b/src/utils/measureUtil.ts
@@ -1,0 +1,93 @@
+import * as React from 'react';
+
+/**
+ * Props that should be filtered out from measure row elements to avoid DOM conflicts
+ */
+const FILTERED_PROPS = [
+  // Unique identifiers that shouldn't be duplicated in DOM
+  'id',
+  'data-testid',
+  'data-test-id',
+  'data-cy', // Cypress
+  'data-qa',
+  'data-automation-id',
+  'data-id',
+  'data-key',
+
+  // Event handlers that are unnecessary in hidden measure elements
+  'onClick',
+  'onMouseEnter',
+  'onMouseLeave',
+  'onFocus',
+  'onBlur',
+  'onKeyDown',
+  'onKeyPress',
+  'onKeyUp',
+  'onDoubleClick',
+  'onContextMenu',
+
+  // Accessibility props that might reference other elements and cause conflicts
+  'aria-describedby',
+  'aria-labelledby',
+  'aria-controls',
+  'aria-owns',
+
+  // Form-related props that might conflict
+  'name',
+  'htmlFor',
+  'for',
+] as const;
+
+/**
+ * Filter props from a React element that might cause DOM conflicts in measure row
+ * @param element - The React element to filter
+ * @param deep - Whether to recursively filter nested elements
+ * @returns A new React element with filtered props
+ */
+export function filterMeasureProps<T = any>(
+  element: React.ReactElement<T>,
+  deep: boolean = true,
+): React.ReactElement<T> {
+  if (!React.isValidElement(element)) {
+    return element;
+  }
+
+  const filteredProps = { ...element.props } as any;
+
+  FILTERED_PROPS.forEach(prop => {
+    filteredProps[prop] = undefined;
+  });
+
+  // Recursively filter children if deep filtering is enabled
+  if (deep && filteredProps.children) {
+    filteredProps.children = filterMeasureChildren(filteredProps.children);
+  }
+
+  return React.cloneElement(element, filteredProps);
+}
+
+/**
+ * Recursively filter children elements
+ * @param children - React children to filter
+ * @returns Filtered children
+ */
+function filterMeasureChildren(children: React.ReactNode): React.ReactNode {
+  return React.Children.map(children, child => {
+    if (React.isValidElement(child)) {
+      return filterMeasureProps(child, true);
+    }
+    return child;
+  });
+}
+
+/**
+ * Prepare title content for use in measure row
+ * @param title - The original title content
+ * @returns Filtered title safe for measure row usage
+ */
+export function prepareMeasureTitle(title: React.ReactNode): React.ReactNode {
+  if (React.isValidElement(title)) {
+    return filterMeasureProps(title, true); // Enable deep filtering
+  }
+  return title;
+}

--- a/src/utils/measureUtil.ts
+++ b/src/utils/measureUtil.ts
@@ -1,9 +1,7 @@
-import * as React from 'react';
-
 /**
- * Props that should be filtered out from measure row elements to avoid DOM conflicts
+ * Attributes that should be removed from measure row DOM to avoid conflicts
  */
-const FILTERED_PROPS = [
+const FILTERED_ATTRIBUTES = [
   // Unique identifiers that shouldn't be duplicated in DOM
   'id',
   'data-testid',
@@ -13,84 +11,21 @@ const FILTERED_PROPS = [
   'data-automation-id',
   'data-id',
   'data-key',
-
-  // Event handlers that are unnecessary in hidden measure elements
-  'onClick',
-  'onMouseEnter',
-  'onMouseLeave',
-  'onFocus',
-  'onBlur',
-  'onKeyDown',
-  'onKeyPress',
-  'onKeyUp',
-  'onDoubleClick',
-  'onContextMenu',
-
-  // Accessibility props that might reference other elements and cause conflicts
-  'aria-describedby',
-  'aria-labelledby',
-  'aria-controls',
-  'aria-owns',
-
-  // Form-related props that might conflict
-  'name',
-  'htmlFor',
-  'for',
 ] as const;
 
 /**
- * Filter props from a React element that might cause DOM conflicts in measure row
- * @param element - The React element to filter
- * @param deep - Whether to recursively filter nested elements
- * @returns A new React element with filtered props
+ * Remove all ID and test attributes from DOM element and its descendants
+ * This ensures the measure row complies with HTML spec (no duplicate IDs)
+ * and works with custom components whose internal DOM we cannot control at React level
+ * @param element - The DOM element to clean
  */
-export function filterMeasureProps<T = any>(
-  element: React.ReactElement<T>,
-  deep: boolean = true,
-): React.ReactElement<T> {
-  if (!React.isValidElement(element)) {
-    return element;
-  }
+export function cleanMeasureRowAttributes(element: HTMLElement): void {
+  if (!element) return;
 
-  const filteredProps = { ...element.props } as any;
-
-  FILTERED_PROPS.forEach(prop => {
-    filteredProps[prop] = undefined;
+  const allElements = element.querySelectorAll('*');
+  allElements.forEach(el => {
+    FILTERED_ATTRIBUTES.forEach(attr => {
+      el.removeAttribute(attr);
+    });
   });
-
-  // Nullify ref to avoid warnings and conflicts
-  filteredProps.ref = null;
-
-  // Recursively filter children if deep filtering is enabled
-  if (deep && filteredProps.children) {
-    filteredProps.children = filterMeasureChildren(filteredProps.children);
-  }
-
-  return React.cloneElement(element, filteredProps);
-}
-
-/**
- * Recursively filter children elements
- * @param children - React children to filter
- * @returns Filtered children
- */
-function filterMeasureChildren(children: React.ReactNode): React.ReactNode {
-  return React.Children.map(children, child => {
-    if (React.isValidElement(child)) {
-      return filterMeasureProps(child, true);
-    }
-    return child;
-  });
-}
-
-/**
- * Prepare title content for use in measure row
- * @param title - The original title content
- * @returns Filtered title safe for measure row usage
- */
-export function prepareMeasureTitle(title: React.ReactNode): React.ReactNode {
-  if (React.isValidElement(title)) {
-    return filterMeasureProps(title, true); // Enable deep filtering
-  }
-  return title;
 }


### PR DESCRIPTION
在使用 rc-table 时，当列标题包含 id、data-testid 等唯一标识符时，由于 MeasureRow 会复制列标题内容，会导致 DOM 中出现重复的标识符，这违反了 HTML 规范并可能影响测试和可访问性。
fix: https://github.com/ant-design/ant-design/issues/55244
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 自动清理度量行 DOM 中的重复 ID 与多余 data-* 属性，避免测试与组件间冲突导致的问题。
  - 优化列变更时的布局更新时机，减少闪烁与错位现象。
  - 提升组件稳定性与可访问性，改善边缘场景下的交互体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->