### PR TITLE
fix: pass classNames.body.cell to VirtualCell in virtual mode

### DIFF
--- a/src/VirtualTable/BodyLine.tsx
+++ b/src/VirtualTable/BodyLine.tsx
@@ -99,11 +99,11 @@ const BodyLine = React.forwardRef<HTMLDivElement, BodyLineProps>((props, ref) =>
       {...restProps}
       data-row-key={rowKey}
       ref={rowSupportExpand ? null : ref}
-      className={clsx(className, `${prefixCls}-row`, rowProps?.className, {
+      className={clsx(className, `${prefixCls}-row`, rowProps?.className, classNames?.body?.row, {
         [expandedClsName]: indent >= 1,
         [`${prefixCls}-row-extra`]: extra,
       })}
-      style={{ ...rowStyle, ...rowProps?.style }}
+      style={{ ...rowStyle, ...rowProps?.style, ...styles?.body?.row }}
     >
       {flattenColumns.map((column, colIndex) => {
         return (

--- a/src/VirtualTable/BodyLine.tsx
+++ b/src/VirtualTable/BodyLine.tsx
@@ -25,9 +25,9 @@ const BodyLine = React.forwardRef<HTMLDivElement, BodyLineProps>((props, ref) =>
   const { data, index, className, rowKey, style, extra, getHeight, ...restProps } = props;
   const { record, indent, index: renderIndex } = data;
 
-  const { scrollX, flattenColumns, prefixCls, fixColumn, componentWidth } = useContext(
+  const { scrollX, flattenColumns, prefixCls, fixColumn, componentWidth, classNames } = useContext(
     TableContext,
-    ['prefixCls', 'flattenColumns', 'fixColumn', 'componentWidth', 'scrollX'],
+    ['prefixCls', 'flattenColumns', 'fixColumn', 'componentWidth', 'scrollX', 'classNames'],
   );
   const { getComponent } = useContext(StaticContext, ['getComponent']);
 
@@ -103,6 +103,7 @@ const BodyLine = React.forwardRef<HTMLDivElement, BodyLineProps>((props, ref) =>
         return (
           <VirtualCell
             key={colIndex}
+            className={classNames?.body?.cell}
             component={cellComponent}
             rowInfo={rowInfo}
             column={column}

--- a/src/VirtualTable/BodyLine.tsx
+++ b/src/VirtualTable/BodyLine.tsx
@@ -25,10 +25,16 @@ const BodyLine = React.forwardRef<HTMLDivElement, BodyLineProps>((props, ref) =>
   const { data, index, className, rowKey, style, extra, getHeight, ...restProps } = props;
   const { record, indent, index: renderIndex } = data;
 
-  const { scrollX, flattenColumns, prefixCls, fixColumn, componentWidth, classNames } = useContext(
-    TableContext,
-    ['prefixCls', 'flattenColumns', 'fixColumn', 'componentWidth', 'scrollX', 'classNames'],
-  );
+  const { scrollX, flattenColumns, prefixCls, fixColumn, componentWidth, classNames, styles } =
+    useContext(TableContext, [
+      'prefixCls',
+      'flattenColumns',
+      'fixColumn',
+      'componentWidth',
+      'scrollX',
+      'classNames',
+      'styles',
+    ]);
   const { getComponent } = useContext(StaticContext, ['getComponent']);
 
   const rowInfo = useRowInfo(record, rowKey, index, indent);
@@ -104,6 +110,7 @@ const BodyLine = React.forwardRef<HTMLDivElement, BodyLineProps>((props, ref) =>
           <VirtualCell
             key={colIndex}
             className={classNames?.body?.cell}
+            style={styles?.body?.cell}
             component={cellComponent}
             rowInfo={rowInfo}
             column={column}


### PR DESCRIPTION
In non-virtual mode, Body/index.tsx extracts classNames from TableContext and passes classNames.body to BodyRow, which then applies classNames.cell to each Cell. However, VirtualTable/BodyLine.tsx does not read classNames from TableContext, so VirtualCell never receives the body cell className.

This causes custom cell classNames (e.g. from antd's Table wrapper like itp-design) to be missing on cells rendered in virtual scroll mode.

non-virtual
<img width="1240" height="573" alt="img_v3_0211f_93295b97-83db-4a9e-8b05-44769a8dc43g" src="https://github.com/user-attachments/assets/3f2e7879-d54e-4110-a917-c2fe0ef693a2" />

virtual
<img width="1242" height="507" alt="img_v3_0211f_4283994f-9fb1-44c8-8df4-84f3180bcbfg" src="https://github.com/user-attachments/assets/f72f55b0-b37b-4560-b36e-6cb338e8bf83" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 虚拟表格的行与单元格样式现在可通过表级配置统一控制，行样式会与每行样式合并应用，单元格可接收表级样式与类名，便于全表范围的视觉定制与一致性调整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->