### PR TITLE
feat: scrollTo add align support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ React.render(<Table columns={columns} data={data} />, mountNode);
 
 #### scrollTo
 
-Table 组件暴露 `scrollTo` 方法用于滚动到指定位置：
+Table component exposes `scrollTo` method to scroll to a specific position:
 
 ```js
 const tblRef = useRef();

--- a/README.md
+++ b/README.md
@@ -119,6 +119,25 @@ React.render(<Table columns={columns} data={data} />, mountNode);
 | summary | (data: readonly RecordType[]) => React.ReactNode | - | `summary` attribute in `table` component is used to define the summary row. |
 | rowHoverable | boolean | true | Table hover interaction |
 
+### Methods
+
+#### scrollTo
+
+Table 组件暴露 `scrollTo` 方法用于滚动到指定位置：
+
+```js
+const tblRef = useRef();
+tblRef.current?.scrollTo({ key: 'rowKey', align: 'start' });
+```
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| index | number | - | Row index to scroll to |
+| top | number | - | Scroll to specific top position (in px) |
+| key | string | - | Scroll to row by row key |
+| offset | number | - | Additional offset from target position |
+| align | `start` \| `center` \| `end` \| `nearest` | `nearest` | Alignment of the target element within the scroll container. `start` aligns to top, `center` to middle, `end` to bottom, `nearest` automatically chooses the closest alignment |
+
 ## Column Props
 
 | Name | Type | Default | Description |

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ tblRef.current?.scrollTo({ key: 'rowKey', align: 'start' });
 | top | number | - | Scroll to specific top position (in px) |
 | key | string | - | Scroll to row by row key |
 | offset | number | - | Additional offset from target position |
-| align | `start` \| `center` \| `end` \| `nearest` | `nearest` | Alignment of the target element within the scroll container. `start` aligns to top, `center` to middle, `end` to bottom, `nearest` automatically chooses the closest alignment |
+| align | `start` \| `center` \| `end` \| `nearest` | `nearest` | Alignment of the target element within the scroll container. `start` aligns to top, `center` to middle, `end` to bottom, `nearest` automatically chooses the closest alignment. Note: Virtual table does not support `center`. |
 
 ## Column Props
 

--- a/docs/examples/scrollY.tsx
+++ b/docs/examples/scrollY.tsx
@@ -88,6 +88,36 @@ const Test = () => {
       >
         Scroll To Key 6 + Offset -10
       </button>
+      <button
+        onClick={() => {
+          tblRef.current?.scrollTo({
+            key: 9,
+            align: 'start',
+          });
+        }}
+      >
+        Scroll To key 9 (align: start)
+      </button>
+      <button
+        onClick={() => {
+          tblRef.current?.scrollTo({
+            key: 9,
+            align: 'center',
+          });
+        }}
+      >
+        Scroll To key 9 (align: center)
+      </button>
+      <button
+        onClick={() => {
+          tblRef.current?.scrollTo({
+            key: 9,
+            align: 'end',
+          });
+        }}
+      >
+        Scroll To key 9 (align: end)
+      </button>
       <Table
         ref={tblRef}
         columns={columns}

--- a/docs/examples/scrollY.tsx
+++ b/docs/examples/scrollY.tsx
@@ -41,103 +41,35 @@ const Test = () => {
   return (
     <div>
       <h2>scroll body table</h2>
-      <button
-        onClick={() => {
-          tblRef.current?.scrollTo({
-            top: 9999,
-          });
-        }}
-      >
-        Scroll To End
+      <button onClick={() => tblRef.current?.scrollTo({ top: 0 })}>Top</button>
+      <button onClick={() => tblRef.current?.scrollTo({ top: 9999 })}>End</button>
+      <button onClick={() => tblRef.current?.scrollTo({ key: 9 })}>Key 9</button>
+      <button onClick={() => tblRef.current?.scrollTo({ key: 9, align: 'start' })}>
+        Key 9 align: start
       </button>
-      <button
-        onClick={() => {
-          tblRef.current?.scrollTo({
-            key: 9,
-          });
-        }}
-      >
-        Scroll To key 9
+      <button onClick={() => tblRef.current?.scrollTo({ key: 9, align: 'center' })}>
+        Key 9 align: center
       </button>
-      <button
-        onClick={() => {
-          tblRef.current?.scrollTo({
-            top: 0,
-          });
-        }}
-      >
-        Scroll To top
+      <button onClick={() => tblRef.current?.scrollTo({ key: 9, align: 'end' })}>
+        Key 9 align: end
       </button>
-      <button
-        onClick={() => {
-          tblRef.current?.scrollTo({
-            index: 5,
-            offset: -10,
-          });
-        }}
-      >
-        Scroll To Index 5 + Offset -10
+      <button onClick={() => tblRef.current?.scrollTo({ key: 9, align: 'nearest' })}>
+        Key 9 align: nearest
       </button>
-      <button
-        onClick={() => {
-          tblRef.current?.scrollTo({
-            key: 6,
-            offset: -10,
-          });
-        }}
-      >
-        Scroll To Key 6 + Offset -10
+      <button onClick={() => tblRef.current?.scrollTo({ key: 9, align: 'start', offset: 20 })}>
+        Key 9 start offset20
       </button>
-      <button
-        onClick={() => {
-          tblRef.current?.scrollTo({
-            key: 9,
-            align: 'start',
-          });
-        }}
-      >
-        Scroll To key 9 (align: start)
+      <button onClick={() => tblRef.current?.scrollTo({ key: 9, align: 'center', offset: 20 })}>
+        Key 9 center offset20
       </button>
-      <button
-        onClick={() => {
-          tblRef.current?.scrollTo({
-            key: 9,
-            align: 'center',
-          });
-        }}
-      >
-        Scroll To key 9 (align: center)
+      <button onClick={() => tblRef.current?.scrollTo({ key: 9, align: 'end', offset: 20 })}>
+        Key 9 end offset20
       </button>
-      <button
-        onClick={() => {
-          tblRef.current?.scrollTo({
-            key: 9,
-            align: 'end',
-          });
-        }}
-      >
-        Scroll To key 9 (align: end)
+      <button onClick={() => tblRef.current?.scrollTo({ key: 9, align: 'nearest', offset: 20 })}>
+        Key 9 nearest offset20
       </button>
-      <button
-        onClick={() => {
-          tblRef.current?.scrollTo({
-            key: 9,
-            align: 'nearest',
-          });
-        }}
-      >
-        Scroll To key 9 (align: nearest)
-      </button>
-      <button
-        onClick={() => {
-          tblRef.current?.scrollTo({
-            index: 9,
-            offset: 50,
-            align: 'nearest',
-          });
-        }}
-      >
-        Scroll To index 9 + offset 50 (align: nearest)
+      <button onClick={() => tblRef.current?.scrollTo({ index: 5, offset: 50 })}>
+        Index 5 + Offset 50
       </button>
       <Table
         ref={tblRef}

--- a/docs/examples/scrollY.tsx
+++ b/docs/examples/scrollY.tsx
@@ -118,6 +118,27 @@ const Test = () => {
       >
         Scroll To key 9 (align: end)
       </button>
+      <button
+        onClick={() => {
+          tblRef.current?.scrollTo({
+            key: 9,
+            align: 'nearest',
+          });
+        }}
+      >
+        Scroll To key 9 (align: nearest)
+      </button>
+      <button
+        onClick={() => {
+          tblRef.current?.scrollTo({
+            index: 9,
+            offset: 50,
+            align: 'nearest',
+          });
+        }}
+      >
+        Scroll To index 9 + offset 50 (align: nearest)
+      </button>
       <Table
         ref={tblRef}
         columns={columns}

--- a/docs/examples/virtual.tsx
+++ b/docs/examples/virtual.tsx
@@ -205,6 +205,21 @@ const Demo: React.FC = () => {
       <button onClick={() => tableRef.current?.scrollTo({ key: '50', offset: -10 })}>
         Scroll To Key 50 + Offset -10
       </button>
+      <button onClick={() => tableRef.current?.scrollTo({ index: 500, align: 'start' })}>
+        index 500 + align start
+      </button>
+      <button onClick={() => tableRef.current?.scrollTo({ index: 500, align: 'end' })}>
+        index 500 + align end
+      </button>
+      <button onClick={() => tableRef.current?.scrollTo({ index: 500, align: 'nearest' })}>
+        index 500 + align nearest
+      </button>
+      <button onClick={() => tableRef.current?.scrollTo({ index: 500, offset: 50 })}>
+        index 500 + offset 50
+      </button>
+      <button onClick={() => tableRef.current?.scrollTo({ index: 500, offset: 50, align: 'end' })}>
+        index 500 + offset 50 + align end
+      </button>
       <VirtualTable
         style={{ marginTop: 16 }}
         ref={tableRef}

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -351,7 +351,7 @@ const Table = <RecordType extends DefaultRecordType>(
       scrollTo: config => {
         if (scrollBodyRef.current instanceof HTMLElement) {
           // Native scroll
-          const { index, top, key, offset, align = 'nearest' } = config;
+          const { index, top, key, offset, align } = config;
 
           if (validNumberValue(top)) {
             // In top mode, offset is ignored
@@ -363,21 +363,38 @@ const Table = <RecordType extends DefaultRecordType>(
             );
             if (targetElement) {
               if (!offset) {
-                targetElement.scrollIntoView({ block: align });
+                targetElement.scrollIntoView({ block: align ?? 'nearest' });
               } else {
                 const container = scrollBodyRef.current;
                 const elementTop = (targetElement as HTMLElement).offsetTop;
                 const elementHeight = (targetElement as HTMLElement).offsetHeight;
                 const containerHeight = container.clientHeight;
+                const currentTop = container.scrollTop;
+                const elementBottom = elementTop + elementHeight;
+                const viewportBottom = currentTop + containerHeight;
+                let targetTop: number;
 
-                const alignMap: Record<ScrollLogicalPosition, number> = {
-                  start: elementTop,
-                  end: elementTop + elementHeight - containerHeight,
-                  center: elementTop + (elementHeight - containerHeight) / 2,
-                  nearest: elementTop,
-                };
-                const targetTop = alignMap[align] ?? elementTop;
-                container.scrollTo({ top: targetTop + offset });
+                if (align === 'nearest') {
+                  const targetWithOffset = elementTop + offset;
+                  const targetBottomWithOffset = elementBottom + offset;
+
+                  if (targetWithOffset < currentTop) {
+                    targetTop = targetWithOffset;
+                  } else if (targetBottomWithOffset > viewportBottom) {
+                    targetTop = targetBottomWithOffset - containerHeight;
+                  } else {
+                    targetTop = currentTop;
+                  }
+                } else {
+                  const alignMap: Record<string, number> = {
+                    start: elementTop,
+                    end: elementBottom - containerHeight,
+                    center: elementTop - (containerHeight - elementHeight) / 2,
+                  };
+                  targetTop = alignMap[align ?? 'start'] + offset;
+                }
+
+                container.scrollTo({ top: targetTop });
               }
             }
           }

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -365,39 +365,7 @@ const Table = <RecordType extends DefaultRecordType>(
               targetElement.scrollIntoView({ block: align });
               if (offset) {
                 const container = scrollBodyRef.current;
-                const elementTop = (targetElement as HTMLElement).offsetTop;
-                const elementHeight = (targetElement as HTMLElement).offsetHeight;
-                const containerHeight = container.clientHeight;
-                const elementBottom = elementTop + elementHeight;
-                let targetTop: number;
-                switch (align) {
-                  case 'nearest': {
-                    const currentTop = container.scrollTop;
-                    const viewportBottom = currentTop + containerHeight;
-                    const targetWithOffset = elementTop + offset;
-                    const targetBottomWithOffset = elementBottom + offset;
-
-                    if (targetWithOffset < currentTop) {
-                      targetTop = targetWithOffset;
-                    } else if (targetBottomWithOffset > viewportBottom) {
-                      targetTop = targetBottomWithOffset - containerHeight;
-                    } else {
-                      targetTop = currentTop;
-                    }
-                    break;
-                  }
-                  case 'end':
-                    targetTop = elementBottom - containerHeight + offset;
-                    break;
-                  case 'center':
-                    targetTop = elementTop - (containerHeight - elementHeight) / 2 + offset;
-                    break;
-                  case 'start':
-                  default:
-                    targetTop = elementTop + offset;
-                }
-
-                container.scrollTo({ top: targetTop });
+                container.scrollTo({ top: container.scrollTop + offset });
               }
             }
           }

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -351,7 +351,7 @@ const Table = <RecordType extends DefaultRecordType>(
       scrollTo: config => {
         if (scrollBodyRef.current instanceof HTMLElement) {
           // Native scroll
-          const { index, top, key, offset, align } = config;
+          const { index, top, key, offset, align = 'nearest' } = config;
 
           if (validNumberValue(top)) {
             // In top mode, offset is ignored
@@ -362,16 +362,14 @@ const Table = <RecordType extends DefaultRecordType>(
               `[data-row-key="${mergedKey}"]`,
             );
             if (targetElement) {
-              if (!offset) {
-                targetElement.scrollIntoView({ block: align ?? 'nearest' });
-              } else {
+              targetElement.scrollIntoView({ block: align });
+              if (offset) {
                 const container = scrollBodyRef.current;
                 const elementTop = (targetElement as HTMLElement).offsetTop;
                 const elementHeight = (targetElement as HTMLElement).offsetHeight;
                 const containerHeight = container.clientHeight;
                 const elementBottom = elementTop + elementHeight;
                 let targetTop: number;
-
                 switch (align) {
                   case 'nearest': {
                     const currentTop = container.scrollTop;

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -369,29 +369,34 @@ const Table = <RecordType extends DefaultRecordType>(
                 const elementTop = (targetElement as HTMLElement).offsetTop;
                 const elementHeight = (targetElement as HTMLElement).offsetHeight;
                 const containerHeight = container.clientHeight;
-                const currentTop = container.scrollTop;
                 const elementBottom = elementTop + elementHeight;
-                const viewportBottom = currentTop + containerHeight;
                 let targetTop: number;
 
-                if (align === 'nearest') {
-                  const targetWithOffset = elementTop + offset;
-                  const targetBottomWithOffset = elementBottom + offset;
+                switch (align) {
+                  case 'nearest': {
+                    const currentTop = container.scrollTop;
+                    const viewportBottom = currentTop + containerHeight;
+                    const targetWithOffset = elementTop + offset;
+                    const targetBottomWithOffset = elementBottom + offset;
 
-                  if (targetWithOffset < currentTop) {
-                    targetTop = targetWithOffset;
-                  } else if (targetBottomWithOffset > viewportBottom) {
-                    targetTop = targetBottomWithOffset - containerHeight;
-                  } else {
-                    targetTop = currentTop;
+                    if (targetWithOffset < currentTop) {
+                      targetTop = targetWithOffset;
+                    } else if (targetBottomWithOffset > viewportBottom) {
+                      targetTop = targetBottomWithOffset - containerHeight;
+                    } else {
+                      targetTop = currentTop;
+                    }
+                    break;
                   }
-                } else {
-                  const alignMap: Record<string, number> = {
-                    start: elementTop,
-                    end: elementBottom - containerHeight,
-                    center: elementTop - (containerHeight - elementHeight) / 2,
-                  };
-                  targetTop = alignMap[align ?? 'start'] + offset;
+                  case 'end':
+                    targetTop = elementBottom - containerHeight + offset;
+                    break;
+                  case 'center':
+                    targetTop = elementTop - (containerHeight - elementHeight) / 2 + offset;
+                    break;
+                  case 'start':
+                  default:
+                    targetTop = elementTop + offset;
                 }
 
                 container.scrollTo({ top: targetTop });

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -88,8 +88,10 @@ const EMPTY_SCROLL_TARGET = {};
 export type SemanticName = 'section' | 'title' | 'footer' | 'content';
 export type ComponentsSemantic = 'wrapper' | 'cell' | 'row';
 
-export interface TableProps<RecordType = any>
-  extends Omit<LegacyExpandableProps<RecordType>, 'showExpandColumn'> {
+export interface TableProps<RecordType = any> extends Omit<
+  LegacyExpandableProps<RecordType>,
+  'showExpandColumn'
+> {
   prefixCls?: string;
   className?: string;
   style?: React.CSSProperties;
@@ -349,7 +351,7 @@ const Table = <RecordType extends DefaultRecordType>(
       scrollTo: config => {
         if (scrollBodyRef.current instanceof HTMLElement) {
           // Native scroll
-          const { index, top, key, offset } = config;
+          const { index, top, key, offset, align = 'nearest' } = config;
 
           if (validNumberValue(top)) {
             // In top mode, offset is ignored
@@ -361,12 +363,21 @@ const Table = <RecordType extends DefaultRecordType>(
             );
             if (targetElement) {
               if (!offset) {
-                // No offset, use scrollIntoView for default behavior
-                targetElement.scrollIntoView();
+                targetElement.scrollIntoView({ block: align });
               } else {
-                // With offset, use element's offsetTop + offset
+                const container = scrollBodyRef.current;
                 const elementTop = (targetElement as HTMLElement).offsetTop;
-                scrollBodyRef.current.scrollTo({ top: elementTop + offset });
+                const elementHeight = (targetElement as HTMLElement).offsetHeight;
+                const containerHeight = container.clientHeight;
+
+                const alignMap: Record<string, number> = {
+                  start: elementTop,
+                  end: elementTop + elementHeight - containerHeight,
+                  center: elementTop + (elementHeight - containerHeight) / 2,
+                  nearest: elementTop,
+                };
+                const targetTop = alignMap[align] ?? elementTop;
+                container.scrollTo({ top: targetTop + offset });
               }
             }
           }

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -370,7 +370,7 @@ const Table = <RecordType extends DefaultRecordType>(
                 const elementHeight = (targetElement as HTMLElement).offsetHeight;
                 const containerHeight = container.clientHeight;
 
-                const alignMap: Record<string, number> = {
+                const alignMap: Record<ScrollLogicalPosition, number> = {
                   start: elementTop,
                   end: elementTop + elementHeight - containerHeight,
                   center: elementTop + (elementHeight - containerHeight) / 2,

--- a/src/VirtualTable/BodyGrid.tsx
+++ b/src/VirtualTable/BodyGrid.tsx
@@ -93,7 +93,7 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
           nearest: 'auto',
         };
 
-        const virtualAlign = align ? alignMap[align] : offset ? 'top' : 'auto';
+        const virtualAlign = alignMap[align] ?? (offset ? 'top' : 'auto');
 
         listRef.current?.scrollTo({
           ...restConfig,

--- a/src/VirtualTable/BodyGrid.tsx
+++ b/src/VirtualTable/BodyGrid.tsx
@@ -12,6 +12,12 @@ import type {
 import BodyLine from './BodyLine';
 import { GridContext, StaticContext } from './context';
 
+const ALIGN_MAP: Record<string, 'top' | 'bottom' | 'auto'> = {
+  start: 'top',
+  end: 'bottom',
+  nearest: 'auto',
+};
+
 export interface GridProps<RecordType = any> {
   data: RecordType[];
   onScroll: OnCustomizeScroll;
@@ -87,13 +93,7 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
       scrollTo: (config: VirtualScrollConfig) => {
         const { align, offset, ...restConfig } = config;
 
-        const alignMap: Record<string, 'top' | 'bottom' | 'auto'> = {
-          start: 'top',
-          end: 'bottom',
-          nearest: 'auto',
-        };
-
-        const virtualAlign = alignMap[align] ?? (offset ? 'top' : 'auto');
+        const virtualAlign = ALIGN_MAP[align] ?? (offset ? 'top' : 'auto');
 
         listRef.current?.scrollTo({
           ...restConfig,

--- a/src/VirtualTable/BodyGrid.tsx
+++ b/src/VirtualTable/BodyGrid.tsx
@@ -3,7 +3,12 @@ import VirtualList, { type ListProps, type ListRef } from '@rc-component/virtual
 import * as React from 'react';
 import TableContext, { responseImmutable } from '../context/TableContext';
 import useFlattenRecords, { type FlattenData } from '../hooks/useFlattenRecords';
-import type { ColumnType, OnCustomizeScroll, ScrollConfig } from '../interface';
+import type {
+  ColumnType,
+  OnCustomizeScroll,
+  ScrollConfig,
+  VirtualScrollConfig,
+} from '../interface';
 import BodyLine from './BodyLine';
 import { GridContext, StaticContext } from './context';
 
@@ -79,15 +84,22 @@ const Grid = React.forwardRef<GridRef, GridProps>((props, ref) => {
   // =========================== Ref ============================
   React.useImperativeHandle(ref, () => {
     const obj = {
-      scrollTo: (config: ScrollConfig) => {
-        const { offset, ...restConfig } = config;
+      scrollTo: (config: VirtualScrollConfig) => {
+        const { align, offset, ...restConfig } = config;
 
-        // If offset is provided, force align to 'top' for consistent behavior
-        if (offset) {
-          listRef.current?.scrollTo({ ...restConfig, offset, align: 'top' });
-        } else {
-          listRef.current?.scrollTo(config);
-        }
+        const alignMap: Record<string, 'top' | 'bottom' | 'auto'> = {
+          start: 'top',
+          end: 'bottom',
+          nearest: 'auto',
+        };
+
+        const virtualAlign = align ? alignMap[align] : offset ? 'top' : 'auto';
+
+        listRef.current?.scrollTo({
+          ...restConfig,
+          offset,
+          align: virtualAlign,
+        });
       },
       nativeElement: listRef.current?.nativeElement,
     } as unknown as GridRef;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -40,11 +40,15 @@ export type ScrollConfig = {
    * Additional offset in pixels to apply to the scroll position.
    * Only effective when using `key` or `index` mode.
    * Ignored when using `top` mode.
-   * When offset is set, the target element will be aligned according to the `align` parameter.
+   * In `key` / `index` mode, `offset` is added to the position resolved by `align`.
    */
   offset?: number;
 
   align?: ScrollLogicalPosition;
+};
+
+export type VirtualScrollConfig = ScrollConfig & {
+  align?: Exclude<ScrollLogicalPosition, 'center'>;
 };
 
 export type Reference = {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -43,6 +43,8 @@ export type ScrollConfig = {
    * When offset is set, the target element will always be aligned to the top of the container.
    */
   offset?: number;
+
+  align?: ScrollLogicalPosition;
 };
 
 export type Reference = {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -40,7 +40,7 @@ export type ScrollConfig = {
    * Additional offset in pixels to apply to the scroll position.
    * Only effective when using `key` or `index` mode.
    * Ignored when using `top` mode.
-   * When offset is set, the target element will always be aligned to the top of the container.
+   * When offset is set, the target element will be aligned according to the `align` parameter.
    */
   offset?: number;
 

--- a/tests/Virtual.spec.tsx
+++ b/tests/Virtual.spec.tsx
@@ -373,6 +373,7 @@ describe('Table.Virtual', () => {
 
     expect(global.scrollToConfig).toEqual({
       index: 99,
+      align: 'auto',
     });
   });
 
@@ -421,6 +422,31 @@ describe('Table.Virtual', () => {
       offset: 30,
       align: 'top',
     });
+  });
+
+  it('scrollTo with align should pass', async () => {
+    const tblRef = React.createRef<Reference>();
+    getTable({ ref: tblRef });
+
+    // align start -> top
+    tblRef.current.scrollTo({ index: 50, align: 'start' });
+    await waitFakeTimer();
+    expect(global.scrollToConfig).toEqual({ index: 50, align: 'top' });
+
+    // align end -> bottom
+    tblRef.current.scrollTo({ index: 50, align: 'end' });
+    await waitFakeTimer();
+    expect(global.scrollToConfig).toEqual({ index: 50, align: 'bottom' });
+
+    // align nearest -> auto
+    tblRef.current.scrollTo({ index: 50, align: 'nearest' });
+    await waitFakeTimer();
+    expect(global.scrollToConfig).toEqual({ index: 50, align: 'auto' });
+
+    // offset + align
+    tblRef.current.scrollTo({ index: 50, offset: 20, align: 'end' });
+    await waitFakeTimer();
+    expect(global.scrollToConfig).toEqual({ index: 50, offset: 20, align: 'bottom' });
   });
 
   describe('auto width', () => {

--- a/tests/__snapshots__/ExpandRow.spec.jsx.snap
+++ b/tests/__snapshots__/ExpandRow.spec.jsx.snap
@@ -129,7 +129,7 @@ exports[`Table.Expand > does not crash if scroll is not set 1`] = `
           <tr>
             <th
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             />
             <th
               class="rc-table-cell"
@@ -202,7 +202,7 @@ exports[`Table.Expand > does not crash if scroll is not set 1`] = `
           >
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-collapsed"
@@ -230,7 +230,7 @@ exports[`Table.Expand > does not crash if scroll is not set 1`] = `
           >
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-collapsed"
@@ -284,7 +284,7 @@ exports[`Table.Expand > does not crash if scroll is not set 2`] = `
           <tr>
             <th
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             />
             <th
               class="rc-table-cell"
@@ -357,7 +357,7 @@ exports[`Table.Expand > does not crash if scroll is not set 2`] = `
           >
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-collapsed"
@@ -385,7 +385,7 @@ exports[`Table.Expand > does not crash if scroll is not set 2`] = `
           >
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-collapsed"
@@ -525,12 +525,12 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
           <tr>
             <th
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             />
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 7; --z-offset-reverse: 5;"
+              style="inset-inline-start: 0px; --z-offset: 7; --z-offset-reverse: 5;"
             >
               Name
             </th>
@@ -543,7 +543,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               scope="col"
-              style="inset-inline-end: 0; --z-offset: 3; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 3; --z-offset-reverse: 1;"
             >
               Gender
             </th>
@@ -600,7 +600,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
           >
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-expanded"
@@ -608,7 +608,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 7; --z-offset-reverse: 5;"
+              style="inset-inline-start: 0px; --z-offset: 7; --z-offset-reverse: 5;"
             >
               Lucy
             </td>
@@ -619,7 +619,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 3; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 3; --z-offset-reverse: 1;"
             >
               F
             </td>
@@ -647,7 +647,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
           >
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-expanded"
@@ -655,7 +655,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 7; --z-offset-reverse: 5;"
+              style="inset-inline-start: 0px; --z-offset: 7; --z-offset-reverse: 5;"
             >
               Jack
             </td>
@@ -666,7 +666,7 @@ exports[`Table.Expand > renders fixed column correctly > work 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 3; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 3; --z-offset-reverse: 1;"
             >
               M
             </td>
@@ -991,7 +991,7 @@ exports[`Table.Expand > work in expandable fix 1`] = `
           <tr>
             <th
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             />
             <th
               class="rc-table-cell"
@@ -1064,7 +1064,7 @@ exports[`Table.Expand > work in expandable fix 1`] = `
           >
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-collapsed"
@@ -1092,7 +1092,7 @@ exports[`Table.Expand > work in expandable fix 1`] = `
           >
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-collapsed"
@@ -1167,7 +1167,7 @@ exports[`Table.Expand > work in expandable fix 2`] = `
             </th>
             <th
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 5; --z-offset-reverse: 7;"
+              style="inset-inline-start: 0px; --z-offset: 5; --z-offset-reverse: 7;"
             />
           </tr>
         </thead>
@@ -1237,7 +1237,7 @@ exports[`Table.Expand > work in expandable fix 2`] = `
             </td>
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 5; --z-offset-reverse: 7;"
+              style="inset-inline-start: 0px; --z-offset: 5; --z-offset-reverse: 7;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-collapsed"
@@ -1265,7 +1265,7 @@ exports[`Table.Expand > work in expandable fix 2`] = `
             </td>
             <td
               class="rc-table-cell rc-table-row-expand-icon-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
-              style="inset-inline-start: 0; --z-offset: 5; --z-offset-reverse: 7;"
+              style="inset-inline-start: 0px; --z-offset: 5; --z-offset-reverse: 7;"
             >
               <span
                 class="rc-table-row-expand-icon rc-table-row-collapsed"

--- a/tests/__snapshots__/FixedColumn.spec.tsx.snap
+++ b/tests/__snapshots__/FixedColumn.spec.tsx.snap
@@ -41,7 +41,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               title1
             </th>
@@ -114,7 +114,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               scope="col"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             >
               title12
             </th>
@@ -243,7 +243,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               123
             </td>
@@ -305,7 +305,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             >
               xxxxxxxx
             </td>
@@ -316,7 +316,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               cdd
             </td>
@@ -378,7 +378,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             >
               edd12221
             </td>
@@ -389,7 +389,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -437,7 +437,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -446,7 +446,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -494,7 +494,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -503,7 +503,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -551,7 +551,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -560,7 +560,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -608,7 +608,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -617,7 +617,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -665,7 +665,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -674,7 +674,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -722,7 +722,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -731,7 +731,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -779,7 +779,7 @@ exports[`Table.FixedColumn > fixed column renders correctly RTL 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
         </tbody>
@@ -832,7 +832,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               title1
             </th>
@@ -905,7 +905,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               scope="col"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             >
               title12
             </th>
@@ -1034,7 +1034,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               123
             </td>
@@ -1096,7 +1096,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             >
               xxxxxxxx
             </td>
@@ -1107,7 +1107,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               cdd
             </td>
@@ -1169,7 +1169,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             >
               edd12221
             </td>
@@ -1180,7 +1180,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -1228,7 +1228,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -1237,7 +1237,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -1285,7 +1285,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -1294,7 +1294,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -1342,7 +1342,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -1351,7 +1351,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -1399,7 +1399,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -1408,7 +1408,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -1456,7 +1456,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -1465,7 +1465,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -1513,7 +1513,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -1522,7 +1522,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -1570,7 +1570,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
         </tbody>
@@ -1621,7 +1621,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - without data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               title1
             </th>
@@ -1694,7 +1694,7 @@ exports[`Table.FixedColumn > renders correctly > scrollX - without data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               scope="col"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             >
               title12
             </th>
@@ -1901,7 +1901,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 26; --z-offset-reverse: 13;"
+              style="inset-inline-start: 0px; --z-offset: 26; --z-offset-reverse: 13;"
             >
               title1
             </th>
@@ -1980,7 +1980,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             </th>
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-scrollbar"
-              style="inset-inline-end: 0; --z-offset: 12; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 12; --z-offset-reverse: 1;"
             />
           </tr>
         </thead>
@@ -2136,7 +2136,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               123
             </td>
@@ -2198,7 +2198,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             >
               xxxxxxxx
             </td>
@@ -2209,7 +2209,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               cdd
             </td>
@@ -2271,7 +2271,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             </td>
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             >
               edd12221
             </td>
@@ -2282,7 +2282,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -2330,7 +2330,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -2339,7 +2339,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -2387,7 +2387,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -2396,7 +2396,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -2444,7 +2444,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -2453,7 +2453,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -2501,7 +2501,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -2510,7 +2510,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -2558,7 +2558,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -2567,7 +2567,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -2615,7 +2615,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
           <tr
@@ -2624,7 +2624,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
           >
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
-              style="inset-inline-start: 0; --z-offset: 24; --z-offset-reverse: 12;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               133
             </td>
@@ -2672,7 +2672,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - with data 1`] = `
             />
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
-              style="inset-inline-end: 0; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             />
           </tr>
         </tbody>
@@ -2723,7 +2723,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 26; --z-offset-reverse: 13;"
+              style="inset-inline-start: 0px; --z-offset: 26; --z-offset-reverse: 13;"
             >
               title1
             </th>
@@ -2802,7 +2802,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
             </th>
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-scrollbar"
-              style="inset-inline-end: 0; --z-offset: 12; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 12; --z-offset-reverse: 1;"
             />
           </tr>
         </thead>

--- a/tests/__snapshots__/Summary.spec.tsx.snap
+++ b/tests/__snapshots__/Summary.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`Table.Summary > support data type 1`] = `
     <td
       class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
       colspan="2"
-      style="inset-inline-start: 0; --z-offset: 6; --z-offset-reverse: 3;"
+      style="inset-inline-start: 0px; --z-offset: 6; --z-offset-reverse: 3;"
     >
       Light
     </td>

--- a/tests/__snapshots__/Table.spec.jsx.snap
+++ b/tests/__snapshots__/Table.spec.jsx.snap
@@ -98,7 +98,7 @@ exports[`Table.Basic > custom components > renders fixed column and header corre
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
               name="my-header-cell"
               scope="col"
-              style="inset-inline-start: 0; --z-offset: 8; --z-offset-reverse: 4;"
+              style="inset-inline-start: 0px; --z-offset: 8; --z-offset-reverse: 4;"
             >
               Name
             </th>
@@ -120,7 +120,7 @@ exports[`Table.Basic > custom components > renders fixed column and header corre
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-scrollbar"
               name="my-header-cell"
-              style="inset-inline-end: 0; --z-offset: 3; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 3; --z-offset-reverse: 1;"
             />
           </tr>
         </thead>
@@ -179,7 +179,7 @@ exports[`Table.Basic > custom components > renders fixed column and header corre
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow"
               name="my-body-cell"
-              style="inset-inline-start: 0; --z-offset: 6; --z-offset-reverse: 3;"
+              style="inset-inline-start: 0px; --z-offset: 6; --z-offset-reverse: 3;"
             >
               Lucy
             </td>
@@ -192,7 +192,7 @@ exports[`Table.Basic > custom components > renders fixed column and header corre
             <td
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               name="my-body-cell"
-              style="inset-inline-end: 0; --z-offset: 2; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 2; --z-offset-reverse: 1;"
             >
               F
             </td>

--- a/tests/refs.spec.tsx
+++ b/tests/refs.spec.tsx
@@ -21,6 +21,7 @@ describe('Table.Ref', () => {
 
   beforeEach(() => {
     scrollParam = null;
+    scrollIntoViewElement = null;
   });
 
   it('support reference', () => {
@@ -108,5 +109,79 @@ describe('Table.Ref', () => {
       index: 0,
     });
     expect(scrollIntoViewElement.textContent).toEqual('light');
+  });
+
+  it('support scrollTo with align', () => {
+    const ref = React.createRef<Reference>();
+
+    render(
+      <Table
+        data={[{ key: 'light' }, { key: 'bamboo' }]}
+        columns={[
+          {
+            dataIndex: 'key',
+          },
+        ]}
+        ref={ref}
+        scroll={{
+          y: 10,
+        }}
+      />,
+    );
+
+    // Default behavior: uses scrollIntoView (not scrollTo)
+    ref.current.scrollTo({ index: 0 });
+    expect(scrollIntoViewElement).not.toBeNull();
+    expect(scrollIntoViewElement.textContent).toEqual('light');
+
+    // Align start - should use scrollIntoView
+    scrollIntoViewElement = null;
+    ref.current.scrollTo({ index: 0, align: 'start' });
+    expect(scrollIntoViewElement.textContent).toEqual('light');
+
+    // Align center - should use scrollIntoView
+    ref.current.scrollTo({ index: 1, align: 'center' });
+    expect(scrollIntoViewElement.textContent).toEqual('bamboo');
+
+    // Align end - should use scrollIntoView
+    scrollIntoViewElement = null;
+    ref.current.scrollTo({ key: 'bamboo', align: 'end' });
+    expect(scrollIntoViewElement.textContent).toEqual('bamboo');
+  });
+
+  it('support scrollTo with align and offset', () => {
+    const ref = React.createRef<Reference>();
+
+    render(
+      <Table
+        data={[{ key: 'light' }, { key: 'bamboo' }]}
+        columns={[
+          {
+            dataIndex: 'key',
+          },
+        ]}
+        ref={ref}
+        scroll={{
+          y: 10,
+        }}
+      />,
+    );
+
+    // align start + offset 20 = 0 + 20 = 20
+    ref.current.scrollTo({ index: 0, align: 'start', offset: 20 });
+    expect(scrollIntoViewElement).toBeNull();
+    expect(scrollParam.top).toEqual(20);
+
+    // align center + offset 30 = 0 + 30 = 30
+    ref.current.scrollTo({ index: 1, align: 'center', offset: 30 });
+    expect(scrollParam.top).toEqual(30);
+
+    // align end + offset 10 = 0 + 10 = 10
+    ref.current.scrollTo({ key: 'bamboo', align: 'end', offset: 10 });
+    expect(scrollParam.top).toEqual(10);
+
+    // align nearest + offset 50 = 0 + 50 = 50
+    ref.current.scrollTo({ index: 0, align: 'nearest', offset: 50 });
+    expect(scrollParam.top).toEqual(50);
   });
 });

--- a/tests/refs.spec.tsx
+++ b/tests/refs.spec.tsx
@@ -169,7 +169,6 @@ describe('Table.Ref', () => {
 
     // align start + offset 20 = 0 + 20 = 20
     ref.current.scrollTo({ index: 0, align: 'start', offset: 20 });
-    expect(scrollIntoViewElement).toBeNull();
     expect(scrollParam.top).toEqual(20);
 
     // align center + offset 30 = 0 + 30 = 30

--- a/tests/refs.spec.tsx
+++ b/tests/refs.spec.tsx
@@ -184,4 +184,28 @@ describe('Table.Ref', () => {
     ref.current.scrollTo({ index: 0, align: 'nearest', offset: 50 });
     expect(scrollParam.top).toEqual(50);
   });
+
+  it('support scrollTo with align nearest and element above viewport', () => {
+    const ref = React.createRef<Reference>();
+
+    render(
+      <Table
+        data={[{ key: 'light' }, { key: 'bamboo' }]}
+        columns={[
+          {
+            dataIndex: 'key',
+          },
+        ]}
+        ref={ref}
+        scroll={{
+          y: 100,
+        }}
+      />,
+    );
+
+    ref.current.scrollTo({ top: 50 });
+
+    ref.current.scrollTo({ index: 0, align: 'nearest', offset: -10 });
+    expect(scrollParam.top).toEqual(-10);
+  });
 });


### PR DESCRIPTION
## Summary

  为 Table 组件的 `scrollTo` 方法增加 `align` 参数支持，类似于虚拟列表中的对齐方式。

  ## Feature

  - `align: 'start'` - 滚动到顶部
  - `align: 'center'` - 滚动到中间
  - `align: 'end'` - 滚动到底部
  - `align: 'nearest'` - 智能滚动（默认）


  ## Related Issue

  [ant-design/ant-design#45945](https://github.com/ant-design/ant-design/issues/45945)

  ### Usage

  ```tsx
  tableRef.current?.scrollTo({
    index: 9,
    align: 'start', // 'center' | 'end' | 'nearest'
  });
```
  也可以结合 offset 使用：
  ```tsx
  tableRef.current?.scrollTo({
    index: 9,
    align: 'center',
    offset: 10,
  });
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发版说明

* **新功能**
  * Table 组件新增公开方法 scrollTo，支持 align（start/center/end/nearest）和 offset 等配置；虚拟滚动场景对 align 有约束（不支持 center），新增对应虚拟滚动配置类型。
* **文档**
  * README 增补 scrollTo 使用说明与参数示例，更新了 ScrollConfig 中 align/offset 的描述。
* **示例**
  * 增加示例按钮展示不同 align 与 offset 组合的滚动效果。
* **测试**
  * 补充了针对 align 行为及带 offset 的滚动计算的测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->