### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/docs/examples/animation.tsx
+++ b/docs/examples/animation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import CSSMotionList from 'rc-animate/lib/CSSMotionList';
+import { CSSMotionList } from '@rc-component/motion';
 import { clsx } from 'clsx';
-import toArray from '@rc-component/util/lib/Children/toArray';
+import { toArray } from '@rc-component/util';
 import type { TableProps } from 'rc-table';
 import Table from 'rc-table';
 import '../../assets/index.less';

--- a/package.json
+++ b/package.json
@@ -51,12 +51,13 @@
   "dependencies": {
     "@rc-component/context": "^2.0.1",
     "@rc-component/resize-observer": "^1.0.0",
-    "@rc-component/util": "^1.1.0",
+    "@rc-component/util": "^1.11.1",
     "@rc-component/virtual-list": "^1.0.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.1",
+    "@rc-component/father-plugin": "^2.2.0",
+    "@rc-component/motion": "^1.3.2",
     "@rc-component/np": "^1.0.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.4.0",
@@ -80,7 +81,6 @@
     "less": "^4.1.3",
     "lint-staged": "^16.1.5",
     "prettier": "^3.1.0",
-    "rc-animate": "^3.0.0",
     "rc-dropdown": "~4.0.1",
     "rc-menu": "~9.16.1",
     "rc-tooltip": "^6.2.0",

--- a/src/Body/MeasureCell.tsx
+++ b/src/Body/MeasureCell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import ResizeObserver from '@rc-component/resize-observer';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+import { useLayoutEffect } from '@rc-component/util';
 
 export interface MeasureCellProps {
   columnKey: React.Key;

--- a/src/Body/MeasureRow.tsx
+++ b/src/Body/MeasureRow.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import ResizeObserver from '@rc-component/resize-observer';
 import MeasureCell from './MeasureCell';
-import isVisible from '@rc-component/util/lib/Dom/isVisible';
+import { isVisible } from '@rc-component/util';
 import { useContext } from '@rc-component/context';
 import TableContext from '../context/TableContext';
 import type { ColumnType } from '../interface';

--- a/src/Cell/useCellRender.ts
+++ b/src/Cell/useCellRender.ts
@@ -1,7 +1,4 @@
-import useMemo from '@rc-component/util/lib/hooks/useMemo';
-import isEqual from '@rc-component/util/lib/isEqual';
-import getValue from '@rc-component/util/lib/utils/get';
-import warning from '@rc-component/util/lib/warning';
+import { get as getValue, isEqual, useMemo, warning } from '@rc-component/util';
 import * as React from 'react';
 import PerfContext from '../context/PerfContext';
 import type { CellType, ColumnType, DataIndex, RenderedCell } from '../interface';

--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -1,6 +1,6 @@
 import { useContext } from '@rc-component/context';
 import { clsx } from 'clsx';
-import { fillRef } from '@rc-component/util/lib/ref';
+import { fillRef } from '@rc-component/util';
 import * as React from 'react';
 import { useMemo } from 'react';
 import ColGroup from '../ColGroup';

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -78,7 +78,7 @@ import Column from './sugar/Column';
 import ColumnGroup from './sugar/ColumnGroup';
 import { getColumnsKey, validateValue, validNumberValue } from './utils/valueUtil';
 
-type CompareProps<T extends React.ComponentType<any>> = (
+export type CompareProps<T extends React.ComponentType<any>> = (
   prevProps: Readonly<React.ComponentProps<T>>,
   nextProps: Readonly<React.ComponentProps<T>>,
 ) => boolean;

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -24,14 +24,18 @@
  *  - All expanded props, move into expandable
  */
 
-import type { CompareProps } from '@rc-component/context/lib/Immutable';
 import { clsx } from 'clsx';
 import ResizeObserver from '@rc-component/resize-observer';
-import { getTargetScrollBarSize } from '@rc-component/util/lib/getScrollBarSize';
-import useEvent from '@rc-component/util/lib/hooks/useEvent';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
-import getValue from '@rc-component/util/lib/utils/get';
-import warning from '@rc-component/util/lib/warning';
+import {
+  getDOM,
+  get as getValue,
+  getTargetScrollBarSize,
+  isEqual,
+  pickAttrs,
+  useEvent,
+  useLayoutEffect,
+  warning,
+} from '@rc-component/util';
 import * as React from 'react';
 import Body from './Body';
 import ColGroup from './ColGroup';
@@ -73,9 +77,11 @@ import StickyScrollBar from './stickyScrollBar';
 import Column from './sugar/Column';
 import ColumnGroup from './sugar/ColumnGroup';
 import { getColumnsKey, validateValue, validNumberValue } from './utils/valueUtil';
-import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
-import isEqual from '@rc-component/util/lib/isEqual';
-import useLayoutEffect from '@rc-component/util/lib/hooks/useLayoutEffect';
+
+type CompareProps<T extends React.ComponentType<any>> = (
+  prevProps: Readonly<React.ComponentProps<T>>,
+  nextProps: Readonly<React.ComponentProps<T>>,
+) => boolean;
 
 export const DEFAULT_PREFIX = 'rc-table';
 

--- a/src/VirtualTable/index.tsx
+++ b/src/VirtualTable/index.tsx
@@ -4,14 +4,9 @@ import * as React from 'react';
 import { INTERNAL_HOOKS } from '../constant';
 import { makeImmutable } from '../context/TableContext';
 import type { CustomizeScrollBody, GetComponent, Reference } from '../interface';
-import Table, { DEFAULT_PREFIX, type TableProps } from '../Table';
+import Table, { DEFAULT_PREFIX, type CompareProps, type TableProps } from '../Table';
 import Grid from './BodyGrid';
 import { StaticContext } from './context';
-
-type CompareProps<T extends React.ComponentType<any>> = (
-  prevProps: Readonly<React.ComponentProps<T>>,
-  nextProps: Readonly<React.ComponentProps<T>>,
-) => boolean;
 
 const renderBody: CustomizeScrollBody<any> = (rawData, props) => {
   const { ref, onScroll } = props;

--- a/src/VirtualTable/index.tsx
+++ b/src/VirtualTable/index.tsx
@@ -1,6 +1,5 @@
-import type { CompareProps } from '@rc-component/context/lib/Immutable';
 import { clsx } from 'clsx';
-import { useEvent, warning } from '@rc-component/util';
+import { get as getValue, useEvent, warning } from '@rc-component/util';
 import * as React from 'react';
 import { INTERNAL_HOOKS } from '../constant';
 import { makeImmutable } from '../context/TableContext';
@@ -8,7 +7,11 @@ import type { CustomizeScrollBody, GetComponent, Reference } from '../interface'
 import Table, { DEFAULT_PREFIX, type TableProps } from '../Table';
 import Grid from './BodyGrid';
 import { StaticContext } from './context';
-import getValue from '@rc-component/util/lib/utils/get';
+
+type CompareProps<T extends React.ComponentType<any>> = (
+  prevProps: Readonly<React.ComponentProps<T>>,
+  nextProps: Readonly<React.ComponentProps<T>>,
+) => boolean;
 
 const renderBody: CustomizeScrollBody<any> = (rawData, props) => {
   const { ref, onScroll } = props;

--- a/src/hooks/useColumns/index.tsx
+++ b/src/hooks/useColumns/index.tsx
@@ -1,5 +1,4 @@
-import toArray from '@rc-component/util/lib/Children/toArray';
-import warning from '@rc-component/util/lib/warning';
+import { toArray, warning } from '@rc-component/util';
 import * as React from 'react';
 import { EXPAND_COLUMN } from '../../constant';
 import type {

--- a/src/hooks/useExpand.ts
+++ b/src/hooks/useExpand.ts
@@ -1,4 +1,4 @@
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import * as React from 'react';
 import { INTERNAL_HOOKS } from '../constant';
 import type {

--- a/src/hooks/useFixedInfo.ts
+++ b/src/hooks/useFixedInfo.ts
@@ -1,5 +1,4 @@
-import useMemo from '@rc-component/util/lib/hooks/useMemo';
-import isEqual from '@rc-component/util/lib/isEqual';
+import { isEqual, useMemo } from '@rc-component/util';
 import type { ColumnType, StickyOffsets } from '../interface';
 import { getCellFixedInfo } from '../utils/fixUtil';
 import * as React from 'react';

--- a/src/hooks/useSticky.ts
+++ b/src/hooks/useSticky.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import canUseDom from '@rc-component/util/lib/Dom/canUseDom';
+import { canUseDom } from '@rc-component/util';
 import type { TableSticky } from '../interface';
 
 // fix ssr render

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import type {
 } from './interface';
 import Column from './sugar/Column';
 import ColumnGroup from './sugar/ColumnGroup';
-import type { CompareProps, TableProps } from './Table';
+import type { TableProps } from './Table';
 import Table, { genTable } from './Table';
 import { INTERNAL_COL_DEFINE } from './utils/legacyUtil';
 import type { VirtualTableProps } from './VirtualTable';
@@ -27,7 +27,6 @@ export {
   Column,
   ColumnGroup,
   type TableProps,
-  type CompareProps,
   INTERNAL_COL_DEFINE,
   EXPAND_COLUMN,
   INTERNAL_HOOKS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,16 @@
 import { EXPAND_COLUMN, INTERNAL_HOOKS } from './constant';
 import { FooterComponents as Summary } from './Footer';
-import type { ColumnType, ColumnsType, Reference } from './interface';
+import type {
+  ColumnType,
+  ColumnsType,
+  DefaultRecordType,
+  ExpandableConfig,
+  FixedType,
+  GetComponentProps,
+  GetRowKey,
+  Reference,
+  RenderedCell,
+} from './interface';
 import Column from './sugar/Column';
 import ColumnGroup from './sugar/ColumnGroup';
 import type { TableProps } from './Table';
@@ -8,9 +18,11 @@ import Table, { genTable } from './Table';
 import { INTERNAL_COL_DEFINE } from './utils/legacyUtil';
 import type { VirtualTableProps } from './VirtualTable';
 import VirtualTable, { genVirtualTable } from './VirtualTable';
+import { convertChildrenToColumns } from './hooks/useColumns';
 
 export {
   genTable,
+  convertChildrenToColumns,
   Summary,
   Column,
   ColumnGroup,
@@ -24,6 +36,12 @@ export {
   type Reference,
   type ColumnType,
   type ColumnsType,
+  type DefaultRecordType,
+  type ExpandableConfig,
+  type FixedType,
+  type GetComponentProps,
+  type GetRowKey,
+  type RenderedCell,
 };
 
 export default Table;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import type {
 } from './interface';
 import Column from './sugar/Column';
 import ColumnGroup from './sugar/ColumnGroup';
-import type { TableProps } from './Table';
+import type { CompareProps, TableProps } from './Table';
 import Table, { genTable } from './Table';
 import { INTERNAL_COL_DEFINE } from './utils/legacyUtil';
 import type { VirtualTableProps } from './VirtualTable';
@@ -27,6 +27,7 @@ export {
   Column,
   ColumnGroup,
   type TableProps,
+  type CompareProps,
   INTERNAL_COL_DEFINE,
   EXPAND_COLUMN,
   INTERNAL_HOOKS,

--- a/src/stickyScrollBar.tsx
+++ b/src/stickyScrollBar.tsx
@@ -1,12 +1,10 @@
 import { useContext } from '@rc-component/context';
 import { clsx } from 'clsx';
-import getScrollBarSize from '@rc-component/util/lib/getScrollBarSize';
+import { getDOM, getScrollBarSize, raf } from '@rc-component/util';
 import * as React from 'react';
 import TableContext from './context/TableContext';
 import { useLayoutState } from './hooks/useFrame';
-import raf from '@rc-component/util/lib/raf';
 import { getOffset } from './utils/offsetUtil';
-import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
 
 const MOUSEUP_EVENT: keyof WindowEventMap = 'mouseup';
 const MOUSEMOVE_EVENT: keyof WindowEventMap = 'mousemove';

--- a/src/utils/legacyUtil.ts
+++ b/src/utils/legacyUtil.ts
@@ -1,4 +1,4 @@
-import warning from '@rc-component/util/lib/warning';
+import { warning } from '@rc-component/util';
 import type { ExpandableConfig, LegacyExpandableProps } from '../interface';
 
 export const INTERNAL_COL_DEFINE = 'RC_TABLE_INTERNAL_COL_DEFINE';

--- a/src/utils/offsetUtil.ts
+++ b/src/utils/offsetUtil.ts
@@ -1,4 +1,4 @@
-import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
+import { getDOM } from '@rc-component/util';
 
 // Copy from `rc-component/util/Dom/css.js`
 export function getOffset(node: HTMLElement | Window) {

--- a/tests/Deprecated.spec.jsx
+++ b/tests/Deprecated.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { resetWarned } from '@rc-component/util';
 import Table from '../src';
 
 describe('Table.Deprecated', () => {

--- a/tests/ExpandRow.spec.jsx
+++ b/tests/ExpandRow.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
-import { spyElementPrototype } from '@rc-component/util/lib/test/domHook';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { resetWarned, spyElementPrototype } from '@rc-component/util';
 import Table from '../src';
 
 describe('Table.Expand', () => {

--- a/tests/ExpandedOffset.spec.tsx
+++ b/tests/ExpandedOffset.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { spyElementPrototypes } from 'rc-util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import { render, act } from '@testing-library/react';
 import { _rs } from '@rc-component/resize-observer';
 import Table, { type ColumnsType } from '../src';

--- a/tests/FixedColumn-IE.spec.jsx
+++ b/tests/FixedColumn-IE.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, act } from '@testing-library/react';
 import Table from '../src';
 // 保留 spyElementPrototype 的相关逻辑
-import { spyElementPrototype } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototype } from '@rc-component/util';
 import RcResizeObserver from '@rc-component/resize-observer';
 
 vi.mock('@rc-component/util/lib/Dom/styleChecker', () => {

--- a/tests/FixedColumn.spec.tsx
+++ b/tests/FixedColumn.spec.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent, act } from '@testing-library/react';
 import { _rs } from '@rc-component/resize-observer';
 import Table, { type ColumnsType } from '../src';
 import { RowColSpanWithFixed, RowColSpanWithFixed2 } from './__mocks__/shadowTest';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 
 async function triggerResize(ele: HTMLElement) {
   await act(async () => {

--- a/tests/FixedHeader.spec.jsx
+++ b/tests/FixedHeader.spec.jsx
@@ -1,6 +1,6 @@
 import { render, act } from '@testing-library/react';
 import { _rs } from '@rc-component/resize-observer';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import Table, { INTERNAL_COL_DEFINE } from '../src';
 import { safeAct } from './utils';

--- a/tests/Hover.spec.tsx
+++ b/tests/Hover.spec.tsx
@@ -1,6 +1,5 @@
 import { render, fireEvent } from '@testing-library/react';
-import toArray from '@rc-component/util/lib/Children/toArray';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { resetWarned, toArray } from '@rc-component/util';
 import React from 'react';
 import Table from '../src';
 import type { TableProps } from '../src/Table';

--- a/tests/Scroll.spec.jsx
+++ b/tests/Scroll.spec.jsx
@@ -1,5 +1,5 @@
 import { render, fireEvent } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import { act } from '@testing-library/react';
 import Table from '../src';

--- a/tests/Sticky.spec.jsx
+++ b/tests/Sticky.spec.jsx
@@ -1,5 +1,5 @@
 import { render, fireEvent, createEvent } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import { act } from '@testing-library/react';
 import Table from '../src';

--- a/tests/Table.spec.jsx
+++ b/tests/Table.spec.jsx
@@ -1,5 +1,5 @@
 import { render, fireEvent } from '@testing-library/react';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { resetWarned } from '@rc-component/util';
 import React from 'react';
 import { VariableSizeGrid as Grid } from 'react-window';
 import Table, { INTERNAL_COL_DEFINE } from '../src';

--- a/tests/Virtual.spec.tsx
+++ b/tests/Virtual.spec.tsx
@@ -1,8 +1,6 @@
 import { act, fireEvent, render } from '@testing-library/react';
-import { _rs as onEsResize } from '@rc-component/resize-observer/es/utils/observerUtil';
-import { _rs as onLibResize } from '@rc-component/resize-observer/lib/utils/observerUtil';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
-import { resetWarned } from '@rc-component/util/lib/warning';
+import { _rs as onResize } from '@rc-component/resize-observer';
+import { resetWarned, spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import { VirtualTable, type Reference, type VirtualTableProps } from '../src';
 
@@ -89,8 +87,7 @@ describe('Table.Virtual', () => {
 
   function resize(target: HTMLElement) {
     act(() => {
-      onLibResize([{ target } as any]);
-      onEsResize([{ target } as any]);
+      onResize([{ target } as any]);
     });
   }
 

--- a/tests/refs.spec.tsx
+++ b/tests/refs.spec.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import { spyElementPrototypes } from '@rc-component/util/lib/test/domHook';
+import { spyElementPrototypes } from '@rc-component/util';
 import React from 'react';
 import Table, { type Reference } from '../src';
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -8,6 +8,20 @@ global.requestAnimationFrame = cb => setTimeout(cb, 0);
 require('regenerator-runtime');
 
 vi.mock('@rc-component/util/lib/getScrollBarSize');
+vi.mock('@rc-component/util', async importOriginal => {
+  const actual = await importOriginal<typeof import('@rc-component/util')>();
+
+  return {
+    ...actual,
+    getScrollBarSize: () => 15,
+    getTargetScrollBarSize: (target: HTMLElement) => {
+      if (!target || !(target instanceof Element)) {
+        return { width: 0, height: 0 };
+      }
+      return { width: 15, height: 15 };
+    },
+  };
+});
 
 // Mock ResizeObserver
 global.ResizeObserver = class ResizeObserver implements ResizeObserver {


### PR DESCRIPTION
## 背景

为配合 rc 包统一避免引用其他 rc 包的 `es` / `lib` 构建产物内部路径，本次将 table 中相关引用调整为从包根入口导入公开 API。

## 调整内容

- 升级 `@rc-component/father-plugin` 和 `@rc-component/util`
- 将 `@rc-component/context`、`@rc-component/resize-observer`、`@rc-component/util`、`@rc-component/virtual-list` 等深路径引用改为根入口引用
- 补充 table 根入口导出，方便 antd 和其他 rc 包去除 `lib` 路径引用
- 同步调整测试中的相关引用

## 验证

- `npm run lint` 通过，存在既有 warning，无 error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 新增导出 convertChildrenToColumns 及多项类型，扩展公共 API 能力。

* **Chores**
  * 统一并简化包内导入来源，减少深层子路径引用。
  * 调整与升级内部依赖版本（含新增/移除部分包）。
  * 统一并修正测试导入及全局测试 mock，提升测试兼容性与稳定性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/table/pull/1489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->