### PR TITLE
fix: add bounds check to getColumnWidth function

### DIFF
--- a/src/VirtualTable/VirtualCell.tsx
+++ b/src/VirtualTable/VirtualCell.tsx
@@ -31,9 +31,15 @@ export interface VirtualCellProps<RecordType> {
  * Return the width of the column by `colSpan`.
  * When `colSpan` is `0` will be trade as `1`.
  */
-export function getColumnWidth(colIndex: number, colSpan: number, columnsOffset: number[]) {
+export function getColumnWidth(colIndex: number, colSpan: number, columnsOffset: number[]): number {
   const mergedColSpan = colSpan || 1;
-  return columnsOffset[colIndex + mergedColSpan] - (columnsOffset[colIndex] || 0);
+
+  const startIndex = Math.max(colIndex, 0);
+  const endIndex = Math.min(startIndex + mergedColSpan, columnsOffset.length - 1);
+
+  const startOffset = columnsOffset[startIndex] || 0;
+  const endOffset = columnsOffset[endIndex] || startOffset;
+  return Math.max(endOffset - startOffset, 0);
 }
 
 const VirtualCell = <RecordType,>(props: VirtualCellProps<RecordType>) => {


### PR DESCRIPTION
fix: prevent array bounds error in getColumnWidth calculation

当colSpan过大时，getColumnWidth 中数组越界，将产生样式错乱

<img width="828" height="350" alt="c71ef100eac0c9f759dcaaf3c195e584" src="https://github.com/user-attachments/assets/d3bf01d7-3e02-4050-8eae-b200fd12ddb4" />
<img width="588" height="305" alt="4c1debeb6132812c2175aa1e534534e5" src="https://github.com/user-attachments/assets/81521ce1-e85f-43cc-a259-97319c076a9b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **优化改进**
  * 改进了列宽度计算的内部逻辑，增强了边界验证和数据安全性。
  * 优化了多列跨度场景下的计算准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->