### PR TITLE
fix: do not render scrollbar column when table is empty

### DIFF
--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -131,15 +131,16 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
       className: `${prefixCls}-cell-scrollbar`,
     }),
   };
+  const shouldAppendScrollBarColumn = combinationScrollBarSize && !noData;
 
   const columnsWithScrollbar = useMemo<ColumnsType<unknown>>(
-    () => (combinationScrollBarSize ? [...columns, ScrollBarColumn] : columns),
-    [combinationScrollBarSize, columns],
+    () => (shouldAppendScrollBarColumn ? [...columns, ScrollBarColumn] : columns),
+    [shouldAppendScrollBarColumn, columns],
   );
 
   const flattenColumnsWithScrollbar = useMemo(
-    () => (combinationScrollBarSize ? [...flattenColumns, ScrollBarColumn] : flattenColumns),
-    [combinationScrollBarSize, flattenColumns],
+    () => (shouldAppendScrollBarColumn ? [...flattenColumns, ScrollBarColumn] : flattenColumns),
+    [shouldAppendScrollBarColumn, flattenColumns],
   );
 
   // Calculate the sticky offsets

--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -146,6 +146,7 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
   // Calculate the sticky offsets
   const headerStickyOffsets = useMemo(() => {
     const { start, end } = stickyOffsets;
+    const scrollbarOffset = shouldAppendScrollBarColumn ? combinationScrollBarSize : 0;
     return {
       ...stickyOffsets,
       // left:
@@ -153,10 +154,10 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
       // right:
       //   direction === 'rtl' ? right : [...right.map(width => width + combinationScrollBarSize), 0],
       start: start,
-      end: [...end.map(width => width + combinationScrollBarSize), 0],
+      end: [...end.map(width => width + scrollbarOffset), 0],
       isSticky,
     };
-  }, [combinationScrollBarSize, stickyOffsets, isSticky]);
+  }, [shouldAppendScrollBarColumn, combinationScrollBarSize, stickyOffsets, isSticky]);
 
   const mergedColumnWidth = useColumnWidth(colWidths, columCount);
 

--- a/tests/FixedColumn.spec.tsx
+++ b/tests/FixedColumn.spec.tsx
@@ -119,6 +119,30 @@ describe('Table.FixedColumn', () => {
 
       expect(container.querySelector('colgroup')?.outerHTML).toMatchSnapshot();
     });
+
+    it('does not render scrollbar header cell when data is empty', async () => {
+      const { container } = render(
+        <Table columns={columns} data={[]} scroll={{ x: 1200, y: 100 }} />,
+      );
+
+      await triggerResize(container.querySelector<HTMLElement>('.rc-table'));
+
+      act(() => {
+        const coll = container.querySelector('.rc-table-resize-collection');
+        if (coll) {
+          triggerResize(coll as HTMLElement);
+        }
+      });
+
+      await act(async () => {
+        vi.runAllTimers();
+        await Promise.resolve();
+      });
+
+      expect(container.querySelectorAll('thead .rc-table-cell-scrollbar')).toHaveLength(0);
+      expect(container.querySelector('.rc-table-placeholder')).toBeTruthy();
+      vi.useRealTimers();
+    });
   });
 
   it('has correct scroll classNames when table resize', async () => {

--- a/tests/__snapshots__/FixedColumn.spec.tsx.snap
+++ b/tests/__snapshots__/FixedColumn.spec.tsx.snap
@@ -2723,14 +2723,14 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start"
               scope="col"
-              style="inset-inline-start: 0px; --z-offset: 26; --z-offset-reverse: 13;"
+              style="inset-inline-start: 0px; --z-offset: 24; --z-offset-reverse: 12;"
             >
               title1
             </th>
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-start rc-table-cell-fix-start-shadow rc-table-cell-ellipsis"
               scope="col"
-              style="inset-inline-start: 1000px; --z-offset: 25; --z-offset-reverse: 14;"
+              style="inset-inline-start: 1000px; --z-offset: 23; --z-offset-reverse: 13;"
               title="title2"
             >
               <span
@@ -2796,14 +2796,10 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               scope="col"
-              style="inset-inline-end: 15px; --z-offset: 11; --z-offset-reverse: 2;"
+              style="inset-inline-end: 15px; --z-offset: 11; --z-offset-reverse: 1;"
             >
               title12
             </th>
-            <th
-              class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-scrollbar"
-              style="inset-inline-end: 0px; --z-offset: 12; --z-offset-reverse: 1;"
-            />
           </tr>
         </thead>
       </table>

--- a/tests/__snapshots__/FixedColumn.spec.tsx.snap
+++ b/tests/__snapshots__/FixedColumn.spec.tsx.snap
@@ -2796,7 +2796,7 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
             <th
               class="rc-table-cell rc-table-cell-fix rc-table-cell-fix-end rc-table-cell-fix-end-shadow"
               scope="col"
-              style="inset-inline-end: 15px; --z-offset: 11; --z-offset-reverse: 1;"
+              style="inset-inline-end: 0px; --z-offset: 11; --z-offset-reverse: 1;"
             >
               title12
             </th>


### PR DESCRIPTION
### Chinese template / 中文版模板

### This is a ...

- Bug fix

### Related Issues

- Reproduces in `antd@5.29.3` with `scroll.y` enabled and empty data.

### Background and Solution

When `scroll.y` is enabled, `FixedHolder` always appends `ScrollBarColumn` to header columns when `combinationScrollBarSize` is truthy.

In empty state, the table body renders the placeholder row instead of a scrollable body, so the extra scrollbar placeholder column is not needed. Keeping it in the header causes an extra `rc-table-cell-scrollbar` header cell to be rendered.

This change skips appending `ScrollBarColumn` when `noData` is true, and adds a regression test to cover the empty-state case.

### Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Table rendering an extra scrollbar header cell when `scroll.y` is enabled and data is empty. |
| 🇨🇳 Chinese | 修复 Table 在启用 `scroll.y` 且数据为空时，表头额外渲染 scrollbar 占位列的问题。 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了表格数据为空时仍显示滚动条列的问题：当无数据时自动隐藏滚动条列，改善固定列表格的显示与体验。

* **Tests**
  * 新增单元测试，验证在空数据且开启横纵滚动时不渲染滚动条表头并保留占位符，用以防止回归。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->