### PR TITLE
fix: cancel stale scroll retry sync

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -453,6 +453,9 @@ const Table = <RecordType extends DefaultRecordType>(
   }, []);
 
   const [setScrollTarget, getScrollTarget] = useTimeoutLock(null);
+  const [scrollRetryTimeoutMap] = React.useState(
+    () => new WeakMap<HTMLDivElement, ReturnType<typeof setTimeout>>(),
+  );
 
   function forceScroll(scrollLeft: number, target: HTMLDivElement | ((left: number) => void)) {
     if (!target) {
@@ -460,16 +463,26 @@ const Table = <RecordType extends DefaultRecordType>(
     }
     if (typeof target === 'function') {
       target(scrollLeft);
-    } else if (target.scrollLeft !== scrollLeft) {
+      return;
+    }
+
+    const scrollRetryTimeout = scrollRetryTimeoutMap.get(target);
+    if (scrollRetryTimeout) {
+      clearTimeout(scrollRetryTimeout);
+    }
+
+    if (target.scrollLeft !== scrollLeft) {
       target.scrollLeft = scrollLeft;
 
       // Delay to force scroll position if not sync
       // ref: https://github.com/ant-design/ant-design/issues/37179
-      setTimeout(() => {
+      const retryTimeout = setTimeout(() => {
         if (target.scrollLeft !== scrollLeft) {
           target.scrollLeft = scrollLeft;
         }
       }, 0);
+
+      scrollRetryTimeoutMap.set(target, retryTimeout);
     }
   }
 

--- a/tests/Table.spec.jsx
+++ b/tests/Table.spec.jsx
@@ -1365,4 +1365,48 @@ describe('Table.Basic', () => {
       vi.useRealTimers();
     }
   });
+
+  it('cancels stale scrollLeft retry when target already synced', () => {
+    vi.useFakeTimers();
+
+    try {
+      const { container } = render(
+        createTable({
+          scroll: { x: 100, y: 100 },
+        }),
+      );
+
+      const tableHeader = container.querySelector('.rc-table-header');
+      const tableBody = container.querySelector('.rc-table-body');
+      let headerScrollLeft = 0;
+      let bodyScrollLeft = 0;
+
+      Object.defineProperty(tableHeader, 'scrollLeft', {
+        get() {
+          return headerScrollLeft;
+        },
+        set(value) {
+          headerScrollLeft = value;
+        },
+      });
+      Object.defineProperty(tableBody, 'scrollLeft', {
+        get() {
+          return bodyScrollLeft;
+        },
+      });
+
+      bodyScrollLeft = 100;
+      fireEvent.scroll(tableBody);
+
+      headerScrollLeft = 50;
+      bodyScrollLeft = 50;
+      fireEvent.scroll(tableBody);
+
+      vi.runAllTimers();
+
+      expect(headerScrollLeft).toBe(50);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
### Summary

- Cancel pending scroll retry timers for a DOM target when a newer sync arrives.
- Keep only the latest retry per target and clean pending retry timers on unmount.
- Add a regression test for the case where the target already matches the latest scrollLeft.

### Related

Follow-up to #1495.

### Verification

- node_modules/.bin/vitest run tests/Table.spec.jsx
- npm run tsc
- npm run lint
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了表格滚动同步时的延迟重试问题，避免旧的滚动位置在后续交互中误覆盖最新位置。
  * 提升了滚动行为的稳定性，减少了同一容器多次滚动时的异常跳变。

* **Tests**
  * 新增滚动同步相关测试，覆盖过期重试定时器的取消与最新滚动状态保持。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->