### PR TITLE
fix: apply expandedRowClassName to virtual tree rows

### DIFF
--- a/src/VirtualTable/BodyLine.tsx
+++ b/src/VirtualTable/BodyLine.tsx
@@ -39,11 +39,11 @@ const BodyLine = React.forwardRef<HTMLDivElement, BodyLineProps>((props, ref) =>
   // ========================== Expand ==========================
   const { rowSupportExpand, expanded, rowProps, expandedRowRender, expandedRowClassName } = rowInfo;
 
+  const expandedClsName = computedExpandedClassName(expandedRowClassName, record, index, indent);
+
   let expandRowNode: React.ReactElement<any>;
   if (rowSupportExpand && expanded) {
     const expandContent = expandedRowRender(record, index, indent + 1, expanded);
-
-    const expandedClsName = computedExpandedClassName(expandedRowClassName, record, index, indent);
 
     let additionalProps: React.TdHTMLAttributes<HTMLElement> = {};
     if (fixColumn) {
@@ -94,6 +94,7 @@ const BodyLine = React.forwardRef<HTMLDivElement, BodyLineProps>((props, ref) =>
       data-row-key={rowKey}
       ref={rowSupportExpand ? null : ref}
       className={clsx(className, `${prefixCls}-row`, rowProps?.className, {
+        [expandedClsName]: indent >= 1,
         [`${prefixCls}-row-extra`]: extra,
       })}
       style={{ ...rowStyle, ...rowProps?.style }}

--- a/tests/Virtual.spec.tsx
+++ b/tests/Virtual.spec.tsx
@@ -183,6 +183,32 @@ describe('Table.Virtual', () => {
       });
     });
 
+    it('applies expanded row class to tree rows', () => {
+      const { container } = getTable({
+        data: [
+          {
+            name: 'parent',
+            age: 0,
+            address: 'address0',
+            children: [
+              {
+                name: 'child',
+                age: 1,
+                address: 'address1',
+              },
+            ],
+          },
+        ],
+        expandable: {
+          expandedRowKeys: ['parent'],
+          expandedRowClassName: 'bamboo',
+          expandIcon: () => <span className="custom-expand-icon" />,
+        },
+      });
+
+      expect(container.querySelector('[data-row-key="child"]')).toHaveClass('bamboo');
+    });
+
     it('fixed', () => {
       const { container } = getTable({
         columns: [


### PR DESCRIPTION
## 变更说明
- 修复 `virtual` 模式下树形展开子行未应用 `expandedRowClassName` 的问题
- 保持 `expandedRowRender` 展开行现有行为不变
- 补充虚拟表格树形展开场景的回归测试

## 验证
- `npx vitest run tests/Virtual.spec.tsx`
- `npx vitest run tests/ExpandRow.spec.jsx -t "renders expend row class correctly using children without expandedRowRender"`

Fix ant-design/ant-design#57758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Bug 修复**
  * 虚拟表现在可正确地将展开行样式应用到树形展开产生的行中。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->