### PR TITLE
fix: Render ColGroup even if table has no data to maintain layout consistency

### DIFF
--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -51,7 +51,6 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
   const {
     className,
     style,
-    noData,
     columns,
     flattenColumns,
     colWidths,

--- a/src/FixedHolder/index.tsx
+++ b/src/FixedHolder/index.tsx
@@ -160,12 +160,14 @@ const FixedHolder = React.forwardRef<HTMLDivElement, FixedHeaderProps<any>>((pro
   const mergedColumnWidth = useColumnWidth(colWidths, columCount);
 
   const isColGroupEmpty = useMemo<boolean>(() => {
-    // use original ColGroup if no data or no calculated column width, otherwise use calculated column width
-    // Return original colGroup if no data, or mergedColumnWidth is empty, or all widths are falsy
+    // ColGroup should be rendered as long as column widths are available,
+    // even if there is no data. This maintains layout consistency between
+    // Header, Body, and Summary sections.
+    // Ref: https://github.com/ant-design/ant-design/issues/57916
     const noWidth =
       !mergedColumnWidth || !mergedColumnWidth.length || mergedColumnWidth.every(w => !w);
-    return noData || noWidth;
-  }, [noData, mergedColumnWidth]);
+    return noWidth;
+  }, [mergedColumnWidth]);
 
   return (
     <div

--- a/tests/__snapshots__/FixedColumn.spec.tsx.snap
+++ b/tests/__snapshots__/FixedColumn.spec.tsx.snap
@@ -2698,22 +2698,43 @@ exports[`Table.FixedColumn > renders correctly > scrollXY - without data 1`] = `
       >
         <colgroup>
           <col
-            style="width: 100px;"
+            style="width: 1000px;"
           />
           <col
-            style="width: 100px;"
+            style="width: 1000px;"
           />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
           <col
-            style="width: 100px;"
+            style="width: 1000px;"
+          />
+          <col
+            style="width: 1000px;"
+          />
+          <col
+            style="width: 1000px;"
+          />
+          <col
+            style="width: 1000px;"
+          />
+          <col
+            style="width: 1000px;"
+          />
+          <col
+            style="width: 1000px;"
+          />
+          <col
+            style="width: 1000px;"
+          />
+          <col
+            style="width: 1000px;"
+          />
+          <col
+            style="width: 1000px;"
+          />
+          <col
+            style="width: 1000px;"
+          />
+          <col
+            style="width: 15px;"
           />
         </colgroup>
         <thead


### PR DESCRIPTION
Ensures FixedHolder renders the colgroup as long as column widths are available, fixing layout issues when the table is empty but has fixed columns. Fixes ant-design/ant-design/issues/57916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 改进

* **Bug Fixes**
  * 优化表格在无数据或部分列宽可用时的渲染判断：只要列宽信息存在，仍保持表头、数据行与汇总行的列布局一致，避免布局错位。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/table/pull/1490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->