### PR TITLE
docs: example sortable columns

### DIFF
--- a/docs/demo/column-sortable.md
+++ b/docs/demo/column-sortable.md
@@ -1,0 +1,8 @@
+---
+title: column-sortable
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/column-sortable.tsx"></code>

--- a/docs/examples/column-resize.tsx
+++ b/docs/examples/column-resize.tsx
@@ -1,95 +1,71 @@
-import React from 'react';
-import { Resizable } from 'react-resizable';
+import React, { useMemo, useState } from 'react';
+import type { ColumnType, ColumnsType } from 'rc-table';
 import Table from 'rc-table';
+import { Resizable } from 'react-resizable';
 import '../../assets/index.less';
 import 'react-resizable/css/styles.css';
-import type { ColumnType } from '@/interface';
-
 const ResizableTitle = props => {
   const { onResize, width, ...restProps } = props;
 
   if (!width) {
     return <th {...restProps} />;
   }
-
   return (
-    <Resizable width={width} height={0} onResize={onResize}>
+    <Resizable width={width} onResize={onResize}>
       <th {...restProps} />
     </Resizable>
   );
 };
 
-interface RecordType {
-  a: string;
-  b?: string;
-  c?: string;
-  d?: number;
-  key: string;
-}
+const data = [
+  { a: '123', key: '1' },
+  { a: 'cdd', b: 'edd', key: '2' },
+  { a: '1333', c: 'eee', d: 2, key: '3' },
+] as const;
 
-interface DemoState {
-  columns: ColumnType<RecordType>[];
-}
+type RecordType = (typeof data)[number];
 
-class Demo extends React.Component<{}, DemoState> {
-  state: DemoState = {
-    columns: [
-      { title: 'title1', dataIndex: 'a', key: 'a', width: 100 },
-      { title: 'title2', dataIndex: 'b', key: 'b', width: 100 },
-      { title: 'title3', dataIndex: 'c', key: 'c', width: 200 },
-      {
-        title: 'Operations',
-        dataIndex: '',
-        key: 'd',
-        render() {
-          return <a href="#">Operations</a>;
-        },
+const Demo = () => {
+  const [columns, setColumns] = useState<ColumnsType<RecordType>>([
+    { title: 'title1', dataIndex: 'a', key: 'a', width: 100 },
+    { title: 'title2', dataIndex: 'b', key: 'b', width: 100 },
+    { title: 'title3', dataIndex: 'c', key: 'c', width: 200 },
+    {
+      title: 'Operations',
+      dataIndex: '',
+      key: 'd',
+      render() {
+        return <a href="#">Operations</a>;
       },
-    ],
-  };
-
-  components = {
-    header: {
-      cell: ResizableTitle,
     },
-  };
-
-  data = [
-    { a: '123', key: '1' },
-    { a: 'cdd', b: 'edd', key: '2' },
-    { a: '1333', c: 'eee', d: 2, key: '3' },
-  ];
-
-  handleResize =
-    index =>
-    (e, { size }) => {
-      this.setState(({ columns }) => {
-        const nextColumns = [...columns];
-        nextColumns[index] = {
-          ...nextColumns[index],
-          width: size.width,
-        };
-        return { columns: nextColumns };
-      });
+  ]);
+  const handleResize = useMemo(() => {
+    return (index: number) => {
+      return (_: React.MouseEvent<HTMLTableCellElement>, { size }: { size: { width: number } }) => {
+        setColumns(prevColumns =>
+          prevColumns.map((col, i) => (i === index ? { ...col, width: size.width } : col)),
+        );
+      };
     };
-
-  render() {
-    const columns = this.state.columns.map((col, index) => ({
+  }, []);
+  const columnsWithResizable = useMemo(() => {
+    return columns.map((col, index) => ({
       ...col,
-      onHeaderCell: (column: ColumnType<RecordType>) =>
-        ({
-          width: column.width,
-          onResize: this.handleResize(index),
-        }) as any,
+      onHeaderCell: (column: ColumnType<RecordType>) => ({
+        width: column.width,
+        onResize: handleResize(index),
+      }),
     }));
+  }, [columns, handleResize]);
 
-    return (
-      <div>
-        <h2>Integrate with react-resizable</h2>
-        <Table components={this.components} columns={columns} data={this.data} />
-      </div>
-    );
-  }
-}
+  const tableProps = useMemo(() => {
+    return {
+      components: { header: { cell: ResizableTitle } },
+      columns: columnsWithResizable,
+      data,
+    };
+  }, [columnsWithResizable]);
+  return <Table {...tableProps} />;
+};
 
 export default Demo;

--- a/docs/examples/column-resize.tsx
+++ b/docs/examples/column-resize.tsx
@@ -11,7 +11,7 @@ const ResizableTitle = props => {
     return <th {...restProps} />;
   }
   return (
-    <Resizable width={width} onResize={onResize}>
+    <Resizable width={width} height={0} onResize={onResize}>
       <th {...restProps} />
     </Resizable>
   );
@@ -32,7 +32,7 @@ const Demo = () => {
     { title: 'title3', dataIndex: 'c', key: 'c', width: 200 },
     {
       title: 'Operations',
-      dataIndex: '',
+      dataIndex: 'd',
       key: 'd',
       render() {
         return <a href="#">Operations</a>;

--- a/docs/examples/column-sortable.tsx
+++ b/docs/examples/column-sortable.tsx
@@ -1,15 +1,14 @@
 import type { DragEndEvent } from '@dnd-kit/core';
 import { DndContext, closestCenter } from '@dnd-kit/core';
-import { SortableContext, arrayMove, useSortable, rectSwappingStrategy } from '@dnd-kit/sortable';
+import { restrictToHorizontalAxis } from '@dnd-kit/modifiers';
+import { SortableContext, arrayMove, rectSwappingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import type { ColumnType } from 'rc-table';
 import Table from 'rc-table';
 import React, { useCallback, useMemo, useState } from 'react';
 import 'react-resizable/css/styles.css';
 import '../../assets/index.less';
-import { restrictToHorizontalAxis } from '@dnd-kit/modifiers';
 const SortableHeaderCell = props => {
-  const { width, style: styleProps, ...restProps } = props;
+  const { style: styleProps, ...restProps } = props;
 
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: props.id as string,
@@ -38,7 +37,7 @@ const Demo = () => {
     { title: 'title3', dataIndex: 'c', key: 'c', width: 200 },
     {
       title: 'Operations',
-      dataIndex: 's',
+      dataIndex: 'd',
       key: 'd',
       render() {
         return <a href="#">Operations</a>;
@@ -50,9 +49,6 @@ const Demo = () => {
     return columns.map(col => ({
       ...col,
       onHeaderCell: () => ({
-        id: col.dataIndex?.toString(),
-      }),
-      onCell: () => ({
         id: col.dataIndex?.toString(),
       }),
     }));

--- a/docs/examples/column-sortable.tsx
+++ b/docs/examples/column-sortable.tsx
@@ -69,8 +69,8 @@ const Demo = () => {
     const { active, over } = e;
     if (over) {
       setColumns(prevColumns => {
-        const activeIndex = prevColumns.findIndex(col => col.key === active.id);
-        const overIndex = prevColumns.findIndex(col => col.key === over.id);
+        const activeIndex = prevColumns.findIndex(col => col.dataIndex === active.id);
+        const overIndex = prevColumns.findIndex(col => col.dataIndex === over.id);
         if (activeIndex === -1 || overIndex === -1) {
           return prevColumns;
         }

--- a/docs/examples/column-sortable.tsx
+++ b/docs/examples/column-sortable.tsx
@@ -1,0 +1,97 @@
+import type { DragEndEvent } from '@dnd-kit/core';
+import { DndContext, closestCenter } from '@dnd-kit/core';
+import { SortableContext, arrayMove, useSortable, rectSwappingStrategy } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { ColumnType } from 'rc-table';
+import Table from 'rc-table';
+import React, { useCallback, useMemo, useState } from 'react';
+import 'react-resizable/css/styles.css';
+import '../../assets/index.less';
+import { restrictToHorizontalAxis } from '@dnd-kit/modifiers';
+const SortableHeaderCell = props => {
+  const { width, style: styleProps, ...restProps } = props;
+
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id: props.id as string,
+  });
+
+  const style = {
+    ...styleProps,
+    transform: CSS.Transform.toString(transform),
+    transition,
+    cursor: 'move',
+  };
+
+  return <th ref={setNodeRef} style={style} {...attributes} {...listeners} {...restProps} />;
+};
+
+const data = [
+  { a: '123', key: '1' },
+  { a: 'cdd', b: 'edd', key: '2' },
+  { a: '1333', c: 'eee', d: 2, key: '3' },
+] as const;
+
+const Demo = () => {
+  const [columns, setColumns] = useState([
+    { title: 'title1', dataIndex: 'a', key: 'a', width: 100 },
+    { title: 'title2', dataIndex: 'b', key: 'b', width: 100 },
+    { title: 'title3', dataIndex: 'c', key: 'c', width: 200 },
+    {
+      title: 'Operations',
+      dataIndex: 's',
+      key: 'd',
+      render() {
+        return <a href="#">Operations</a>;
+      },
+    },
+  ]);
+
+  const columnsWithSortable = useMemo(() => {
+    return columns.map(col => ({
+      ...col,
+      onHeaderCell: () => ({
+        id: col.dataIndex?.toString(),
+      }),
+      onCell: () => ({
+        id: col.dataIndex?.toString(),
+      }),
+    }));
+  }, [columns]);
+
+  const tableProps = useMemo(() => {
+    return {
+      components: { header: { cell: SortableHeaderCell } },
+      columns: columnsWithSortable,
+      data,
+    };
+  }, [columnsWithSortable]);
+  const handleDragEnd = useCallback((e: DragEndEvent) => {
+    const { active, over } = e;
+    if (over) {
+      setColumns(prevColumns => {
+        const activeIndex = prevColumns.findIndex(col => col.key === active.id);
+        const overIndex = prevColumns.findIndex(col => col.key === over.id);
+        if (activeIndex === -1 || overIndex === -1) {
+          return prevColumns;
+        }
+        return arrayMove([...prevColumns], activeIndex, overIndex);
+      });
+    }
+  }, []);
+  return (
+    <DndContext
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+      modifiers={[restrictToHorizontalAxis]}
+    >
+      <SortableContext
+        items={columns.map(col => col.dataIndex?.toString())}
+        strategy={rectSwappingStrategy}
+      >
+        <Table {...tableProps} />;
+      </SortableContext>
+    </DndContext>
+  );
+};
+
+export default Demo;

--- a/docs/examples/column-sortable.tsx
+++ b/docs/examples/column-sortable.tsx
@@ -49,7 +49,7 @@ const Demo = () => {
     return columns.map(col => ({
       ...col,
       onHeaderCell: () => ({
-        id: col.dataIndex?.toString(),
+        id: col.dataIndex,
       }),
     }));
   }, [columns]);
@@ -80,10 +80,7 @@ const Demo = () => {
       onDragEnd={handleDragEnd}
       modifiers={[restrictToHorizontalAxis]}
     >
-      <SortableContext
-        items={columns.map(col => col.dataIndex?.toString())}
-        strategy={rectSwappingStrategy}
-      >
+      <SortableContext items={columns.map(col => col.dataIndex)} strategy={rectSwappingStrategy}>
         <Table {...tableProps} />;
       </SortableContext>
     </DndContext>

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "rc-virtual-list": "^3.14.2"
   },
   "devDependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@rc-component/father-plugin": "^2.0.1",
     "@rc-component/np": "^1.0.3",
     "@testing-library/dom": "^10.4.1",


### PR DESCRIPTION
This pull request introduces a new column sorting demo using drag-and-drop, refactors the column resizing demo to use React hooks, and adds the necessary dependencies for drag-and-drop functionality. The main focus is on improving demo interactivity and modernizing the codebase.

**New Features:**

* Added a drag-and-drop sortable columns demo in `docs/examples/column-sortable.tsx`, using the `@dnd-kit` library for interactive column reordering.
* Created a documentation page for the column sorting demo at `docs/demo/column-sortable.md`.

**Refactoring and Improvements:**

* Refactored the column resizing demo in `docs/examples/column-resize.tsx` from a class component to a functional component using React hooks, improving readability and maintainability. [[1]](diffhunk://#diff-e8534cbb1b482e426dedca44616a766e42ff540453e42930f7d34a272dd941beL1-R29) [[2]](diffhunk://#diff-e8534cbb1b482e426dedca44616a766e42ff540453e42930f7d34a272dd941beL48-R69)

**Dependency Updates:**

* Added `@dnd-kit/core`, `@dnd-kit/modifiers`, and `@dnd-kit/sortable` to `package.json` to support drag-and-drop functionality in demos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增表格列可拖拽排序示例，支持通过拖放改变列显示顺序。

* **文档**
  * 新增列可排序示例的演示页面与示例引用，便于快速查看与复现。

* **优化 / 重构**
  * 将列调整示例重构为函数式组件，使用 React hooks 与 memo 化优化渲染与状态管理。

* **杂项**
  * 增加用于实现拖拽交互的开发依赖以支持示例。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->