### PR TITLE
fix: avoid stale scroll retry sync

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -465,11 +465,11 @@ const Table = <RecordType extends DefaultRecordType>(
 
       // Delay to force scroll position if not sync
       // ref: https://github.com/ant-design/ant-design/issues/37179
-      if (target.scrollLeft !== scrollLeft) {
-        setTimeout(() => {
+      setTimeout(() => {
+        if (target.scrollLeft !== scrollLeft) {
           target.scrollLeft = scrollLeft;
-        }, 0);
-      }
+        }
+      }, 0);
     }
   }
 

--- a/tests/Table.spec.jsx
+++ b/tests/Table.spec.jsx
@@ -1322,4 +1322,47 @@ describe('Table.Basic', () => {
     fireEvent.scroll(tableBody);
     expect(onScroll).toHaveBeenCalled();
   });
+
+  it('does not retry stale scrollLeft sync', () => {
+    vi.useFakeTimers();
+
+    try {
+      const { container } = render(
+        createTable({
+          scroll: { x: 100, y: 100 },
+        }),
+      );
+
+      const tableHeader = container.querySelector('.rc-table-header');
+      const tableBody = container.querySelector('.rc-table-body');
+      let headerScrollLeft = 0;
+      let bodyScrollLeft = 0;
+
+      Object.defineProperty(tableHeader, 'scrollLeft', {
+        get() {
+          return headerScrollLeft;
+        },
+        set(value) {
+          headerScrollLeft = Math.trunc(value);
+        },
+      });
+      Object.defineProperty(tableBody, 'scrollLeft', {
+        get() {
+          return bodyScrollLeft;
+        },
+      });
+
+      bodyScrollLeft = 794.171875;
+      fireEvent.scroll(tableBody);
+
+      bodyScrollLeft = 0;
+      fireEvent.scroll(tableBody);
+
+      vi.runAllTimers();
+
+      expect(headerScrollLeft).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
Fixes ant-design/ant-design#57850

## Summary

- avoid stale delayed scrollLeft retries overriding newer table scroll sync
- move the retry equality check into the timeout so the latest scroll position can win

## Test Plan

- npm test -- tests/Table.spec.jsx -t "does not retry stale scrollLeft sync"
- GitHub Actions: test / react component workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化表格横向滚动同步逻辑，避免在滚动状态已变化时重复写入滚动位置，减少不必要的滚动抖动。
  * 补充滚动同步相关测试，覆盖异步场景下的旧值回写问题，提升滚动行为稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->